### PR TITLE
chore: align Android toolchain for blocked dependency updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.baijum.ukufretboard"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.baijum.ukufretboard"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-agp = "8.7.3"
+agp = "8.9.1"
 kotlin = "2.3.10"
 composeBom = "2024.12.01"
-activityCompose = "1.9.3"
-lifecycleViewmodelCompose = "2.8.7"
-coreKtx = "1.15.0"
+activityCompose = "1.12.4"
+lifecycleViewmodelCompose = "2.10.0"
+coreKtx = "1.17.0"
 glance = "1.1.1"
 workRuntime = "2.10.0"
 kotlinxSerializationJson = "1.7.3"
-kotlinxSerialization = "2.0.21"
+kotlinxSerialization = "2.3.10"
 reorderable = "3.0.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- upgrade Android toolchain to support newer dependency requirements (`com.android.application` to `8.9.1`, Gradle wrapper to `8.11.1`)
- bump blocked AndroidX dependencies (`activity-compose` `1.12.4`, `lifecycle-viewmodel-compose` `2.10.0`, `core-ktx` `1.17.0`) and align `kotlinxSerialization` plugin version with Kotlin `2.3.10`
- increase app `compileSdk` from `35` to `36` to satisfy updated AndroidX AAR metadata requirements

## Test plan
- [x] `./gradlew clean lint testDebugUnitTest assembleDebug`

Closes #10

Made with [Cursor](https://cursor.com)