### PR TITLE
Update: optimize iPad landscape UI with sidebar navigation and adaptive layouts

### DIFF
--- a/iosApp/UkuleleCompanion/ContentView.swift
+++ b/iosApp/UkuleleCompanion/ContentView.swift
@@ -1,10 +1,23 @@
 import SwiftUI
 
+enum SidebarDestination: String, Hashable {
+    case explorer, tuner, pitchMonitor, metronome, chordLibrary, favorites
+    case progressions, strumPatterns, songbook, melodyNotepad
+    case dailyChallenge, practiceRoutine, chordTransitions, playAlong
+    case intervalTrainer, chordEarTraining, noteQuiz, scalePractice
+    case theoryLessons, theoryQuiz
+    case learningProgress, achievements
+    case glossary, capoGuide, fretboardNoteMap, chordSubstitutions, scaleChords, circleOfFifths
+}
+
 struct ContentView: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var selectedTab = 0
     @State private var showSettings = false
     @State private var showOnboarding: Bool
+    @State private var selectedDestination: SidebarDestination? = .explorer
     @StateObject private var settingsVM = SettingsViewModel()
+    @StateObject private var learnVM = LearnViewModel()
 
     init() {
         let completed = UserDefaults(suiteName: "app_settings")?.bool(forKey: "onboarding_completed") ?? false
@@ -27,48 +40,188 @@ struct ContentView: View {
                 showOnboarding = false
             }
         } else {
-            mainContent
-                .preferredColorScheme(colorScheme)
+            Group {
+                if sizeClass == .regular {
+                    sidebarContent
+                } else {
+                    tabContent
+                }
+            }
+            .preferredColorScheme(colorScheme)
         }
     }
 
-    private var mainContent: some View {
+    // MARK: - Tab layout (iPhone / iPad portrait)
+
+    private var tabContent: some View {
         TabView(selection: $selectedTab) {
             PlayView(showSettings: $showSettings)
-                .tabItem {
-                    Label("Play", systemImage: "play.circle")
-                }
+                .tabItem { Label("Play", systemImage: "play.circle") }
                 .tag(0)
 
             CreateView(showSettings: $showSettings)
-                .tabItem {
-                    Label("Create", systemImage: "pencil.circle")
-                }
+                .tabItem { Label("Create", systemImage: "pencil.circle") }
                 .tag(1)
 
             if settingsVM.showLearnTab {
                 LearnView(showSettings: $showSettings)
-                    .tabItem {
-                        Label("Learn", systemImage: "book")
-                    }
+                    .tabItem { Label("Learn", systemImage: "book") }
                     .tag(2)
             }
 
             if settingsVM.showReferenceTab {
                 ReferenceView(showSettings: $showSettings)
-                    .tabItem {
-                        Label("Reference", systemImage: "list.bullet")
-                    }
+                    .tabItem { Label("Reference", systemImage: "list.bullet") }
                     .tag(3)
             }
         }
         .environmentObject(settingsVM)
+        .environmentObject(learnVM)
         .tint(isHighContrast ? .yellow : nil)
-        .sheet(isPresented: $showSettings) {
-            SettingsView()
-        }
+        .sheet(isPresented: $showSettings) { SettingsView() }
         .onChange(of: showSettings) { isShowing in
             if !isShowing { settingsVM.load() }
+        }
+    }
+
+    // MARK: - Sidebar layout (iPad landscape)
+
+    private var sidebarContent: some View {
+        NavigationSplitView {
+            sidebarList
+        } detail: {
+            detailView
+        }
+        .environmentObject(settingsVM)
+        .environmentObject(learnVM)
+        .tint(isHighContrast ? .yellow : nil)
+        .sheet(isPresented: $showSettings) { SettingsView() }
+        .onChange(of: showSettings) { isShowing in
+            if !isShowing { settingsVM.load() }
+        }
+    }
+
+    private var sidebarList: some View {
+        List(selection: $selectedDestination) {
+            Section {
+                sidebarLink(.explorer, "Explorer", icon: "guitars")
+                sidebarLink(.tuner, "Tuner", icon: "tuningfork")
+                sidebarLink(.pitchMonitor, "Pitch Monitor", icon: "waveform")
+                sidebarLink(.metronome, "Metronome", icon: "metronome")
+                sidebarLink(.chordLibrary, "Chord Library", icon: "music.note.list")
+                sidebarLink(.favorites, "Favorites", icon: "heart")
+            } header: {
+                Text("Play").accessibilityAddTraits(.isHeader)
+            }
+
+            Section {
+                sidebarLink(.progressions, "Chord Progressions", icon: "play.circle")
+                sidebarLink(.strumPatterns, "Strumming Patterns", icon: "metronome")
+                sidebarLink(.songbook, "Songbook", icon: "music.note.list")
+                sidebarLink(.melodyNotepad, "Melody Notepad", icon: "pianokeys")
+            } header: {
+                Text("Create").accessibilityAddTraits(.isHeader)
+            }
+
+            if settingsVM.showLearnTab {
+                Section {
+                    sidebarLink(.dailyChallenge, "Daily Challenge", icon: "star.circle")
+                    sidebarLink(.practiceRoutine, "Practice Routine", icon: "list.bullet.clipboard")
+                    sidebarLink(.chordTransitions, "Chord Transitions", icon: "arrow.left.arrow.right")
+                    sidebarLink(.playAlong, "Play Along", icon: "play.fill")
+                } header: {
+                    Text("Practice").accessibilityAddTraits(.isHeader)
+                }
+
+                Section {
+                    sidebarLink(.intervalTrainer, "Interval Trainer", icon: "waveform.path")
+                    sidebarLink(.chordEarTraining, "Chord Ear Training", icon: "ear")
+                    sidebarLink(.noteQuiz, "Note Quiz", icon: "music.note")
+                    sidebarLink(.scalePractice, "Scale Practice", icon: "music.quarternote.3")
+                } header: {
+                    Text("Training").accessibilityAddTraits(.isHeader)
+                }
+
+                Section {
+                    sidebarLink(.theoryLessons, "Theory Lessons", icon: "book")
+                    sidebarLink(.theoryQuiz, "Theory Quiz", icon: "questionmark.circle")
+                } header: {
+                    Text("Knowledge").accessibilityAddTraits(.isHeader)
+                }
+
+                Section {
+                    sidebarLink(.learningProgress, "Learning Progress", icon: "chart.bar")
+                    sidebarLink(.achievements, "Achievements", icon: "trophy")
+                } header: {
+                    Text("Progress").accessibilityAddTraits(.isHeader)
+                }
+            }
+
+            if settingsVM.showReferenceTab {
+                Section {
+                    sidebarLink(.glossary, "Glossary", icon: "character.book.closed")
+                    sidebarLink(.capoGuide, "Capo Guide", icon: "guitars")
+                    sidebarLink(.fretboardNoteMap, "Fretboard Note Map", icon: "square.grid.3x3")
+                    sidebarLink(.chordSubstitutions, "Chord Substitutions", icon: "arrow.triangle.swap")
+                    sidebarLink(.scaleChords, "Scale Chords", icon: "music.note.tv")
+                    sidebarLink(.circleOfFifths, "Circle of Fifths", icon: "circle.dotted")
+                } header: {
+                    Text("Reference").accessibilityAddTraits(.isHeader)
+                }
+            }
+        }
+        .navigationTitle("Ukulele Companion")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button { showSettings = true } label: {
+                    Image(systemName: "gearshape")
+                        .accessibilityLabel("Settings")
+                }
+            }
+        }
+    }
+
+    private func sidebarLink(_ destination: SidebarDestination, _ title: String, icon: String) -> some View {
+        NavigationLink(value: destination) {
+            Label(title, systemImage: icon)
+        }
+    }
+
+    @ViewBuilder
+    private var detailView: some View {
+        switch selectedDestination {
+        case .explorer: ExplorerView()
+        case .tuner: TunerView()
+        case .pitchMonitor: PitchMonitorView()
+        case .metronome: MetronomeView()
+        case .chordLibrary: ChordLibraryView()
+        case .favorites: FavoritesView()
+        case .progressions: ProgressionsView()
+        case .strumPatterns: StrumPatternsView()
+        case .songbook: SongbookView()
+        case .melodyNotepad: MelodyNotepadView()
+        case .dailyChallenge: DailyChallengeView()
+        case .practiceRoutine: PracticeRoutineView()
+        case .chordTransitions: ChordTransitionsView()
+        case .playAlong: PlayAlongView()
+        case .intervalTrainer: IntervalTrainerView()
+        case .chordEarTraining: ChordEarTrainingView()
+        case .noteQuiz: NoteQuizView()
+        case .scalePractice: ScalePracticeView()
+        case .theoryLessons: TheoryLessonsView()
+        case .theoryQuiz: TheoryQuizView()
+        case .learningProgress: LearningProgressView()
+        case .achievements: AchievementsView()
+        case .glossary: GlossaryView()
+        case .capoGuide: CapoGuideView()
+        case .fretboardNoteMap: FretboardNoteMapView()
+        case .chordSubstitutions: ChordSubstitutionsView()
+        case .scaleChords: ScaleChordsView()
+        case .circleOfFifths: CircleOfFifthsView()
+        case nil:
+            Text("Select an item from the sidebar")
+                .font(.title2)
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/iosApp/UkuleleCompanion/Views/CapoGuideView.swift
+++ b/iosApp/UkuleleCompanion/Views/CapoGuideView.swift
@@ -182,10 +182,7 @@ struct CapoGuideView: View {
                         .padding(.top, 8)
 
                     let shapes = CapoReference.shared.FRIENDLY_SHAPES as! [KotlinPair<NSString, NSString>]
-                    LazyVGrid(columns: [
-                        GridItem(.flexible()), GridItem(.flexible()),
-                        GridItem(.flexible()), GridItem(.flexible()),
-                    ], spacing: 8) {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 8)], spacing: 8) {
                         ForEach(Array(shapes.enumerated()), id: \.offset) { _, pair in
                             let name = pair.first! as String
                             let tab = pair.second! as String

--- a/iosApp/UkuleleCompanion/Views/ChordDiagramView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordDiagramView.swift
@@ -13,11 +13,13 @@ struct ChordDiagramView: View {
     var isFavorite: Bool = false
     var onFavoriteClick: (() -> Void)? = nil
 
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
     private let stringCount = 4
     private let fretCount = 5
-    private let stringSpacing: CGFloat = 24
-    private let fretSpacing: CGFloat = 22
-    private let dotRadius: CGFloat = 8
+    private var stringSpacing: CGFloat { sizeClass == .regular ? 32 : 24 }
+    private var fretSpacing: CGFloat { sizeClass == .regular ? 30 : 22 }
+    private var dotRadius: CGFloat { sizeClass == .regular ? 10 : 8 }
     private let nutHeight: CGFloat = 4
 
     private var diagramWidth: CGFloat { CGFloat(stringCount - 1) * stringSpacing }

--- a/iosApp/UkuleleCompanion/Views/ChordLibraryView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordLibraryView.swift
@@ -13,10 +13,7 @@ struct ChordLibraryView: View {
     @State private var filtersExpanded: Bool = true
     @State private var transposeSemitones: Int = 0
 
-    private let columns = [
-        GridItem(.flexible(), spacing: 12),
-        GridItem(.flexible(), spacing: 12),
-    ]
+    private let columns = [GridItem(.adaptive(minimum: 160), spacing: 12)]
 
     @FocusState private var searchFocused: Bool
 

--- a/iosApp/UkuleleCompanion/Views/ChordTransitionsView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordTransitionsView.swift
@@ -24,7 +24,6 @@ struct ChordTransitionsView: View {
 
                 if let v1 = viewModel.voicingForChord(name: chordName(root: root1, quality: quality1)) {
                     ChordDiagramView(voicing: v1, chordName: chordName(root: root1, quality: quality1))
-                        .frame(height: 120)
                         .onTapGesture { viewModel.playChord(name: chordName(root: root1, quality: quality1)) }
                         .accessibilityLabel("Chord 1 diagram, tap to play")
                 }
@@ -38,7 +37,6 @@ struct ChordTransitionsView: View {
 
                 if let v2 = viewModel.voicingForChord(name: chordName(root: root2, quality: quality2)) {
                     ChordDiagramView(voicing: v2, chordName: chordName(root: root2, quality: quality2))
-                        .frame(height: 120)
                         .onTapGesture { viewModel.playChord(name: chordName(root: root2, quality: quality2)) }
                         .accessibilityLabel("Chord 2 diagram, tap to play")
                 }

--- a/iosApp/UkuleleCompanion/Views/CircleOfFifthsView.swift
+++ b/iosApp/UkuleleCompanion/Views/CircleOfFifthsView.swift
@@ -21,9 +21,9 @@ struct CircleOfFifthsView: View {
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
 
-                // Circle visualization
                 circleCanvas
-                    .frame(height: 320)
+                    .aspectRatio(1, contentMode: .fit)
+                    .frame(maxHeight: 500)
                     .padding(.horizontal)
 
                 // Detail panel
@@ -210,7 +210,7 @@ struct CircleOfFifthsView: View {
                     .padding(.top, 4)
                     .accessibilityAddTraits(.isHeader)
 
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4), spacing: 8) {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 70), spacing: 8)], spacing: 8) {
                     let chords: [KotlinPair<NSString, NSString>] = showMinor
                         ? KeySignatures.shared.diatonicChordsForMinor(
                             pitchClass: keySig.relativeMinorPitchClass

--- a/iosApp/UkuleleCompanion/Views/FavoritesView.swift
+++ b/iosApp/UkuleleCompanion/Views/FavoritesView.swift
@@ -258,7 +258,6 @@ private struct FavoriteCard: View {
             }
 
             ChordDiagramView(voicing: voicing, chordName: favorite.chordName)
-                .frame(height: 120)
         }
         .padding(12)
         .background(Color(.secondarySystemGroupedBackground))

--- a/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
@@ -3,11 +3,12 @@ import shared
 
 struct FretboardNoteMapView: View {
     @EnvironmentObject var settings: SettingsViewModel
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var highlightPitchClass: Int32 = -1
     @State private var isLowG = false
 
     private let fretCount = 12
-    private let cellSize: CGFloat = 36
+    private var cellSize: CGFloat { sizeClass == .regular ? 52 : 36 }
     private let tonePlayer = TonePlayer()
 
     private var effectiveTuning: UkuleleTuning {

--- a/iosApp/UkuleleCompanion/Views/FretboardView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardView.swift
@@ -4,8 +4,9 @@ import shared
 struct FretboardView: View {
     @ObservedObject var viewModel: FretboardViewModel
     var leftHanded: Bool = false
+    @Environment(\.horizontalSizeClass) private var sizeClass
 
-    private let cellSize: CGFloat = 48
+    private var cellSize: CGFloat { sizeClass == .regular ? 64 : 48 }
     private let nutWidth: CGFloat = 4
     private let stringLineWidth: CGFloat = 1.5
     private let fretLineWidth: CGFloat = 1

--- a/iosApp/UkuleleCompanion/Views/LearnView.swift
+++ b/iosApp/UkuleleCompanion/Views/LearnView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct LearnView: View {
     @Binding var showSettings: Bool
-    @StateObject private var learnVM = LearnViewModel()
+    @EnvironmentObject var learnVM: LearnViewModel
 
     var body: some View {
         NavigationStack {
@@ -97,6 +97,5 @@ struct LearnView: View {
                 }
             }
         }
-        .environmentObject(learnVM)
     }
 }

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -82,7 +82,7 @@ struct MelodyNotepadView: View {
     private var tapInput: some View {
         VStack(spacing: 8) {
             // Note buttons
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 6), spacing: 6) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 44), spacing: 6)], spacing: 6) {
                 ForEach(0..<12, id: \.self) { pc in
                     Button {
                         viewModel.addNote(pitchClass: pc, octave: viewModel.currentOctave)
@@ -236,8 +236,7 @@ struct MelodyNotepadView: View {
 
     private var noteChipsView: some View {
         ScrollView {
-            let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 8)
-            LazyVGrid(columns: columns, spacing: 4) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 44), spacing: 4)], spacing: 4) {
                 ForEach(0..<viewModel.notes.count, id: \.self) { i in
                     let note = viewModel.notes[i]
                     let isPlaying = viewModel.playingIndex == i

--- a/iosApp/UkuleleCompanion/Views/OnboardingView.swift
+++ b/iosApp/UkuleleCompanion/Views/OnboardingView.swift
@@ -205,7 +205,7 @@ struct OnboardingView: View {
                     "High-G (Standard)", "Low-G", "Baritone (DGBE)", "D-Tuning (ADF#B)",
                     "Slack Key (GCEG)", "Open A (AC#EA)", "Low A (GCEa)", "Half-Step Down"
                 ]
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
                     ForEach(tuningOptions, id: \.self) { tuning in
                         Button {
                             settingsVM.selectedTuning = tuning

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -459,7 +459,6 @@ struct SongViewerView: View {
                 .font(.headline)
             if let voicing = voicings.first {
                 ChordDiagramView(voicing: voicing, chordName: chord)
-                    .frame(width: 150, height: 150)
                 Button {
                     let pitchClasses = (0..<voicing.frets.count).compactMap { i -> Int32? in
                         let fret = (voicing.frets[i] as! NSNumber).intValue


### PR DESCRIPTION
## Summary

- **Sidebar navigation for iPad landscape**: When `horizontalSizeClass` is `.regular`, `ContentView` shows a `NavigationSplitView` with a sidebar listing all sections (Play, Create, Practice, Training, Knowledge, Progress, Reference) instead of the phone-style `TabView`. The sidebar includes proper VoiceOver accessibility traits on section headers.
- **Adaptive content layouts across 12 views**: Replaced fixed grid columns, hardcoded cell sizes, and fixed frame dimensions with `GridItem(.adaptive(...))`, `horizontalSizeClass`-based sizing, and `aspectRatio` constraints so content scales naturally on wider screens.

### Files changed (13)

| File | Change |
|------|--------|
| `ContentView.swift` | Added `SidebarDestination` enum, size-class branching, `NavigationSplitView` sidebar with detail pane |
| `LearnView.swift` | Changed `LearnViewModel` from `@StateObject` to `@EnvironmentObject` (now owned by `ContentView`) |
| `ChordLibraryView.swift` | Fixed 2-column grid → `GridItem(.adaptive(minimum: 160))` |
| `FretboardView.swift` | Fixed `cellSize = 48` → 64pt on iPad via `horizontalSizeClass` |
| `FretboardNoteMapView.swift` | Fixed `cellSize = 36` → 52pt on iPad via `horizontalSizeClass` |
| `CircleOfFifthsView.swift` | Removed `.frame(height: 320)`, added `.aspectRatio(1, contentMode: .fit)` with max 500pt; diatonic chords grid → adaptive |
| `ChordDiagramView.swift` | `stringSpacing`/`fretSpacing`/`dotRadius` scale up on iPad (24/22/8 → 32/30/10) |
| `ChordTransitionsView.swift` | Removed fixed `.frame(height: 120)` from chord diagrams |
| `FavoritesView.swift` | Removed fixed `.frame(height: 120)` from chord diagrams |
| `SongbookView.swift` | Removed fixed `.frame(width: 150, height: 150)` from chord diagrams |
| `CapoGuideView.swift` | Friendly shapes grid → `GridItem(.adaptive(minimum: 80))` |
| `OnboardingView.swift` | Tuning options grid → `GridItem(.adaptive(minimum: 150))` |
| `MelodyNotepadView.swift` | Note buttons and note chips grids → `GridItem(.adaptive(minimum: 44))` |

## Test plan

- [ ] Run on iPad mini simulator in landscape — verify sidebar appears with all sections
- [ ] Rotate to portrait — verify TabView appears instead of sidebar
- [ ] Navigate sidebar items and confirm detail pane updates correctly
- [ ] Verify chord library shows 3+ columns in landscape
- [ ] Verify fretboard cells are larger on iPad
- [ ] Verify circle of fifths scales to available width
- [ ] Test VoiceOver navigation through the sidebar
- [ ] Verify light, dark, and high-contrast themes render correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sidebar navigation for iPad and larger screens with organized sections (Play, Create, Practice, Training, Knowledge, Progress, Reference).

* **Improvements**
  * Enhanced responsive layouts that better adapt to different screen sizes and device orientations.
  * Improved spacing and visual presentation of chord diagrams and interactive elements across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->