### PR TITLE
Update: change iOS app display name from "Ukulele Companion" to "Uke"

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -736,7 +736,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UkuleleCompanion/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Uke;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ukulele Companion needs microphone access for the tuner and pitch detection features.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Uke needs microphone access for the tuner and pitch detection features.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -770,7 +770,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UkuleleCompanion/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Uke;
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Ukulele Companion needs microphone access for the tuner and pitch detection features.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Uke needs microphone access for the tuner and pitch detection features.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/iosApp/UkuleleCompanion/Info.plist
+++ b/iosApp/UkuleleCompanion/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Ukulele Companion needs microphone access for the tuner and pitch detection features.</string>
+	<string>Uke needs microphone access for the tuner and pitch detection features.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
## Summary

- Changes the iOS home screen icon label from "Ukulele Companion" to "Uke", matching the Android app
- Updates `CFBundleDisplayName` in `Info.plist` and `INFOPLIST_KEY_CFBundleDisplayName` in `project.pbxproj` (both Debug and Release)

## Test plan

- [ ] Install on iOS simulator or device and verify the icon label reads "Uke"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * App display name changed from "Ukulele Companion" to "Uke" — will appear as "Uke" on devices and in stores.
  * Microphone permission message updated to reference "Uke" in the prompt shown when requesting access for tuner and pitch detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->