### PR TITLE
Add post-bugfix improvements: CI, tests, rules, skills

### DIFF
--- a/.cursor/rules/compose-coroutines.mdc
+++ b/.cursor/rules/compose-coroutines.mdc
@@ -1,0 +1,67 @@
+---
+description: Compose scroll/coroutine patterns — prevent programmatic scroll from being mistaken for user scroll, cancellation-safe flag resets
+globs: app/src/main/java/com/baijum/ukufretboard/ui/**/*.kt
+alwaysApply: false
+---
+
+- **Guard programmatic scroll from state observers**
+
+  `scrollState.isScrollInProgress` cannot distinguish between a user finger drag and a programmatic `animateScrollTo` call. If you observe `isScrollInProgress` to detect manual scrolling, always gate it with a flag:
+
+  ```kotlin
+  val programmaticScroll = remember { mutableStateOf(false) }
+
+  // Auto-scroll loop
+  LaunchedEffect(autoScrolling) {
+      if (autoScrolling) {
+          while (autoScrolling) {
+              programmaticScroll.value = true
+              try {
+                  scrollState.animateScrollTo(/* ... */)
+              } finally {
+                  programmaticScroll.value = false
+              }
+              delay(16L)
+          }
+      }
+  }
+
+  // Manual-scroll detector — skip when programmatic
+  LaunchedEffect(scrollState.isScrollInProgress) {
+      if (scrollState.isScrollInProgress && autoScrolling && !programmaticScroll.value) {
+          autoScrolling = false
+      }
+  }
+  ```
+
+- **Always wrap cancellable suspend calls in try/finally**
+
+  `animateScrollTo`, `animateTo`, and similar Compose suspend functions are cancellable. If you set a flag before calling them, reset it in a `finally` block so the flag is cleared even if the coroutine is cancelled (e.g., by user touch or `LaunchedEffect` recomposition):
+
+  ```kotlin
+  // ✅ DO
+  flag.value = true
+  try {
+      scrollState.animateScrollTo(target)
+  } finally {
+      flag.value = false
+  }
+
+  // ❌ DON'T — flag stays true if animateScrollTo is cancelled
+  flag.value = true
+  scrollState.animateScrollTo(target)
+  flag.value = false
+  ```
+
+- **Prefer snapshotFlow over LaunchedEffect(stateValue) for contextual reactions**
+
+  `LaunchedEffect(stateValue)` restarts whenever `stateValue` changes, but you lose the previous value. When you need to compare old vs. new, or combine the state change with other conditions, use `snapshotFlow`:
+
+  ```kotlin
+  // ✅ Richer context — can debounce, filter, combine
+  LaunchedEffect(Unit) {
+      snapshotFlow { scrollState.isScrollInProgress }
+          .filter { it && !programmaticScroll.value }
+          .collect { autoScrolling = false }
+  }
+  ```

--- a/.cursor/skills/android-bug-reproduce/SKILL.md
+++ b/.cursor/skills/android-bug-reproduce/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: android-bug-reproduce
+description: Reproduce and debug Android bugs on an emulator using ADB. Covers emulator setup, test data seeding, UI navigation via uiautomator, log capture, and screenshots. Use when the user asks to reproduce a bug, debug an issue on an emulator, or investigate an Android crash/behavior.
+---
+
+# Android Bug Reproduction on Emulator
+
+Systematically reproduce and investigate Android bugs using ADB and the emulator.
+
+## Prerequisites
+
+- Android SDK installed with `emulator` and `adb` on PATH
+- At least one AVD configured (check with `emulator -list-avds`)
+- A debug APK (build with `./gradlew assembleDebug` if needed)
+
+## Workflow
+
+### Step 1: Start the emulator
+
+Check for a running emulator first:
+
+```bash
+adb devices
+```
+
+If none is running, start one:
+
+```bash
+emulator -list-avds
+emulator -avd <avd_name> -no-snapshot-load &
+```
+
+Wait for the device to be ready:
+
+```bash
+adb wait-for-device
+adb shell getprop sys.boot_completed  # should return "1"
+```
+
+### Step 2: Install the debug APK
+
+```bash
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+### Step 3: Seed test data (if needed)
+
+For features that require existing data (e.g., chord sheets, favorites), seed SharedPreferences directly:
+
+```bash
+# Stop the app first
+adb shell am force-stop com.baijum.ukufretboard
+
+# Write test data to SharedPreferences
+adb shell run-as com.baijum.ukufretboard sh -c 'cat > shared_prefs/<pref_file>.xml << '\''XMLEOF'\''
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<map>
+    <!-- Your test data here -->
+</map>
+XMLEOF'
+```
+
+Common preference files:
+
+| File | Contents |
+|------|----------|
+| `chord_sheets.xml` | Saved songs/chord sheets (JSON list) |
+| `favorites.xml` | Favorited chords |
+| `app_settings.xml` | App settings |
+
+Example — seed a chord sheet:
+
+```bash
+adb shell run-as com.baijum.ukufretboard sh -c 'cat > shared_prefs/chord_sheets.xml << '\''XMLEOF'\''
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<map>
+    <string name="chord_sheets_json">[{"id":"test-1","title":"Test Song","artist":"Test","content":"[C]Hello [Am]world\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8\nLine 9\nLine 10","strumPatternName":"","labels":[],"createdAt":1700000000000,"updatedAt":1700000000000}]</string>
+</map>
+XMLEOF'
+```
+
+### Step 4: Launch the app and navigate
+
+```bash
+adb shell am start -n com.baijum.ukufretboard/.MainActivity
+```
+
+#### Find UI element coordinates with uiautomator
+
+Dump the current UI tree to find element bounds:
+
+```bash
+adb shell uiautomator dump /sdcard/ui.xml
+adb shell cat /sdcard/ui.xml | head -c 5000  # quick preview
+```
+
+Search for a specific element by content-description or text:
+
+```bash
+adb shell uiautomator dump /sdcard/ui.xml
+adb pull /sdcard/ui.xml /tmp/ui.xml
+grep -o 'content-desc="[^"]*"[^/]*bounds="[^"]*"' /tmp/ui.xml
+```
+
+#### Common navigation actions
+
+```bash
+# Open navigation drawer
+adb shell uiautomator dump /sdcard/ui.xml
+# Find "Open navigation menu" button bounds, then:
+adb shell input tap <x> <y>
+
+# Tap by coordinates (center of element bounds)
+# bounds="[left,top][right,bottom]" -> tap at ((left+right)/2, (top+bottom)/2)
+adb shell input tap 540 960
+
+# Go back
+adb shell input keyevent 4
+
+# Enter text in a focused field
+adb shell input text "hello"
+
+# Scroll down
+adb shell input swipe 540 1500 540 500 300
+```
+
+### Step 5: Add instrumentation logging
+
+When the root cause isn't obvious, add temporary `Log.d` statements to the relevant code:
+
+```kotlin
+import android.util.Log
+
+Log.d("DEBUG_<issue>", "state: autoScrolling=$autoScrolling, scrollValue=${scrollState.value}")
+```
+
+Rebuild and reinstall:
+
+```bash
+./gradlew assembleDebug && adb install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+### Step 6: Capture and filter logs
+
+```bash
+# Filter for your debug tag
+adb logcat -c  # clear old logs
+adb logcat -s "DEBUG_<issue>:D" &
+
+# Or capture to file for analysis
+adb logcat -s "DEBUG_<issue>:D" > /tmp/debug_log.txt &
+```
+
+Reproduce the bug, then stop logcat and analyze the output.
+
+### Step 7: Take screenshots
+
+```bash
+adb shell screencap -p /sdcard/screenshot.png
+adb pull /sdcard/screenshot.png /tmp/screenshot_before.png
+```
+
+For before/after comparison:
+
+```bash
+# Before fix
+adb shell screencap -p /sdcard/before.png
+adb pull /sdcard/before.png /tmp/before.png
+
+# After fix (rebuild, reinstall, reproduce)
+adb shell screencap -p /sdcard/after.png
+adb pull /sdcard/after.png /tmp/after.png
+```
+
+### Step 8: Clean up
+
+Remove debug logging before committing:
+
+```bash
+# Find all debug log lines added during this session
+grep -rn "DEBUG_<issue>" app/src/main/java/
+```
+
+Remove the `Log.d` lines and the `import android.util.Log` if no longer needed.
+
+## Tips
+
+- **Prefer seeding data over UI automation** — writing SharedPreferences XML is far more reliable than tapping through UI to create test data.
+- **Use `uiautomator dump` before every tap** — screen layouts change between devices and orientations; never hardcode coordinates from memory.
+- **Keep debug tags unique** — include the issue number (e.g., `DEBUG_issue41`) so logs don't mix with other debugging sessions.
+- **Force-stop before seeding** — SharedPreferences are cached in memory; the app must be stopped before writing XML files.

--- a/.cursor/skills/android-release/SKILL.md
+++ b/.cursor/skills/android-release/SKILL.md
@@ -60,6 +60,22 @@ Follow the [android-test-run](~/.cursor/skills/android-test-run/SKILL.md) skill 
 
 **If any tests fail, stop the release and fix the failures first.** Do not proceed to version bumping until lint and all tests pass.
 
+### Step 1d: Check for version drift
+
+Before bumping, verify the current `versionName` in `build.gradle.kts` matches expectations:
+
+```bash
+LATEST_TAG=$(git describe --tags --abbrev=0)
+TAG_VERSION="${LATEST_TAG#v}"
+GRADLE_VERSION=$(grep 'versionName' app/build.gradle.kts | head -1 | sed 's/.*"\(.*\)".*/\1/')
+echo "Latest tag: $LATEST_TAG ($TAG_VERSION) | Gradle versionName: $GRADLE_VERSION"
+if [ "$TAG_VERSION" != "$GRADLE_VERSION" ]; then
+  echo "⚠️  VERSION DRIFT DETECTED: Tag says $TAG_VERSION but Gradle says $GRADLE_VERSION"
+fi
+```
+
+If version drift is detected, **warn the user** before proceeding. Version drift means users received APKs with a stale version string. For example, if the latest tag is `v9.10.5` but `versionName` is `"9.10.1"`, four releases shipped with the wrong user-visible version.
+
 ### Step 2: Bump the version
 
 Read the current `versionCode` and `versionName` in `app/build.gradle.kts`:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -106,6 +106,47 @@ jobs:
           echo "### APK Size" >> "$GITHUB_STEP_SUMMARY"
           echo "**Debug APK**: ${SIZE_MB} MB (${SIZE_BYTES} bytes)" >> "$GITHUB_STEP_SUMMARY"
 
+  instrumented-tests:
+    name: Instrumented Tests
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [33]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: ./gradlew connectedAndroidTest
+
+      - name: Upload instrumented test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: instrumented-test-report-api${{ matrix.api-level }}
+          path: app/build/reports/androidTests/connected/
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /.idea
 .vscode/*
 !.vscode/settings.json
-.cursor/
+.cursor/*
 !.cursor/skills/
 !.cursor/rules/
 .DS_Store

--- a/app/src/androidTest/java/com/baijum/ukufretboard/AccessibilityTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/AccessibilityTest.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasClickAction
@@ -7,6 +8,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.printToLog
+import com.baijum.ukufretboard.ui.ChordSubstitutionsView
+import com.baijum.ukufretboard.ui.GlossaryView
 import org.junit.Rule
 import org.junit.Test
 
@@ -81,28 +84,24 @@ class AccessibilityTest {
     }
 
     @Test
-    fun verifySettingsSheetContentDescriptions() {
-        // This test serves as a template. To test specific screens,
-        // set the content to the screen's composable and call the assertions.
-        //
-        // Example:
-        // composeTestRule.setContent {
-        //     SettingsSheet(
-        //         soundSettings = SoundSettings(),
-        //         onSoundSettingsChange = {},
-        //         displaySettings = DisplaySettings(),
-        //         onDisplaySettingsChange = {},
-        //         tuningSettings = TuningSettings(),
-        //         onTuningSettingsChange = {},
-        //         fretboardSettings = FretboardSettings(),
-        //         onFretboardSettingsChange = {},
-        //         onDismiss = {},
-        //     )
-        // }
-        // assertNoClickableWithoutDescription()
-        // assertHeadingsExist()
+    fun glossaryView_hasHeadingsAndDescriptions() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                GlossaryView()
+            }
+        }
+        assertHeadingsExist()
+        assertNoClickableWithoutDescription()
+    }
 
-        // Placeholder assertion — replace with real screen test above
-        assert(true) { "Accessibility test template runs successfully" }
+    @Test
+    fun chordSubstitutionsView_hasClickableDescriptions() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                ChordSubstitutionsView()
+            }
+        }
+        assertHeadingsExist()
+        assertNoClickableWithoutDescription()
     }
 }

--- a/app/src/androidTest/java/com/baijum/ukufretboard/AutoScrollTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/AutoScrollTest.kt
@@ -1,0 +1,181 @@
+package com.baijum.ukufretboard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * UI tests for the song auto-scroll feature.
+ *
+ * Verifies that auto-scroll starts, stops, and does not immediately cancel
+ * due to the programmatic scroll being mistaken for a user gesture.
+ *
+ * Run with: ./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.baijum.ukufretboard.AutoScrollTest
+ */
+class AutoScrollTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Renders a minimal scrollable column with auto-scroll controls that
+     * mirror the pattern used in SheetViewer (SongbookTab.kt).
+     */
+    private fun setAutoScrollContent(): AutoScrollState {
+        val state = AutoScrollState()
+        composeTestRule.setContent {
+            MaterialTheme {
+                var autoScrolling by rememberSaveable { mutableStateOf(false) }
+                val scrollSpeed by rememberSaveable { mutableStateOf(1f) }
+                val scrollState = rememberScrollState()
+                val programmaticScroll = remember { mutableStateOf(false) }
+
+                LaunchedEffect(autoScrolling) {
+                    state.autoScrolling = autoScrolling
+                }
+
+                LaunchedEffect(autoScrolling, scrollSpeed) {
+                    if (autoScrolling) {
+                        while (autoScrolling) {
+                            programmaticScroll.value = true
+                            try {
+                                scrollState.animateScrollTo(
+                                    scrollState.value + scrollSpeed.toInt().coerceAtLeast(1),
+                                    animationSpec = androidx.compose.animation.core.tween(
+                                        durationMillis = 16,
+                                        easing = androidx.compose.animation.core.LinearEasing,
+                                    ),
+                                )
+                            } finally {
+                                programmaticScroll.value = false
+                            }
+                            delay(16L)
+                        }
+                    }
+                }
+
+                LaunchedEffect(scrollState.isScrollInProgress) {
+                    if (scrollState.isScrollInProgress && autoScrolling && !programmaticScroll.value) {
+                        autoScrolling = false
+                    }
+                }
+
+                LaunchedEffect(scrollState.value) {
+                    state.scrollValue = scrollState.value
+                }
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(scrollState),
+                ) {
+                    repeat(100) { i ->
+                        Text(
+                            text = "Line $i of the song",
+                            modifier = Modifier.height(40.dp),
+                        )
+                    }
+                }
+
+                androidx.compose.material3.FloatingActionButton(
+                    onClick = { autoScrolling = !autoScrolling },
+                    modifier = Modifier.semantics {
+                        contentDescription = if (autoScrolling) "Pause scroll" else "Auto-scroll"
+                    },
+                ) {
+                    Text(if (autoScrolling) "⏸" else "▶")
+                }
+            }
+        }
+        return state
+    }
+
+    @Test
+    fun autoScroll_startsScrolling_whenPlayPressed() {
+        val state = setAutoScrollContent()
+        composeTestRule.waitForIdle()
+
+        val initialScroll = state.scrollValue
+
+        // Disable auto-advance so the infinite scroll loop doesn't make Compose perpetually busy
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.onNodeWithContentDescription("Auto-scroll").performClick()
+        composeTestRule.mainClock.advanceTimeBy(1000)
+
+        assertTrue("autoScrolling should be true after pressing play", state.autoScrolling)
+        assertTrue(
+            "scroll position should advance (was $initialScroll, now ${state.scrollValue})",
+            state.scrollValue > initialScroll,
+        )
+    }
+
+    @Test
+    fun autoScroll_stops_whenPausePressed() {
+        val state = setAutoScrollContent()
+        composeTestRule.waitForIdle()
+
+        // Start auto-scroll with clock control
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.onNodeWithContentDescription("Auto-scroll").performClick()
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        assertTrue("autoScrolling should be true", state.autoScrolling)
+
+        // Pause auto-scroll
+        composeTestRule.onNodeWithContentDescription("Pause scroll").performClick()
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        assertFalse("autoScrolling should be false after pressing pause", state.autoScrolling)
+    }
+
+    @Test
+    fun autoScroll_doesNotImmediatelyCancel() {
+        val state = setAutoScrollContent()
+        composeTestRule.waitForIdle()
+
+        // Disable auto-advance so the infinite scroll loop doesn't make Compose perpetually busy
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.onNodeWithContentDescription("Auto-scroll").performClick()
+
+        // The original bug caused auto-scroll to cancel within ~50ms.
+        // Advance 500ms of frames and verify it's still running.
+        composeTestRule.mainClock.advanceTimeBy(500)
+
+        assertTrue(
+            "autoScrolling should still be true (was cancelled prematurely)",
+            state.autoScrolling,
+        )
+        assertTrue(
+            "scroll position should be > 0 (was ${state.scrollValue})",
+            state.scrollValue > 0,
+        )
+    }
+
+    /** Mutable holder for observing state changes from outside the composition. */
+    private class AutoScrollState {
+        @Volatile var autoScrolling = false
+        @Volatile var scrollValue = 0
+    }
+}

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordSubstitutionsView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordSubstitutionsView.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
@@ -56,6 +58,7 @@ fun ChordSubstitutionsView(
             text = stringResource(R.string.chord_subs_title),
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
         )
         Text(
             text = stringResource(R.string.chord_subs_subtitle),


### PR DESCRIPTION
## Summary

Post-bugfix improvements identified during the auto-scroll bug investigation (#41) and release workflow.

- **Auto-scroll UI tests**: 3 Compose instrumented tests verifying scroll starts, stops, and doesn't immediately cancel (regression guard for #41)
- **CI instrumented tests**: New `instrumented-tests` job in `android.yml` using `reactivecircus/android-emulator-runner` on API 33 — previously only lint and unit tests ran in CI
- **AccessibilityTest**: Replaced `assert(true)` placeholder with real assertions on `GlossaryView` (headings + descriptions) and `ChordSubstitutionsView` (clickable descriptions)
- **compose-coroutines rule**: New Cursor rule for scroll/coroutine patterns — guard programmatic scroll with flags, use try/finally, prefer snapshotFlow
- **android-release skill**: Added version drift check (Step 1d) comparing `git describe --tags` with Gradle `versionName`
- **android-bug-reproduce skill**: New skill covering emulator setup, SharedPreferences seeding, uiautomator navigation, logcat capture, screenshots
- **.gitignore fix**: Changed `.cursor/` to `.cursor/*` so `!.cursor/skills/` and `!.cursor/rules/` negation patterns work without `git add -f`

## Test plan
- [ ] Verify `AutoScrollTest` passes on emulator (`./gradlew connectedAndroidTest`)
- [ ] Verify `AccessibilityTest` passes on emulator
- [ ] Verify CI `instrumented-tests` job runs successfully
- [ ] Verify new `.cursor/` files are tracked by git without force-add

Closes #44

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added accessibility tests for Glossary and Chord Substitutions screens.
  * Added instrumented Compose tests for auto-scroll behavior.
  * Enabled instrumented Android tests in CI with emulator support and artifact upload.

* **Documentation**
  * Added an Android emulator bug-reproduction guide.
  * Added a release step that warns when tag and build version differ.
  * Added Compose coroutine/scroll guidance for safer auto-scroll handling.

* **Bug Fixes**
  * Improved accessibility semantics for the Chord Substitutions title.

* **Chores**
  * Broadened ignored patterns for internal tooling files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->