### PR TITLE
Fix: ensure iOS simulator availability before CI build

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -30,6 +30,34 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_16.4.app
 
+      - name: Prepare iOS Simulator
+        run: |
+          for i in $(seq 1 5); do
+            if xcrun simctl list runtimes | grep -q "com.apple.CoreSimulator.SimRuntime.iOS"; then
+              break
+            fi
+            echo "Waiting for iOS simulator runtime (attempt $i/5)..."
+            sleep 10
+          done
+
+          xcrun simctl list runtimes
+
+          RUNTIME=$(xcrun simctl list runtimes | grep "^iOS" | tail -1 | awk '{print $NF}')
+          if [ -z "$RUNTIME" ]; then
+            echo "::error::No iOS simulator runtime found"
+            exit 1
+          fi
+          echo "Runtime: $RUNTIME"
+
+          if ! xcrun simctl list devices available | grep -q "iPhone 16"; then
+            echo "Creating iPhone 16 simulator..."
+            xcrun simctl create "iPhone 16" \
+              "com.apple.CoreSimulator.SimDeviceType.iPhone-16" \
+              "$RUNTIME"
+          fi
+
+          xcrun simctl list devices available | grep "iPhone"
+
       - name: Build shared framework
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
 


### PR DESCRIPTION
## Summary
- Adds a **Prepare iOS Simulator** step to the iOS CI workflow that retries up to 5 times (10s apart) until the iOS simulator runtime is registered on the runner
- Explicitly creates an `iPhone 16` simulator device if one doesn't already exist, using the latest available iOS runtime
- This eliminates the flaky "Unable to find a device matching the provided destination specifier" error on `macos-15` GitHub Actions runners

Closes #46

## Test plan
- [ ] Verify the iOS CI workflow passes on this PR
- [ ] Confirm the "Prepare iOS Simulator" step logs the runtime and device info

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced iOS build pipeline to automatically prepare and configure the iOS simulator environment during the build process, ensuring consistent simulator availability for testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->