### PR TITLE
Fix: resolve Xcode Cloud build error and warning

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		C60001 /* Build KMP Framework */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "=== Installing JDK 17 ==="
+brew install openjdk@17
+JAVA_HOME="$(brew --prefix openjdk@17)"
+if [ -z "$JAVA_HOME" ]; then
+    echo "ERROR: Failed to resolve JAVA_HOME for openjdk@17."
+    exit 1
+fi
+export JAVA_HOME
+
+echo "=== Building KMP shared framework ==="
+cd "$REPO_ROOT"
+./gradlew :shared:linkReleaseFrameworkIosArm64
+
+echo "=== Downloading ONNX Runtime ==="
+bash "$REPO_ROOT/iosApp/setup_onnxruntime.sh"


### PR DESCRIPTION
## Summary

- Add `iosApp/ci_scripts/ci_post_clone.sh` for Xcode Cloud to install JDK 17, build the KMP shared framework, and download the ONNX Runtime xcframework before the build starts (fixes the missing `onnxruntime.xcframework` error)
- Mark the "Build KMP Framework" script phase as `alwaysOutOfDate` in `project.pbxproj` to suppress the warning about missing output dependencies

## Test plan

- [ ] Push to `main` and verify Xcode Cloud build succeeds in App Store Connect
- [ ] Confirm the error "There is no XCFramework found at .../onnxruntime.xcframework" is gone
- [ ] Confirm the warning about "Build KMP Framework" output dependencies is gone
- [ ] Verify local iOS build still works (`xcodebuild build` for simulator)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted iOS build configuration to force re-execution of a build phase, improving build reliability.
  * Added a CI post-clone step to install Java tooling, build the iOS shared framework, and run ONNX Runtime setup to streamline deployment preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->