### PR TITLE
Fix: iOS auto-scroll speed ignored, resume resets position, timer stalls

### DIFF
--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -278,6 +278,13 @@ struct SongbookView: View {
     }
 }
 
+private struct ScrollOffsetKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 struct SongViewerView: View {
     @ObservedObject var viewModel: SongbookViewModel
     @Environment(\.dismiss) private var dismiss
@@ -288,6 +295,10 @@ struct SongViewerView: View {
     @State private var scrollSpeed: Double = 1.0
     @State private var scrollTimer: Timer?
     @State private var scrollOffset: CGFloat = 0
+    @State private var trackedScrollOffset: CGFloat = 0
+    @State private var contentHeight: CGFloat = 1
+    @State private var viewportHeight: CGFloat = 1
+    @State private var shouldRestartFromTop = false
     @State private var showDeleteConfirmation = false
     @State private var showingStrumPicker = false
     @State private var showingAddLabel = false
@@ -330,10 +341,38 @@ struct SongViewerView: View {
                     Color.clear.frame(height: 1).id("bottom")
                 }
                 .padding()
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .preference(key: ScrollOffsetKey.self,
+                                        value: -geo.frame(in: .named("songScroll")).minY)
+                            .onChange(of: geo.size.height) { newHeight in
+                                contentHeight = newHeight
+                            }
+                            .onAppear { contentHeight = geo.size.height }
+                    }
+                )
             }
+            .coordinateSpace(name: "songScroll")
+            .onPreferenceChange(ScrollOffsetKey.self) { value in
+                trackedScrollOffset = max(0, value)
+            }
+            .background(
+                GeometryReader { geo in
+                    Color.clear.onAppear { viewportHeight = geo.size.height }
+                        .onChange(of: geo.size.height) { newHeight in
+                            viewportHeight = newHeight
+                        }
+                }
+            )
             .overlay(alignment: .bottomTrailing) {
                 autoScrollControls(proxy: proxy)
                     .padding()
+            }
+            .onChange(of: scrollSpeed) { _ in
+                guard isAutoScrolling else { return }
+                scrollTimer?.invalidate()
+                scrollTimer = createScrollTimer(proxy: proxy)
             }
         }
         .navigationTitle(displayTitle)
@@ -681,16 +720,30 @@ struct SongViewerView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    private func startAutoScroll(proxy: ScrollViewProxy) {
-        isAutoScrolling = true
-        scrollOffset = 0
+    @discardableResult
+    private func createScrollTimer(proxy: ScrollViewProxy) -> Timer {
         let interval = 1.0 / (scrollSpeed * 2)
-        scrollTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+        let timer = Timer(timeInterval: interval, repeats: true) { [self] _ in
             DispatchQueue.main.async {
+                guard isAutoScrolling else { return }
                 scrollOffset += 1
                 proxy.scrollTo("bottom", anchor: .init(x: 0.5, y: min(1.0, scrollOffset / 500)))
             }
         }
+        RunLoop.current.add(timer, forMode: .common)
+        return timer
+    }
+
+    private func startAutoScroll(proxy: ScrollViewProxy) {
+        isAutoScrolling = true
+        if shouldRestartFromTop {
+            scrollOffset = 0
+            shouldRestartFromTop = false
+        } else {
+            let maxScroll = max(1, contentHeight - viewportHeight)
+            scrollOffset = (trackedScrollOffset / maxScroll) * 500
+        }
+        scrollTimer = createScrollTimer(proxy: proxy)
     }
 
     private func pauseAutoScroll() {
@@ -704,6 +757,7 @@ struct SongViewerView: View {
         scrollTimer?.invalidate()
         scrollTimer = nil
         scrollOffset = 0
+        shouldRestartFromTop = true
     }
 
     // MARK: - Content Parsing


### PR DESCRIPTION
## Summary

Fixes all three auto-scroll bugs in `SongViewerView` reported in issue #43.

- **Speed chips had no effect** — `startAutoScroll` captured the timer interval once at creation. Added `.onChange(of: scrollSpeed)` inside the `ScrollViewReader` closure to invalidate and recreate the timer immediately when the speed changes.
- **Resume jumped back to top** — `startAutoScroll` reset `scrollOffset = 0` unconditionally, so pause → play always restarted from the beginning. Removed the reset; `scrollOffset` is now only zeroed in `stopAutoScroll`.
- **Timer stalled during drag** — `Timer.scheduledTimer` registers in `.default` run loop mode, which pauses during `UIScrollView` tracking. Extracted a `createScrollTimer(proxy:)` helper that adds the timer to `.common` mode so it fires during both normal operation and scroll gestures.

## Test plan

- [ ] Open a song with enough content to scroll
- [ ] Tap Play — verify song scrolls continuously
- [ ] Tap a speed chip (e.g. 0.5x, 2x, 3x) while scrolling — verify speed changes immediately, no restart needed
- [ ] Tap Pause, then Play — verify scrolling resumes from the current position (does not jump to top)
- [ ] Tap Stop, then Play — verify scrolling restarts from the top
- [ ] While auto-scrolling, manually drag to scroll — verify the timer keeps firing after the drag ends (no stall)
- [ ] VoiceOver: navigate to Play/Pause/Stop buttons and speed chips — verify all labels are announced correctly

Closes #43

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-scroll speed changes now take effect immediately without interrupting scrolling.
  * Starting or updating auto-scroll preserves the current position to avoid jumps.
  * Scroll position is clamped to valid bounds to prevent unexpected overscroll.

* **Improvements**
  * Content and viewport sizing are tracked more accurately for smoother scrolling.
  * Stop vs. pause behavior clarified: stopping marks for restart-from-top; pausing preserves position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->