### PR TITLE
Fix: enable JUnit Platform for Jazzer fuzz test discovery

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,10 @@ play {
     serviceAccountCredentials.set(file("play-service-account.json"))
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation(project(":shared"))
     implementation(platform(libs.compose.bom))
@@ -107,6 +111,8 @@ dependencies {
     testImplementation(libs.kotest.property)
     testImplementation(libs.jazzer.junit)
     testImplementation(libs.jazzer.api)
+    testRuntimeOnly(libs.junit.vintage.engine)
+    testRuntimeOnly(libs.junit.jupiter.engine)
     debugImplementation(libs.ui.tooling)
     debugImplementation(libs.ui.test.manifest)
     androidTestImplementation(platform(libs.compose.bom))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ reorderable = "3.0.0"
 onnxruntime = "1.24.3"
 playPublisher = "4.0.0"
 junit = "4.13.2"
+junit5 = "5.11.4"
 material = "1.13.0"
 kotest = "6.1.7"
 jazzer = "0.22.1"
@@ -41,6 +42,8 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 jazzer-junit = { group = "com.code-intelligence", name = "jazzer-junit", version.ref = "jazzer" }
 jazzer-api = { group = "com.code-intelligence", name = "jazzer-api", version.ref = "jazzer" }
+junit-vintage-engine = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit5" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit5" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- Fixes the [Fuzz Tests CI failure](https://github.com/baijum/ukulele-companion/actions/runs/23383836174/job/68027497807) where Gradle reported "No tests found for given includes: [com.baijum.ukufretboard.fuzz.*]"
- The root cause: `@FuzzTest` from `jazzer-junit` is a JUnit 5 (Jupiter) annotation, but Gradle was using JUnit 4's test runner which cannot discover it
- Adds `useJUnitPlatform()`, `junit-jupiter-engine` (for `@FuzzTest` discovery), and `junit-vintage-engine` (to keep existing JUnit 4 tests running)

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` -- all existing JUnit 4 unit and property tests pass via Vintage Engine
- [x] `./gradlew :app:testDebugUnitTest --tests "com.baijum.ukufretboard.fuzz.*"` -- fuzz tests are discovered and pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Activated the JUnit Platform for all test tasks.
  * Added JUnit Vintage and JUnit Jupiter engine artifacts to runtime test dependencies.
  * Introduced a JUnit 5 version alias in the dependency catalog to centralize engine versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->