### PR TITLE
Chore: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,7 +38,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v5
 
       - name: Restore fuzz corpus cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: app/src/test/resources/corpus
           key: fuzz-corpus-${{ github.sha }}


### PR DESCRIPTION
## Summary

- Bump `actions/cache` v4 → v5 in `fuzz.yml` (Node.js 24 support)
- Bump `actions/checkout` v4 → v6 in `claude.yml` (consistency with all other workflows)

Fixes the Node.js 20 deprecation warning for the Fuzz Tests workflow. The remaining warnings (`upload-pages-artifact`, `deploy-pages`, `dependency-review-action`) are tracked in #59 — no upstream Node 24 releases exist yet.

## Test plan

- [ ] Fuzz Tests workflow runs without the Node.js 20 deprecation warning for `actions/cache`
- [ ] Claude Code workflow runs successfully with `actions/checkout@v6`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies for improved CI/CD pipeline performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->