### PR TITLE
Add: composition tools for songwriting workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Ukulele Companion is a **free, fully offline** multiplatform app (Android + iOS)
 | `audio/` | `ToneGenerator`, `MetronomeEngine`, `AudioCaptureEngine` (44.1kHz PCM) |
 | `data/` | Repositories (SharedPreferences-backed), backup/restore manager |
 | `domain/` | `NeuralPitchSupervisor`, `ChordImageSharer`, `AchievementChecker` |
-| `ui/` | 54 Compose screens/components via `ModalNavigationDrawer` (no NavHost) |
+| `ui/` | 55 Compose screens/components via `ModalNavigationDrawer` (no NavHost) |
 | `viewmodel/` | 13 ViewModels exposing `StateFlow` |
 
 ### iOS app (`iosApp/UkuleleCompanion/`)
@@ -50,7 +50,7 @@ Ukulele Companion is a **free, fully offline** multiplatform app (Android + iOS)
 | Directory | Contents |
 |-----------|----------|
 | `Audio/` | `AudioCaptureEngine`, `TonePlayer`, `NeuralPitchSupervisor` (ONNX C API) |
-| `Views/` | 47 SwiftUI views across Play, Create, Learn, Reference tabs |
+| `Views/` | 48 SwiftUI views across Play, Create, Learn, Reference tabs |
 | `ViewModels/` | 15 ViewModels using `@Published` |
 | `Helpers/` | `AccessibilityHelper`, `BackupRestoreManager` |
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The tuner now uses a hybrid pipeline: fast YIN pitch tracking on every frame, su
 A reference guide with 15 strumming and 11 fingerpicking patterns — from beginner to advanced — in 4/4, 3/4, and 6/8 time. Each pattern includes visual beat/step display, notation, description, and a **play button with adjustable tempo** so you can hear what each pattern sounds like. Create custom patterns with adjustable beat counts (2–16) and time signatures, or duplicate any preset to make your own variations.
 
 ### 🎶 Chord Progressions
-Common chord progressions for any key across seven modes (Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, Locrian). Each chord chip shows its harmonic function (Tonic, Subdominant, Dominant) with colour coding. Includes Pop, Classic Rock, 50s, Folk, Jazz ii-V-I, Reggae, and more. Create custom progressions, duplicate presets, and use tap tempo for practice.
+Common chord progressions for any key across seven modes (Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, Locrian). Each chord chip shows its harmonic function (Tonic, Subdominant, Dominant) with colour coding. Includes Pop, Classic Rock, 50s, Folk, Jazz ii-V-I, Reggae, and more. Create custom progressions with diatonic chord suggestions from the selected scale, duplicate presets, copy to clipboard, and use tap tempo for practice.
 
 </td>
 <td width="50%" valign="top">
@@ -55,13 +55,16 @@ Highlight notes from any of 38 scales (Major, Natural/Harmonic/Melodic Minor, Pe
 Long-press any voicing in the Chord Library to save it. Access your saved voicings from the dedicated Favorites tab.
 
 ### 📝 Song Chord Sheets
-Create a personal songbook with lyrics and inline chord markers (e.g., `Some[C]where over the [Em]rainbow`). Search, sort, and label songs for easy organisation. Associate strum patterns, use quick-insert chord chips in the editor, and preview chords above lyrics in real time. Tap any chord name to view its voicings.
+Create a personal songbook with lyrics and inline chord markers (e.g., `Some[C]where over the [Em]rainbow`). Search, sort, and label songs for easy organisation. Associate strum patterns, use quick-insert chord chips in the editor, and preview chords above lyrics in real time. Tap any chord name to view its voicings. Transpose songs with +/- controls and **Save in this key** to permanently rewrite chords. Share via a format picker offering ChordPro, plain text, or clipboard copy.
 
 ### 🎵 Metronome
 A standalone practice metronome with adjustable BPM (30–300), tap tempo, time signatures (2/4 to 7/4), customizable accent patterns, and subdivisions (quarter, eighth, triplet, sixteenth). Visual beat indicators pulse in time.
 
 ### 🎹 Melody Notepad
-Compose short melodies by tapping notes or recording from your ukulele's microphone. Choose note durations, set the octave, and play back at any tempo. Save and load multiple melodies.
+Compose melodies by tapping notes, recording from your ukulele's microphone, or using the **step sequencer** — a grid of 8 or 16 steps for building loops and rhythmic patterns. Choose note durations, set the octave, and play back at any tempo. Save and load multiple melodies.
+
+### ✍️ Songwriter Mode
+A guided **"Start a Song"** flow that walks you through picking a key and scale, building a chord progression from diatonic suggestions, writing lyrics with inline chords, transposing, and saving to your songbook — all in one place.
 
 ### 🔊 Sound Playback
 Hear chords played back using sampled ukulele audio. Notes are strummed with a configurable delay between strings.
@@ -187,12 +190,12 @@ ukulele-companion/
 │       ├── audio/                   # SoundPool, metronome, audio capture
 │       ├── data/                    # Repositories (SharedPreferences), backup/restore
 │       ├── domain/                  # NeuralPitchSupervisor, AchievementChecker
-│       ├── ui/                      # 54 Compose screens and components
+│       ├── ui/                      # 55 Compose screens and components
 │       └── viewmodel/               # 13 ViewModels (StateFlow)
 │
 ├── iosApp/                          # iOS app (SwiftUI)
 │   └── UkuleleCompanion/
-│       ├── Views/                   # 47 SwiftUI views
+│       ├── Views/                   # 48 SwiftUI views
 │       ├── ViewModels/              # 15 ObservableObject ViewModels
 │       ├── Audio/                   # AudioCaptureEngine, TonePlayer, NeuralPitchSupervisor
 │       ├── Helpers/                 # Accessibility helpers, backup/restore manager
@@ -329,9 +332,9 @@ Looking for a place to start? Here are some areas where contributions would be e
 </p>
 
 - **Shared module**: 55 Kotlin files — chord detection, pitch detection, scales, notes, transposition, and all domain/data logic shared across platforms
-- **Android UI layer**: 54 Compose files, single-activity architecture via `MainActivity`
+- **Android UI layer**: 55 Compose files, single-activity architecture via `MainActivity`
 - **Android ViewModel layer**: 13 ViewModels managing state with `StateFlow`
-- **iOS UI layer**: 47 SwiftUI views with full feature parity
+- **iOS UI layer**: 48 SwiftUI views with full feature parity
 - **iOS ViewModel layer**: 15 ObservableObject ViewModels
 - **Audio layer**: Platform-specific audio capture, tone playback, and ONNX neural pitch detection
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/FretboardScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/FretboardScreen.kt
@@ -148,6 +148,7 @@ private const val NAV_DAILY_CHALLENGE = 26
 private const val NAV_PRACTICE_ROUTINE = 28
 private const val NAV_PLAY_ALONG = 29
 private const val NAV_METRONOME = 30
+private const val NAV_SONGWRITER_MODE = 27
 
 /**
  * Drawer navigation item metadata.
@@ -178,6 +179,7 @@ private fun drawerSections(): List<DrawerSection> = listOf(
         DrawerItem(NAV_FAVORITES, stringResource(R.string.nav_favorites), Icons.Filled.Favorite),
     )),
     DrawerSection(stringResource(R.string.nav_section_create), listOf(
+        DrawerItem(NAV_SONGWRITER_MODE, stringResource(R.string.nav_songwriter_mode), Icons.Filled.Create),
         DrawerItem(NAV_SONGBOOK, stringResource(R.string.nav_songs), Icons.Filled.Create),
         DrawerItem(NAV_MELODY_NOTEPAD, stringResource(R.string.nav_melody_notepad), Icons.Filled.Create),
         DrawerItem(NAV_PATTERNS, stringResource(R.string.nav_patterns), Icons.AutoMirrored.Filled.List),
@@ -587,6 +589,14 @@ fun FretboardScreen(
                         },
                         leftHanded = appSettings.fretboard.leftHanded,
                     )
+                    NAV_SONGWRITER_MODE -> ConstrainedWidthContent(isCompactWidth) {
+                        SongwriterModeFlow(
+                            songbookViewModel = songbookViewModel,
+                            onSaveProgression = { name, description, degrees, scaleType ->
+                                customProgressionViewModel.create(name, description, degrees, scaleType)
+                            },
+                        )
+                    }
                     NAV_SONGBOOK -> ConstrainedWidthContent(isCompactWidth) {
                         SongbookTab(
                             viewModel = songbookViewModel,

--- a/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
@@ -76,6 +76,8 @@ import com.baijum.ukufretboard.data.Melody
 import com.baijum.ukufretboard.data.MelodyNote
 import com.baijum.ukufretboard.data.NoteDuration
 import com.baijum.ukufretboard.data.Notes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import com.baijum.ukufretboard.viewmodel.MelodyInputMode
 import com.baijum.ukufretboard.viewmodel.MelodyUiState
 import com.baijum.ukufretboard.viewmodel.MelodyViewModel
@@ -142,49 +144,117 @@ fun MelodyNotepadView(
             },
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // --- Note sequence display ---
-        NoteSequenceCard(
-            state = state,
-            onSelectNote = viewModel::selectNote,
-            onDeleteNote = viewModel::deleteSelectedNote,
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        // --- Duration selector ---
-        DurationSelector(
-            selectedDuration = state.selectedDuration,
-            onSelectDuration = viewModel::setDuration,
-        )
-
         Spacer(modifier = Modifier.height(8.dp))
 
-        // --- Input mode toggle + content ---
-        InputModeSection(
-            state = state,
-            onSetInputMode = viewModel::setInputMode,
-            onAddNote = { pc -> viewModel.addNote(pc) },
-            onAddRest = viewModel::addRest,
-            onOctaveUp = viewModel::incrementOctave,
-            onOctaveDown = viewModel::decrementOctave,
-            onStartRecording = viewModel::startRecording,
-            onStopRecording = viewModel::stopRecording,
-        )
+        // --- Mode toggle ---
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FilterChip(
+                selected = !state.isStepSequencerMode,
+                onClick = { if (state.isStepSequencerMode) viewModel.toggleStepSequencerMode() },
+                label = { Text("Linear") },
+                modifier = Modifier.semantics {
+                    contentDescription = "Linear mode, sequential note entry"
+                },
+            )
+            FilterChip(
+                selected = state.isStepSequencerMode,
+                onClick = { if (!state.isStepSequencerMode) viewModel.toggleStepSequencerMode() },
+                label = { Text("Step Sequencer") },
+                modifier = Modifier.semantics {
+                    contentDescription = "Step sequencer mode, grid-based entry"
+                },
+            )
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // --- BPM and playback controls ---
-        BpmAndPlaybackControls(
-            state = state,
-            bpmSliderValue = bpmSliderValue,
-            onBpmSliderChange = { bpmSliderValue = it },
-            onBpmChange = { viewModel.setBpm(it) },
-            onPlay = viewModel::playMelody,
-            onStop = viewModel::stopPlayback,
-            onClear = viewModel::clearAll,
-        )
+        if (state.isStepSequencerMode) {
+            StepSequencerGrid(
+                state = state,
+                onSetStep = viewModel::setStep,
+                onClearStep = viewModel::clearStep,
+                onExpandSteps = viewModel::expandSteps,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // --- Duration selector for step sequencer ---
+            DurationSelector(
+                selectedDuration = state.selectedDuration,
+                onSelectDuration = viewModel::setDuration,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // --- Octave for step sequencer ---
+            OctaveSelector(
+                currentOctave = state.currentOctave,
+                onOctaveUp = viewModel::incrementOctave,
+                onOctaveDown = viewModel::decrementOctave,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // --- BPM and playback controls ---
+            BpmAndPlaybackControls(
+                state = state,
+                bpmSliderValue = bpmSliderValue,
+                onBpmSliderChange = { bpmSliderValue = it },
+                onBpmChange = { viewModel.setBpm(it) },
+                onPlay = viewModel::playSteps,
+                onStop = viewModel::stopPlayback,
+                onClear = {
+                    for (i in state.steps.indices) {
+                        viewModel.clearStep(i)
+                    }
+                },
+            )
+        } else {
+            // --- Note sequence display ---
+            NoteSequenceCard(
+                state = state,
+                onSelectNote = viewModel::selectNote,
+                onDeleteNote = viewModel::deleteSelectedNote,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // --- Duration selector ---
+            DurationSelector(
+                selectedDuration = state.selectedDuration,
+                onSelectDuration = viewModel::setDuration,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // --- Input mode toggle + content ---
+            InputModeSection(
+                state = state,
+                onSetInputMode = viewModel::setInputMode,
+                onAddNote = { pc -> viewModel.addNote(pc) },
+                onAddRest = viewModel::addRest,
+                onOctaveUp = viewModel::incrementOctave,
+                onOctaveDown = viewModel::decrementOctave,
+                onStartRecording = viewModel::startRecording,
+                onStopRecording = viewModel::stopRecording,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // --- BPM and playback controls ---
+            BpmAndPlaybackControls(
+                state = state,
+                bpmSliderValue = bpmSliderValue,
+                onBpmSliderChange = { bpmSliderValue = it },
+                onBpmChange = { viewModel.setBpm(it) },
+                onPlay = viewModel::playMelody,
+                onStop = viewModel::stopPlayback,
+                onClear = viewModel::clearAll,
+            )
+        }
     }
 
     // --- Dialogs ---
@@ -1191,4 +1261,182 @@ private fun RenameMelodyDialog(
             }
         },
     )
+}
+
+// =============================================================================
+// Step Sequencer Grid
+// =============================================================================
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun StepSequencerGrid(
+    state: MelodyUiState,
+    onSetStep: (Int, Int) -> Unit,
+    onClearStep: (Int) -> Unit,
+    onExpandSteps: () -> Unit,
+) {
+    val gridLabel = "Melody step sequencer, ${state.steps.size} steps"
+
+    Column(modifier = Modifier.semantics { contentDescription = gridLabel }) {
+        Text(
+            text = "Step Sequencer (${state.steps.size} steps)",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            state.steps.forEachIndexed { index, note ->
+                val isPlaying = state.isPlaying && state.playingIndex == index
+                val noteName = note?.pitchClass?.let { Notes.pitchClassToName(it) }
+                val stepDesc = if (noteName != null) {
+                    "Step ${index + 1}: $noteName${note.octave} ${note.duration.name.lowercase()}"
+                } else {
+                    "Step ${index + 1}: empty"
+                }
+
+                var showPitchPicker by remember { mutableStateOf(false) }
+
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .background(
+                            color = when {
+                                isPlaying -> MaterialTheme.colorScheme.primaryContainer
+                                note != null -> MaterialTheme.colorScheme.secondaryContainer
+                                else -> MaterialTheme.colorScheme.surfaceVariant
+                            },
+                            shape = RoundedCornerShape(8.dp),
+                        )
+                        .border(
+                            width = if (isPlaying) 2.dp else 1.dp,
+                            color = if (isPlaying) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.outlineVariant
+                            },
+                            shape = RoundedCornerShape(8.dp),
+                        )
+                        .combinedClickable(
+                            onClick = { showPitchPicker = true },
+                            onLongClick = { onClearStep(index) },
+                        )
+                        .semantics {
+                            contentDescription = stepDesc
+                            role = Role.Button
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (noteName != null) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = noteName,
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Text(
+                                text = "${note!!.octave}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = "${index + 1}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                if (showPitchPicker) {
+                    StepPitchPickerPopup(
+                        onSelect = { pc ->
+                            onSetStep(index, pc)
+                            showPitchPicker = false
+                        },
+                        onDismiss = { showPitchPicker = false },
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            val expandLabel = if (state.steps.size >= MelodyUiState.STEP_COUNT_16) {
+                "8 steps"
+            } else {
+                "16 steps"
+            }
+            OutlinedButton(onClick = onExpandSteps) {
+                Text(expandLabel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepPitchPickerPopup(
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenu(
+        expanded = true,
+        onDismissRequest = onDismiss,
+    ) {
+        for (pc in 0 until Notes.PITCH_CLASS_COUNT) {
+            val name = Notes.pitchClassToName(pc)
+            DropdownMenuItem(
+                text = { Text(name) },
+                onClick = { onSelect(pc) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OctaveSelector(
+    currentOctave: Int,
+    onOctaveUp: () -> Unit,
+    onOctaveDown: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.melody_octave),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        IconButton(onClick = onOctaveDown) {
+            Icon(
+                Icons.Filled.KeyboardArrowDown,
+                contentDescription = stringResource(R.string.cd_decrease_octave),
+            )
+        }
+        Text(
+            text = currentOctave.toString(),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics {
+                contentDescription = "Octave $currentOctave"
+                liveRegion = LiveRegionMode.Polite
+            },
+        )
+        IconButton(onClick = onOctaveUp) {
+            Icon(
+                Icons.Filled.KeyboardArrowUp,
+                contentDescription = stringResource(R.string.cd_increase_octave),
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionsTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionsTab.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard.ui
 
+import android.widget.Toast
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -298,6 +299,11 @@ fun ProgressionsTab(
                             val text = ChordSheetFormatter.formatProgression(custom.progression, selectedRoot)
                             ShareUtils.shareText(context, custom.progression.name, text)
                         },
+                        onCopy = {
+                            val text = ChordSheetFormatter.formatProgression(custom.progression, selectedRoot)
+                            ShareUtils.copyToClipboard(context, custom.progression.name, text)
+                            Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
+                        },
                         onPlay = { playbackProgression = custom.progression },
                         onPractice = {
                             practiceProgression = custom.progression
@@ -354,6 +360,11 @@ fun ProgressionsTab(
                     onShare = {
                         val text = ChordSheetFormatter.formatProgression(progression, selectedRoot)
                         ShareUtils.shareText(context, progression.name, text)
+                    },
+                    onCopy = {
+                        val text = ChordSheetFormatter.formatProgression(progression, selectedRoot)
+                        ShareUtils.copyToClipboard(context, progression.name, text)
+                        Toast.makeText(context, R.string.share_copied, Toast.LENGTH_SHORT).show()
                     },
                     onPlay = { playbackProgression = progression },
                     onPractice = {
@@ -460,6 +471,7 @@ private fun ProgressionCard(
     onVoiceLeading: () -> Unit,
     onCapo: () -> Unit,
     onShare: () -> Unit,
+    onCopy: () -> Unit,
     onPlay: () -> Unit,
     onPractice: () -> Unit = {},
     onDelete: (() -> Unit)? = null,
@@ -609,6 +621,13 @@ private fun ProgressionCard(
                         Icon(
                             imageVector = Icons.Filled.Share,
                             contentDescription = stringResource(R.string.action_share),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                    IconButton(onClick = onCopy) {
+                        Icon(
+                            imageVector = Icons.Filled.ContentCopy,
+                            contentDescription = stringResource(R.string.share_copy_clipboard),
                             tint = MaterialTheme.colorScheme.primary,
                         )
                     }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/SongbookTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/SongbookTab.kt
@@ -35,6 +35,9 @@ import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Stop
@@ -47,6 +50,11 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -54,6 +62,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SmallFloatingActionButton
@@ -75,6 +84,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -127,7 +137,13 @@ fun SongbookTab(
                 sheet = currentSheet,
                 allLabels = allLabels,
                 onSave = { title, artist, content, strumPatternName, labels ->
-                    viewModel.saveSheet(title, artist, content, strumPatternName, labels)
+                    viewModel.saveSheet(
+                        title = title,
+                        artist = artist,
+                        content = content,
+                        strumPatternName = strumPatternName,
+                        labels = labels,
+                    )
                 },
                 onCancel = { viewModel.closeSheet() },
             )
@@ -145,6 +161,7 @@ fun SongbookTab(
                 onChordTapped = onChordTapped,
                 onStrumPatternChange = { viewModel.updateStrumPattern(it) },
                 onLabelsChange = { viewModel.updateLabels(it) },
+                onApplyTranspose = { viewModel.applyTranspose(it) },
             )
         }
         else -> {
@@ -462,6 +479,7 @@ private fun SheetCard(
 /**
  * Viewer for a chord sheet with tappable chord names.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SheetViewer(
     sheet: ChordSheet,
@@ -472,11 +490,13 @@ private fun SheetViewer(
     onChordTapped: (String) -> Unit,
     onStrumPatternChange: (String) -> Unit,
     onLabelsChange: (List<String>) -> Unit,
+    onApplyTranspose: (Int) -> Unit,
 ) {
     val context = LocalContext.current
     val chordSheetLabel = stringResource(R.string.songbook_chord_sheet)
     val exportChooserLabel = stringResource(R.string.songbook_export_chooser)
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showShareSheet by remember { mutableStateOf(false) }
 
     // Transpose controls
     var transposeSemitones by rememberSaveable { mutableStateOf(0) }
@@ -508,83 +528,8 @@ private fun SheetViewer(
                 modifier = Modifier.weight(1f).semantics { heading() },
                 textAlign = TextAlign.Center,
             )
-            // Share / Export menu
-            Box {
-                var showShareMenu by remember { mutableStateOf(false) }
-                IconButton(onClick = { showShareMenu = true }) {
-                    Icon(Icons.Filled.Share, contentDescription = stringResource(R.string.action_share))
-                }
-                DropdownMenu(
-                    expanded = showShareMenu,
-                    onDismissRequest = { showShareMenu = false },
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.songbook_share_as_text)) },
-                        onClick = {
-                            showShareMenu = false
-                            val formatted = ChordSheetFormatter.formatChordsAboveLyrics(sheet)
-                            ShareUtils.shareText(
-                                context = context,
-                                title = sheet.title.ifEmpty { chordSheetLabel },
-                                text = formatted,
-                            )
-                        },
-                    )
-                    if (transposeSemitones != 0) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.songbook_share_transposed)) },
-                            onClick = {
-                                showShareMenu = false
-                                val transposedSheet = sheet.copy(content = displayContent)
-                                val formatted = ChordSheetFormatter.formatChordsAboveLyrics(transposedSheet)
-                                ShareUtils.shareText(
-                                    context = context,
-                                    title = sheet.title.ifEmpty { chordSheetLabel },
-                                    text = formatted,
-                                )
-                            },
-                        )
-                    }
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.songbook_export_chordpro)) },
-                        onClick = {
-                            showShareMenu = false
-                            val chordProText = ChordProExporter.export(sheet)
-                            val intent = Intent(Intent.ACTION_SEND).apply {
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, chordProText)
-                                putExtra(
-                                    Intent.EXTRA_SUBJECT,
-                                    ChordProExporter.suggestedFilename(sheet),
-                                )
-                            }
-                            context.startActivity(
-                                Intent.createChooser(intent, exportChooserLabel),
-                            )
-                        },
-                    )
-                    if (transposeSemitones != 0) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.songbook_export_transposed)) },
-                            onClick = {
-                                showShareMenu = false
-                                val transposedSheet = sheet.copy(content = displayContent)
-                                val chordProText = ChordProExporter.export(transposedSheet)
-                                val intent = Intent(Intent.ACTION_SEND).apply {
-                                    type = "text/plain"
-                                    putExtra(Intent.EXTRA_TEXT, chordProText)
-                                    putExtra(
-                                        Intent.EXTRA_SUBJECT,
-                                        ChordProExporter.suggestedFilename(sheet),
-                                    )
-                                }
-                                context.startActivity(
-                                    Intent.createChooser(intent, exportChooserLabel),
-                                )
-                            },
-                        )
-                    }
-                }
+            IconButton(onClick = { showShareSheet = true }) {
+                Icon(Icons.Filled.Share, contentDescription = stringResource(R.string.action_share))
             }
             IconButton(onClick = onEdit) {
                 Icon(Icons.Filled.Edit, contentDescription = stringResource(R.string.action_edit))
@@ -684,7 +629,7 @@ private fun SheetViewer(
             }
         }
 
-        // Capo equivalent (shown when transposed)
+        // Capo equivalent and "Save in this key" (shown when transposed)
         if (transposeSemitones != 0) {
             val capoFret = ((transposeSemitones % 12) + 12) % 12
             if (capoFret > 0) {
@@ -698,6 +643,22 @@ private fun SheetViewer(
                         .fillMaxWidth()
                         .padding(bottom = 4.dp),
                 )
+            }
+
+            val savedMsg = stringResource(R.string.songbook_saved_in_key)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                FilledTonalButton(
+                    onClick = {
+                        onApplyTranspose(transposeSemitones)
+                        transposeSemitones = 0
+                        Toast.makeText(context, savedMsg, Toast.LENGTH_SHORT).show()
+                    },
+                ) {
+                    Text(stringResource(R.string.songbook_save_in_key))
+                }
             }
         }
 
@@ -863,6 +824,86 @@ private fun SheetViewer(
                             contentDescription = if (autoScrolling) stringResource(R.string.cd_pause_scroll) else stringResource(R.string.cd_auto_scroll),
                         )
                     }
+                }
+            }
+        }
+
+        val copiedMsg = stringResource(R.string.share_copied)
+        if (showShareSheet) {
+            val shareSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val effectiveSheet = if (transposeSemitones != 0) {
+                sheet.copy(content = displayContent)
+            } else {
+                sheet
+            }
+            ModalBottomSheet(
+                onDismissRequest = { showShareSheet = false },
+                sheetState = shareSheetState,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(bottom = 32.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.share_sheet_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .padding(bottom = 16.dp, start = 8.dp)
+                            .semantics { heading() },
+                    )
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.share_as_chordpro)) },
+                        leadingContent = {
+                            Icon(Icons.Filled.MusicNote, contentDescription = null)
+                        },
+                        modifier = Modifier.clickable(role = Role.Button) {
+                            showShareSheet = false
+                            val chordProText = ChordProExporter.export(effectiveSheet)
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, chordProText)
+                                putExtra(
+                                    Intent.EXTRA_SUBJECT,
+                                    ChordProExporter.suggestedFilename(sheet),
+                                )
+                            }
+                            context.startActivity(
+                                Intent.createChooser(intent, exportChooserLabel),
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.share_as_text)) },
+                        leadingContent = {
+                            Icon(Icons.Filled.Description, contentDescription = null)
+                        },
+                        modifier = Modifier.clickable(role = Role.Button) {
+                            showShareSheet = false
+                            val formatted = ChordSheetFormatter.formatChordsAboveLyrics(effectiveSheet)
+                            ShareUtils.shareText(
+                                context = context,
+                                title = sheet.title.ifEmpty { chordSheetLabel },
+                                text = formatted,
+                            )
+                        },
+                    )
+                    HorizontalDivider()
+                    ListItem(
+                        headlineContent = { Text(stringResource(R.string.share_copy_clipboard)) },
+                        leadingContent = {
+                            Icon(Icons.Filled.ContentCopy, contentDescription = null)
+                        },
+                        modifier = Modifier.clickable(role = Role.Button) {
+                            showShareSheet = false
+                            val formatted = ChordSheetFormatter.formatChordsAboveLyrics(effectiveSheet)
+                            ShareUtils.copyToClipboard(context, chordSheetLabel, formatted)
+                            Toast.makeText(context, copiedMsg, Toast.LENGTH_SHORT).show()
+                        },
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/SongwriterModeFlow.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/SongwriterModeFlow.kt
@@ -1,0 +1,576 @@
+package com.baijum.ukufretboard.ui
+
+import android.widget.Toast
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.LiveRegionMode
+import com.baijum.ukufretboard.R
+import com.baijum.ukufretboard.data.ChordDegree
+import com.baijum.ukufretboard.data.Notes
+import com.baijum.ukufretboard.data.Progressions
+import com.baijum.ukufretboard.data.ScaleType
+import com.baijum.ukufretboard.domain.ChordSheetFormatter
+import com.baijum.ukufretboard.domain.ChordSheetTranspose
+import com.baijum.ukufretboard.viewmodel.SongbookViewModel
+
+private const val TOTAL_STEPS = 5
+
+/**
+ * Guided songwriting flow that walks the user through picking a key/scale,
+ * building a progression, writing lyrics, transposing, and sharing.
+ */
+@Composable
+fun SongwriterModeFlow(
+    songbookViewModel: SongbookViewModel,
+    onSaveProgression: (String, String, List<ChordDegree>, ScaleType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var currentStep by rememberSaveable { mutableIntStateOf(0) }
+
+    var selectedRoot by rememberSaveable { mutableIntStateOf(0) }
+    var selectedScale by rememberSaveable { mutableStateOf(ScaleType.MAJOR) }
+    var chosenDegrees by rememberSaveable { mutableStateOf(listOf<ChordDegree>()) }
+    var songTitle by rememberSaveable { mutableStateOf("") }
+    var songContent by rememberSaveable { mutableStateOf("") }
+    var transposeSemitones by rememberSaveable { mutableIntStateOf(0) }
+
+    val context = LocalContext.current
+    val songSavedMessage = stringResource(R.string.songwriter_song_saved)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.nav_songwriter_mode),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.semantics { heading() },
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LinearProgressIndicator(
+            progress = { (currentStep + 1).toFloat() / TOTAL_STEPS },
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        val stepLabel = "Step ${currentStep + 1} of $TOTAL_STEPS"
+        Text(
+            text = stepLabel,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .padding(top = 4.dp, bottom = 12.dp)
+                .semantics { liveRegion = LiveRegionMode.Polite },
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            when (currentStep) {
+                0 -> StepChooseKeyScale(
+                    selectedRoot = selectedRoot,
+                    onRootChange = {
+                        selectedRoot = it
+                        chosenDegrees = emptyList()
+                        transposeSemitones = 0
+                    },
+                    selectedScale = selectedScale,
+                    onScaleChange = {
+                        selectedScale = it
+                        chosenDegrees = emptyList()
+                        transposeSemitones = 0
+                    },
+                )
+                1 -> StepBuildProgression(
+                    selectedRoot = selectedRoot,
+                    selectedScale = selectedScale,
+                    chosenDegrees = chosenDegrees,
+                    onDegreesChange = { chosenDegrees = it },
+                )
+                2 -> StepAddLyrics(
+                    songTitle = songTitle,
+                    onTitleChange = { songTitle = it },
+                    songContent = songContent,
+                    onContentChange = { songContent = it },
+                    selectedRoot = selectedRoot,
+                    chosenDegrees = chosenDegrees,
+                )
+                3 -> StepTranspose(
+                    content = songContent,
+                    transposeSemitones = transposeSemitones,
+                    onTransposeChange = { transposeSemitones = it },
+                )
+                4 -> StepReviewAndSave(
+                    songTitle = songTitle,
+                    songContent = songContent,
+                    transposeSemitones = transposeSemitones,
+                    selectedRoot = selectedRoot,
+                    chosenDegrees = chosenDegrees,
+                    selectedScale = selectedScale,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            if (currentStep > 0) {
+                OutlinedButton(onClick = { currentStep-- }) {
+                    Text(stringResource(R.string.onboarding_back))
+                }
+            } else {
+                Spacer(modifier = Modifier.width(1.dp))
+            }
+
+            if (currentStep < TOTAL_STEPS - 1) {
+                Button(
+                    onClick = { currentStep++ },
+                    enabled = when (currentStep) {
+                        1 -> chosenDegrees.size >= 2
+                        else -> true
+                    },
+                ) {
+                    Text(stringResource(R.string.onboarding_next))
+                }
+            } else {
+                Button(
+                    onClick = {
+                        val finalContent = if (transposeSemitones != 0) {
+                            ChordSheetTranspose.transpose(songContent, transposeSemitones)
+                        } else {
+                            songContent
+                        }
+                        val finalRoot = ((selectedRoot + transposeSemitones) % 12 + 12) % 12
+                        val finalKey = "${Notes.pitchClassToName(finalRoot)} ${selectedScale.label}"
+                        songbookViewModel.saveSheet(
+                            title = songTitle.ifBlank { "My Song" },
+                            artist = "",
+                            content = finalContent,
+                            key = finalKey,
+                        )
+                        if (chosenDegrees.size >= 2) {
+                            val keyName = Notes.pitchClassToName(selectedRoot)
+                            onSaveProgression(
+                                "$keyName ${selectedScale.name} song progression",
+                                "Created in Songwriter Mode",
+                                chosenDegrees,
+                                selectedScale,
+                            )
+                        }
+                        Toast.makeText(context, songSavedMessage, Toast.LENGTH_SHORT).show()
+                        currentStep = 0
+                        songTitle = ""
+                        songContent = ""
+                        chosenDegrees = emptyList()
+                        transposeSemitones = 0
+                    },
+                    enabled = songTitle.isNotBlank() || songContent.isNotBlank(),
+                ) {
+                    Text(stringResource(R.string.dialog_save))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StepChooseKeyScale(
+    selectedRoot: Int,
+    onRootChange: (Int) -> Unit,
+    selectedScale: ScaleType,
+    onScaleChange: (ScaleType) -> Unit,
+) {
+    Text(
+        text = "Choose a key and scale",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "Pick the musical key and scale for your song. This determines which chords will be suggested.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+        text = stringResource(R.string.label_root),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        for (pc in 0 until Notes.PITCH_CLASS_COUNT) {
+            val name = Notes.pitchClassToName(pc)
+            FilterChip(
+                selected = pc == selectedRoot,
+                onClick = { onRootChange(pc) },
+                label = { Text(name) },
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Text(
+        text = stringResource(R.string.label_scale),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        ScaleType.entries.forEach { scale ->
+            FilterChip(
+                selected = scale == selectedScale,
+                onClick = { onScaleChange(scale) },
+                label = { Text(scale.label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepBuildProgression(
+    selectedRoot: Int,
+    selectedScale: ScaleType,
+    chosenDegrees: List<ChordDegree>,
+    onDegreesChange: (List<ChordDegree>) -> Unit,
+) {
+    Text(
+        text = "Build a chord progression",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "Tap the diatonic chords below to build your progression. These are the chords that naturally fit your chosen key.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    val availableDegrees = Progressions.diatonicDegrees(selectedScale)
+
+    Text(
+        text = stringResource(R.string.progression_tap_chords),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        availableDegrees.forEach { degree ->
+            val chordRoot = (selectedRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
+            val chordName = Notes.enharmonicForKey(chordRoot, selectedRoot) + degree.quality
+            FilterChip(
+                selected = false,
+                onClick = { onDegreesChange(chosenDegrees + degree) },
+                label = { Text(chordName) },
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    if (chosenDegrees.isNotEmpty()) {
+        Text(
+            text = stringResource(R.string.progression_your_chords, chosenDegrees.size),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            chosenDegrees.forEachIndexed { index, degree ->
+                val chordRoot = (selectedRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
+                val chordName = Notes.enharmonicForKey(chordRoot, selectedRoot) + degree.quality
+                FilterChip(
+                    selected = true,
+                    onClick = {
+                        onDegreesChange(chosenDegrees.toMutableList().apply { removeAt(index) })
+                    },
+                    label = { Text(chordName) },
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        TextButton(onClick = { onDegreesChange(emptyList()) }) {
+            Text(stringResource(R.string.dialog_reset))
+        }
+    } else {
+        Text(
+            text = stringResource(R.string.progression_placeholder),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    if (chosenDegrees.size == 1) {
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.progression_error_min),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun StepAddLyrics(
+    songTitle: String,
+    onTitleChange: (String) -> Unit,
+    songContent: String,
+    onContentChange: (String) -> Unit,
+    selectedRoot: Int,
+    chosenDegrees: List<ChordDegree>,
+) {
+    Text(
+        text = "Add lyrics and chords",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "Write your lyrics below. Tap the chord chips to insert [Chord] markers.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(12.dp))
+
+    OutlinedTextField(
+        value = songTitle,
+        onValueChange = onTitleChange,
+        label = { Text(stringResource(R.string.songbook_field_title)) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (chosenDegrees.isNotEmpty()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            chosenDegrees.forEach { degree ->
+                val chordRoot = (selectedRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
+                val chordName = Notes.enharmonicForKey(chordRoot, selectedRoot) + degree.quality
+                FilterChip(
+                    selected = false,
+                    onClick = { onContentChange(songContent + "[$chordName]") },
+                    label = { Text(chordName) },
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    OutlinedTextField(
+        value = songContent,
+        onValueChange = onContentChange,
+        label = { Text(stringResource(R.string.songbook_field_lyrics)) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp),
+    )
+}
+
+@Composable
+private fun StepTranspose(
+    content: String,
+    transposeSemitones: Int,
+    onTransposeChange: (Int) -> Unit,
+) {
+    Text(
+        text = "Transpose (optional)",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "Shift the key up or down if needed. The transposition will be applied when you save.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        OutlinedButton(onClick = { onTransposeChange(transposeSemitones - 1) }) {
+            Text("\u2212")
+        }
+        Text(
+            text = ChordSheetTranspose.semitoneLabel(transposeSemitones),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        OutlinedButton(onClick = { onTransposeChange(transposeSemitones + 1) }) {
+            Text("+")
+        }
+        if (transposeSemitones != 0) {
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = { onTransposeChange(0) }) {
+                Text(stringResource(R.string.dialog_reset))
+            }
+        }
+    }
+
+    if (content.isNotEmpty() && transposeSemitones != 0) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "Preview:",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        val transposed = ChordSheetTranspose.transpose(content, transposeSemitones)
+        Text(
+            text = transposed,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun StepReviewAndSave(
+    songTitle: String,
+    songContent: String,
+    transposeSemitones: Int,
+    selectedRoot: Int,
+    chosenDegrees: List<ChordDegree>,
+    selectedScale: ScaleType,
+) {
+    Text(
+        text = "Review and save",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.semantics { heading() },
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    Text(
+        text = "Check your song below, then tap Save to add it to your songbook.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    val keyName = Notes.pitchClassToName(selectedRoot)
+    Text(
+        text = "Key: $keyName ${selectedScale.label}",
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+    )
+
+    if (chosenDegrees.isNotEmpty()) {
+        val chordNames = chosenDegrees.map { degree ->
+            val chordRoot = (selectedRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
+            Notes.enharmonicForKey(chordRoot, selectedRoot) + degree.quality
+        }
+        Text(
+            text = "Progression: ${chordNames.joinToString(" – ")}",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (transposeSemitones != 0) {
+        Text(
+            text = "Transpose: ${ChordSheetTranspose.semitoneLabel(transposeSemitones)} semitones",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+    }
+
+    Text(
+        text = songTitle.ifBlank { "Untitled" },
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+
+    val finalContent = if (transposeSemitones != 0) {
+        ChordSheetTranspose.transpose(songContent, transposeSemitones)
+    } else {
+        songContent
+    }
+    Text(
+        text = finalContent.ifEmpty { "(no lyrics yet)" },
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -57,7 +57,18 @@ data class MelodyUiState(
     val stabilizationProgress: Float = 0f,
     /** Last note that was auto-added via recording (for feedback). */
     val lastAddedFeedback: String? = null,
-)
+    /** Whether the step sequencer mode is active. */
+    val isStepSequencerMode: Boolean = false,
+    /** Fixed-length step grid (null = empty step). */
+    val steps: List<MelodyNote?> = List(STEP_COUNT_8) { null },
+    /** Whether step sequencer playback loops. */
+    val stepLooping: Boolean = true,
+) {
+    companion object {
+        const val STEP_COUNT_8 = 8
+        const val STEP_COUNT_16 = 16
+    }
+}
 
 /**
  * ViewModel for the Melody Notepad feature.
@@ -208,6 +219,82 @@ class MelodyViewModel : ViewModel() {
     fun setInputMode(mode: MelodyInputMode) {
         if (_uiState.value.isRecording) stopRecording()
         _uiState.update { it.copy(inputMode = mode) }
+    }
+
+    // --- Step sequencer ---
+
+    fun toggleStepSequencerMode() {
+        _uiState.update { it.copy(isStepSequencerMode = !it.isStepSequencerMode) }
+    }
+
+    fun setStep(index: Int, pitchClass: Int) {
+        val state = _uiState.value
+        if (index !in state.steps.indices) return
+        val note = MelodyNote(
+            pitchClass = pitchClass,
+            octave = state.currentOctave,
+            duration = state.selectedDuration,
+        )
+        _uiState.update {
+            it.copy(
+                steps = it.steps.toMutableList().apply { set(index, note) },
+                hasUnsavedChanges = true,
+            )
+        }
+        playNote(pitchClass, state.currentOctave)
+    }
+
+    fun clearStep(index: Int) {
+        val state = _uiState.value
+        if (index !in state.steps.indices) return
+        _uiState.update {
+            it.copy(
+                steps = it.steps.toMutableList().apply { set(index, null) },
+                hasUnsavedChanges = true,
+            )
+        }
+    }
+
+    fun expandSteps() {
+        _uiState.update { state ->
+            val currentSize = state.steps.size
+            val newSize = if (currentSize >= MelodyUiState.STEP_COUNT_16) {
+                MelodyUiState.STEP_COUNT_8
+            } else {
+                MelodyUiState.STEP_COUNT_16
+            }
+            if (newSize > currentSize) {
+                state.copy(steps = state.steps + List(newSize - currentSize) { null })
+            } else {
+                state.copy(steps = state.steps.take(newSize))
+            }
+        }
+    }
+
+    fun playSteps() {
+        val state = _uiState.value
+        if (state.isPlaying) return
+        val filledSteps = state.steps.any { it != null }
+        if (!filledSteps) return
+
+        _uiState.update { it.copy(isPlaying = true) }
+        viewModelScope.launch {
+            do {
+                val steps = _uiState.value.steps
+                steps.forEachIndexed { index, note ->
+                    if (!_uiState.value.isPlaying) return@launch
+                    _uiState.update { it.copy(playingIndex = index) }
+                    val pc = note?.pitchClass
+                    if (pc != null) {
+                        playNote(pc, note.octave)
+                    }
+                    val beatDuration = (note?.duration ?: _uiState.value.selectedDuration)
+                    val durationMs = (beatDuration.beats * 60_000f / _uiState.value.bpm).toLong()
+                    delay(durationMs)
+                }
+            } while (_uiState.value.isPlaying && _uiState.value.stepLooping)
+            _uiState.update { it.copy(playingIndex = -1, isPlaying = false) }
+        }
     }
 
     // --- Playback ---

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/SongbookViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/SongbookViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import com.baijum.ukufretboard.data.ChordProParser
 import com.baijum.ukufretboard.data.ChordSheet
 import com.baijum.ukufretboard.data.ChordSheetRepository
+import com.baijum.ukufretboard.domain.ChordSheetTranspose
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -129,6 +130,7 @@ class SongbookViewModel(application: Application) : AndroidViewModel(application
         title: String,
         artist: String,
         content: String,
+        key: String = "",
         strumPatternName: String = "",
         labels: List<String> = emptyList(),
     ) {
@@ -138,6 +140,7 @@ class SongbookViewModel(application: Application) : AndroidViewModel(application
                 title = title,
                 artist = artist,
                 content = content,
+                key = key,
                 strumPatternName = strumPatternName,
                 labels = labels,
                 updatedAt = System.currentTimeMillis(),
@@ -147,6 +150,7 @@ class SongbookViewModel(application: Application) : AndroidViewModel(application
                 title = title,
                 artist = artist,
                 content = content,
+                key = key,
                 strumPatternName = strumPatternName,
                 labels = labels,
             )
@@ -161,6 +165,19 @@ class SongbookViewModel(application: Application) : AndroidViewModel(application
         val sheet = _currentSheet.value ?: return
         val updated = sheet.copy(
             labels = labels,
+            updatedAt = System.currentTimeMillis(),
+        )
+        repository.save(updated)
+        _currentSheet.value = updated
+        refresh()
+    }
+
+    fun applyTranspose(semitones: Int) {
+        if (semitones == 0) return
+        val sheet = _currentSheet.value ?: return
+        val transposedContent = ChordSheetTranspose.transpose(sheet.content, semitones)
+        val updated = sheet.copy(
+            content = transposedContent,
             updatedAt = System.currentTimeMillis(),
         )
         repository.save(updated)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">إضافة تسمية</string>
     <string name="songbook_label_hint">اكتب تسمية…</string>
     <string name="songbook_filter_clear">مسح التصفية</string>
+    <string name="songbook_save_in_key">حفظ في هذا المقام</string>
+    <string name="songbook_saved_in_key">تم حفظ الأغنية في المقام المنقول</string>
     <string name="cd_label">تسمية: %s</string>
     <string name="cd_remove_label">إزالة تسمية %s</string>
     <string name="cd_filter_label">تصفية حسب تسمية %s</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">اعزف سلم كروماتي على كل وتر من الحنق 1 إلى 5 والعودة.</string>
     <string name="routine_warmup_intermediate_2">دور عبر C-Am-F-G عند 80 BPM، 4 نبضات لكل وتر.</string>
     <string name="routine_warmup_intermediate_3">تدرب على أشكال أوتار البار ببطء صعوداً على الرقبة.</string>
+    <string name="share_sheet_title">مشاركة ورقة الأكورد كـ</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">نص عادي</string>
+    <string name="share_copy_clipboard">نسخ إلى الحافظة</string>
+    <string name="share_copied">تم النسخ إلى الحافظة</string>
+    <string name="nav_songwriter_mode">ابدأ أغنية</string>
+    <string name="songwriter_song_saved">تم حفظ الأغنية!</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">添加标签</string>
     <string name="songbook_label_hint">输入标签…</string>
     <string name="songbook_filter_clear">清除筛选</string>
+    <string name="songbook_save_in_key">以此调保存</string>
+    <string name="songbook_saved_in_key">歌曲已以转调保存</string>
     <string name="cd_label">标签：%s</string>
     <string name="cd_remove_label">移除标签 %s</string>
     <string name="cd_filter_label">按标签 %s 筛选</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">在每根弦上从 1 品到 5 品来回弹半音阶。</string>
     <string name="routine_warmup_intermediate_2">以 80 BPM 循环 C-Am-F-G，每和弦 4 拍。</string>
     <string name="routine_warmup_intermediate_3">慢慢在指板上练习横按和弦指型。</string>
+    <string name="share_sheet_title">分享和弦谱为</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">纯文本</string>
+    <string name="share_copy_clipboard">复制到剪贴板</string>
+    <string name="share_copied">已复制到剪贴板</string>
+    <string name="nav_songwriter_mode">开始创作</string>
+    <string name="songwriter_song_saved">歌曲已保存！</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Label hinzufügen</string>
     <string name="songbook_label_hint">Label eingeben…</string>
     <string name="songbook_filter_clear">Filter löschen</string>
+    <string name="songbook_save_in_key">In dieser Tonart speichern</string>
+    <string name="songbook_saved_in_key">Song in transponierter Tonart gespeichert</string>
     <string name="cd_label">Label: %s</string>
     <string name="cd_remove_label">Label %s entfernen</string>
     <string name="cd_filter_label">Nach Label %s filtern</string>
@@ -1117,4 +1119,11 @@
     <string name="theory_title_rhythm_straight_swing">Gerader vs. Swing-Rhythmus</string>
     <string name="theory_title_rhythm_percussive">Perkussive Techniken</string>
     <string name="theory_title_rhythm_world">Weltrhythmen</string>
+    <string name="share_sheet_title">Akkordblatt teilen als</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Klartext</string>
+    <string name="share_copy_clipboard">In die Zwischenablage kopieren</string>
+    <string name="share_copied">In die Zwischenablage kopiert</string>
+    <string name="nav_songwriter_mode">Song starten</string>
+    <string name="songwriter_song_saved">Song gespeichert!</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Añadir etiqueta</string>
     <string name="songbook_label_hint">Escribir etiqueta…</string>
     <string name="songbook_filter_clear">Borrar filtros</string>
+    <string name="songbook_save_in_key">Guardar en esta tonalidad</string>
+    <string name="songbook_saved_in_key">Canción guardada en tonalidad transpuesta</string>
     <string name="cd_label">Etiqueta: %s</string>
     <string name="cd_remove_label">Eliminar etiqueta %s</string>
     <string name="cd_filter_label">Filtrar por etiqueta %s</string>
@@ -1129,4 +1131,11 @@
     <string name="theory_title_rhythm_straight_swing">Ritmo recto vs. swing</string>
     <string name="theory_title_rhythm_percussive">Técnicas percusivas</string>
     <string name="theory_title_rhythm_world">Ritmos del mundo</string>
+    <string name="share_sheet_title">Compartir hoja de acordes como</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Texto sin formato</string>
+    <string name="share_copy_clipboard">Copiar al portapapeles</string>
+    <string name="share_copied">Copiado al portapapeles</string>
+    <string name="nav_songwriter_mode">Comenzar una canción</string>
+    <string name="songwriter_song_saved">¡Canción guardada!</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Ajouter une étiquette</string>
     <string name="songbook_label_hint">Saisir une étiquette…</string>
     <string name="songbook_filter_clear">Effacer les filtres</string>
+    <string name="songbook_save_in_key">Enregistrer dans cette tonalité</string>
+    <string name="songbook_saved_in_key">Chanson enregistrée dans la tonalité transposée</string>
     <string name="cd_label">Étiquette : %s</string>
     <string name="cd_remove_label">Supprimer l\'étiquette %s</string>
     <string name="cd_filter_label">Filtrer par étiquette %s</string>
@@ -1113,4 +1115,11 @@
     <string name="theory_title_rhythm_straight_swing">Rythme binaire vs. swing</string>
     <string name="theory_title_rhythm_percussive">Techniques percussives</string>
     <string name="theory_title_rhythm_world">Rythmes du monde</string>
+    <string name="share_sheet_title">Partager la feuille d\'accords en tant que</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Texte brut</string>
+    <string name="share_copy_clipboard">Copier dans le presse-papiers</string>
+    <string name="share_copied">Copié dans le presse-papiers</string>
+    <string name="nav_songwriter_mode">Commencer une chanson</string>
+    <string name="songwriter_song_saved">Chanson enregistrée !</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">लेबल जोड़ें</string>
     <string name="songbook_label_hint">लेबल टाइप करें…</string>
     <string name="songbook_filter_clear">फ़िल्टर साफ़ करें</string>
+    <string name="songbook_save_in_key">इस स्वर में सहेजें</string>
+    <string name="songbook_saved_in_key">गीत स्थानांतरित स्वर में सहेजा गया</string>
     <string name="cd_label">लेबल: %s</string>
     <string name="cd_remove_label">लेबल %s हटाएं</string>
     <string name="cd_filter_label">लेबल %s से फ़िल्टर करें</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">फ्रेट 1 से 5 तक और वापस हर स्ट्रिंग पर क्रोमैटिक स्केल बजाएँ।</string>
     <string name="routine_warmup_intermediate_2">80 BPM पर C-Am-F-G चक्र करें, प्रति कॉर्ड 4 बीट।</string>
     <string name="routine_warmup_intermediate_3">गर्दन पर धीरे बार कॉर्ड शेप का अभ्यास करें।</string>
+    <string name="share_sheet_title">कॉर्ड शीट इस रूप में साझा करें</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">सादा पाठ</string>
+    <string name="share_copy_clipboard">क्लिपबोर्ड पर कॉपी करें</string>
+    <string name="share_copied">क्लिपबोर्ड पर कॉपी किया गया</string>
+    <string name="nav_songwriter_mode">गीत शुरू करें</string>
+    <string name="songwriter_song_saved">गीत सहेजा गया!</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Tambah label</string>
     <string name="songbook_label_hint">Ketik label…</string>
     <string name="songbook_filter_clear">Hapus filter</string>
+    <string name="songbook_save_in_key">Simpan dalam kunci ini</string>
+    <string name="songbook_saved_in_key">Lagu disimpan dalam kunci yang ditransposisi</string>
     <string name="cd_label">Label: %s</string>
     <string name="cd_remove_label">Hapus label %s</string>
     <string name="cd_filter_label">Filter berdasarkan label %s</string>
@@ -1117,4 +1119,11 @@
     <string name="routine_warmup_intermediate_1">Mainkan tangga nada kromatik pada setiap senar dari fret 1 ke 5 dan kembali.</string>
     <string name="routine_warmup_intermediate_2">Siklus C-Am-F-G pada 80 BPM, 4 ketukan per akor.</string>
     <string name="routine_warmup_intermediate_3">Latih bentuk akor barre perlahan ke atas leher.</string>
+    <string name="share_sheet_title">Bagikan lembar akor sebagai</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Teks biasa</string>
+    <string name="share_copy_clipboard">Salin ke papan klip</string>
+    <string name="share_copied">Disalin ke papan klip</string>
+    <string name="nav_songwriter_mode">Mulai Lagu</string>
+    <string name="songwriter_song_saved">Lagu disimpan!</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Aggiungi etichetta</string>
     <string name="songbook_label_hint">Digita etichetta…</string>
     <string name="songbook_filter_clear">Cancella filtri</string>
+    <string name="songbook_save_in_key">Salva in questa tonalità</string>
+    <string name="songbook_saved_in_key">Brano salvato nella tonalità trasposta</string>
     <string name="cd_label">Etichetta: %s</string>
     <string name="cd_remove_label">Rimuovi etichetta %s</string>
     <string name="cd_filter_label">Filtra per etichetta %s</string>
@@ -1117,4 +1119,11 @@
     <string name="routine_warmup_intermediate_1">Suona una scala cromatica su ogni corda dal tasto 1 al 5 e ritorno.</string>
     <string name="routine_warmup_intermediate_2">Ciclo C-Am-F-G a 80 BPM, 4 battiti per accordo.</string>
     <string name="routine_warmup_intermediate_3">Esercitati con le forme di accordi barré lentamente lungo la tastiera.</string>
+    <string name="share_sheet_title">Condividi foglio accordi come</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Testo semplice</string>
+    <string name="share_copy_clipboard">Copia negli appunti</string>
+    <string name="share_copied">Copiato negli appunti</string>
+    <string name="nav_songwriter_mode">Inizia un brano</string>
+    <string name="songwriter_song_saved">Brano salvato!</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">ラベルを追加</string>
     <string name="songbook_label_hint">ラベルを入力…</string>
     <string name="songbook_filter_clear">フィルターをクリア</string>
+    <string name="songbook_save_in_key">このキーで保存</string>
+    <string name="songbook_saved_in_key">移調したキーで保存しました</string>
     <string name="cd_label">ラベル: %s</string>
     <string name="cd_remove_label">ラベル %s を削除</string>
     <string name="cd_filter_label">ラベル %s でフィルター</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">各弦でフレット1から5まで半音階スケールを往復で弾く。</string>
     <string name="routine_warmup_intermediate_2">80 BPMでC-Am-F-Gを循環、各コード4拍。</string>
     <string name="routine_warmup_intermediate_3">バレーコードのフォームをネック上でゆっくり練習。</string>
+    <string name="share_sheet_title">コードシートを共有</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">プレーンテキスト</string>
+    <string name="share_copy_clipboard">クリップボードにコピー</string>
+    <string name="share_copied">クリップボードにコピーしました</string>
+    <string name="nav_songwriter_mode">曲を作る</string>
+    <string name="songwriter_song_saved">曲を保存しました！</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">라벨 추가</string>
     <string name="songbook_label_hint">라벨 입력…</string>
     <string name="songbook_filter_clear">필터 지우기</string>
+    <string name="songbook_save_in_key">이 키로 저장</string>
+    <string name="songbook_saved_in_key">조옮김한 키로 저장됨</string>
     <string name="cd_label">라벨: %s</string>
     <string name="cd_remove_label">라벨 %s 제거</string>
     <string name="cd_filter_label">라벨 %s 로 필터</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">각 현에서 프렛 1부터 5까지 반음계를 오가며 연주하세요.</string>
     <string name="routine_warmup_intermediate_2">80 BPM으로 C-Am-F-G를 순환, 각 코드 4박.</string>
     <string name="routine_warmup_intermediate_3">바레 코드 폼을 넥 위로 천천히 연습하세요.</string>
+    <string name="share_sheet_title">코드 시트 공유 형식</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">일반 텍스트</string>
+    <string name="share_copy_clipboard">클립보드에 복사</string>
+    <string name="share_copied">클립보드에 복사됨</string>
+    <string name="nav_songwriter_mode">노래 시작</string>
+    <string name="songwriter_song_saved">노래가 저장되었습니다!</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Label toevoegen</string>
     <string name="songbook_label_hint">Typ een label…</string>
     <string name="songbook_filter_clear">Filters wissen</string>
+    <string name="songbook_save_in_key">Opslaan in deze toonsoort</string>
+    <string name="songbook_saved_in_key">Nummer opgeslagen in getransponeerde toonsoort</string>
     <string name="cd_label">Label: %s</string>
     <string name="cd_remove_label">Label %s verwijderen</string>
     <string name="cd_filter_label">Filteren op label %s</string>
@@ -1117,4 +1119,11 @@
     <string name="routine_warmup_intermediate_1">Speel een chromatische toonladder op elke snaar van fret 1 tot 5 en terug.</string>
     <string name="routine_warmup_intermediate_2">Cyclus C-Am-F-G op 80 BPM, 4 tellen per akkoord.</string>
     <string name="routine_warmup_intermediate_3">Oefen barré-akkoordgrepen langzaam langs de hals.</string>
+    <string name="share_sheet_title">Akkoordblad delen als</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Platte tekst</string>
+    <string name="share_copy_clipboard">Kopiëren naar klembord</string>
+    <string name="share_copied">Gekopieerd naar klembord</string>
+    <string name="nav_songwriter_mode">Begin een nummer</string>
+    <string name="songwriter_song_saved">Nummer opgeslagen!</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Dodaj etykietę</string>
     <string name="songbook_label_hint">Wpisz etykietę…</string>
     <string name="songbook_filter_clear">Wyczyść filtry</string>
+    <string name="songbook_save_in_key">Zapisz w tej tonacji</string>
+    <string name="songbook_saved_in_key">Utwór zapisany w transponowanej tonacji</string>
     <string name="cd_label">Etykieta: %s</string>
     <string name="cd_remove_label">Usuń etykietę %s</string>
     <string name="cd_filter_label">Filtruj po etykiecie %s</string>
@@ -1117,4 +1119,11 @@
     <string name="routine_warmup_intermediate_1">Graj gamę chromatyczną na każdej strunie od progu 1 do 5 i z powrotem.</string>
     <string name="routine_warmup_intermediate_2">Przejdź przez C-Am-F-G przy 80 BPM, 4 uderzenia na akord.</string>
     <string name="routine_warmup_intermediate_3">Ćwicz powoli kształty akordów baryłkowych w górę gryfu.</string>
+    <string name="share_sheet_title">Udostępnij kartę akordów jako</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Zwykły tekst</string>
+    <string name="share_copy_clipboard">Kopiuj do schowka</string>
+    <string name="share_copied">Skopiowano do schowka</string>
+    <string name="nav_songwriter_mode">Zacznij utwór</string>
+    <string name="songwriter_song_saved">Utwór zapisany!</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Adicionar etiqueta</string>
     <string name="songbook_label_hint">Digitar etiqueta…</string>
     <string name="songbook_filter_clear">Limpar filtros</string>
+    <string name="songbook_save_in_key">Salvar nesta tonalidade</string>
+    <string name="songbook_saved_in_key">Música salva na tonalidade transposta</string>
     <string name="cd_label">Etiqueta: %s</string>
     <string name="cd_remove_label">Remover etiqueta %s</string>
     <string name="cd_filter_label">Filtrar por etiqueta %s</string>
@@ -1115,4 +1117,11 @@
     <string name="routine_warmup_intermediate_1">Toque uma escala cromática em cada corda do traste 1 ao 5 e volte.</string>
     <string name="routine_warmup_intermediate_2">Ciclo C-Am-F-G a 80 BPM, 4 batidas por acorde.</string>
     <string name="routine_warmup_intermediate_3">Pratique formas de acordes de barra lentamente ao longo do braço.</string>
+    <string name="share_sheet_title">Compartilhar folha de acordes como</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Texto simples</string>
+    <string name="share_copy_clipboard">Copiar para a área de transferência</string>
+    <string name="share_copied">Copiado para a área de transferência</string>
+    <string name="nav_songwriter_mode">Começar uma música</string>
+    <string name="songwriter_song_saved">Música salva!</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Добавить метку</string>
     <string name="songbook_label_hint">Введите метку…</string>
     <string name="songbook_filter_clear">Сбросить фильтры</string>
+    <string name="songbook_save_in_key">Сохранить в этой тональности</string>
+    <string name="songbook_saved_in_key">Песня сохранена в транспонированной тональности</string>
     <string name="cd_label">Метка: %s</string>
     <string name="cd_remove_label">Удалить метку %s</string>
     <string name="cd_filter_label">Фильтровать по метке %s</string>
@@ -1119,4 +1121,11 @@
     <string name="routine_warmup_intermediate_1">Сыграйте хроматическую гамму на каждой струне с 1-го по 5-й лад и обратно.</string>
     <string name="routine_warmup_intermediate_2">Цикл C-Am-F-G при 80 BPM, 4 доли на аккорд.</string>
     <string name="routine_warmup_intermediate_3">Отработайте формы баррэ медленно вверх по грифу.</string>
+    <string name="share_sheet_title">Поделиться аккордовым листом как</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Обычный текст</string>
+    <string name="share_copy_clipboard">Копировать в буфер обмена</string>
+    <string name="share_copied">Скопировано в буфер обмена</string>
+    <string name="nav_songwriter_mode">Начать песню</string>
+    <string name="songwriter_song_saved">Песня сохранена!</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -260,6 +260,8 @@
     <string name="songbook_add_label">Etiket ekle</string>
     <string name="songbook_label_hint">Etiket yazın…</string>
     <string name="songbook_filter_clear">Filtreleri temizle</string>
+    <string name="songbook_save_in_key">Bu tonda kaydet</string>
+    <string name="songbook_saved_in_key">Şarkı aktarılmış tonda kaydedildi</string>
     <string name="cd_label">Etiket: %s</string>
     <string name="cd_remove_label">%s etiketini kaldır</string>
     <string name="cd_filter_label">%s etiketine göre filtrele</string>
@@ -1117,4 +1119,11 @@
     <string name="routine_warmup_intermediate_1">Her telde 1. perdeden 5. perdeye ve geri kromatik dizi çalın.</string>
     <string name="routine_warmup_intermediate_2">80 BPM\'de C-Am-F-G döngüsü, akor başına 4 vuruş.</string>
     <string name="routine_warmup_intermediate_3">Bare akor şekillerini klavyede yukarı doğru yavaşça çalışın.</string>
+    <string name="share_sheet_title">Akor sayfasını şu şekilde paylaş</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Düz metin</string>
+    <string name="share_copy_clipboard">Panoya kopyala</string>
+    <string name="share_copied">Panoya kopyalandı</string>
+    <string name="nav_songwriter_mode">Şarkıya Başla</string>
+    <string name="songwriter_song_saved">Şarkı kaydedildi!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,15 @@
     <string name="cd_remove_label">Remove label %s</string>
     <string name="cd_filter_label">Filter by label %s</string>
     <string name="cd_add_label">Add label</string>
+    <string name="songbook_save_in_key">Save in this key</string>
+    <string name="songbook_saved_in_key">Song saved in transposed key</string>
+    <string name="share_sheet_title">Share chord sheet as</string>
+    <string name="share_as_chordpro">ChordPro (.cho)</string>
+    <string name="share_as_text">Plain text</string>
+    <string name="share_copy_clipboard">Copy to clipboard</string>
+    <string name="share_copied">Copied to clipboard</string>
+    <string name="nav_songwriter_mode">Start a Song</string>
+    <string name="songwriter_song_saved">Song saved!</string>
 
     <!-- ── Progressions ─────────────────────────────────────────────── -->
     <string name="progressions_new">New Progression</string>

--- a/docs/manual/android/01-getting-started.md
+++ b/docs/manual/android/01-getting-started.md
@@ -47,7 +47,8 @@ The four groups are:
 | Section | What It Does |
 |---------|-------------|
 | **Songs** | Personal songbook with chord sheets, ChordPro import/export |
-| **Melody Notepad** | Simple melody composition tool |
+| **Start a Song** | Guided songwriting flow — pick a key, build a progression, write lyrics, transpose, and save |
+| **Melody Notepad** | Melody composer with linear and step sequencer modes |
 | **Patterns** | Strumming and fingerpicking pattern reference |
 | **Progressions** | Common chord progressions in any key |
 

--- a/docs/manual/android/05-progressions.md
+++ b/docs/manual/android/05-progressions.md
@@ -34,6 +34,7 @@ Actions are organised in two rows at the bottom of the card:
 **Row 2 — secondary actions:**
 
 - **Share** — export the progression as text to share with others.
+- **Copy** — copy the progression to the clipboard with a single tap.
 - **Capo** — view capo positions that let you play the progression using simpler chord shapes.
 - **Voice Leading** — view smooth voice-leading suggestions between the chords.
 
@@ -44,6 +45,8 @@ The progression playback bar includes a BPM slider to control the playback speed
 ## Custom Progressions
 
 You can create your own custom progressions by tapping the **New Progression** button. Custom progressions can be edited, duplicated, and deleted.
+
+When creating or editing a custom progression, diatonic chord chips for the selected scale are displayed as suggestions. These chips show the chords that naturally fit the key, making it easy to build harmonically coherent progressions without memorising music theory.
 
 - **Edit** lets you change the name, chord sequence, or mode of an existing custom progression.
 - **Duplicate** creates a new independent copy you can modify separately.

--- a/docs/manual/android/07-songs.md
+++ b/docs/manual/android/07-songs.md
@@ -79,14 +79,19 @@ The song viewer includes **transpose controls** to shift all chords up or down b
 
 When a transposition is active, the app also displays an equivalent **capo suggestion**. For example, if you transpose up 5 semitones, the app shows "Or use Capo 5 with original chords" — so you can choose whichever approach you prefer.
 
+### Save in This Key
+
+If you want to keep the transposed version permanently, tap **Save in this key**. This rewrites the chord sheet with the new chord names and updates the stored key. The original chords are replaced — use this when you have found the right key and want to commit to it.
+
 ## Exporting and Sharing
 
-The share button in the song viewer offers several options:
+Tap the **share button** in the song viewer to open the export format picker. Choose one of three options:
 
-- **Share as text** — sends the chord sheet as plain text via any messaging or sharing app.
-- **Share transposed** — shares the chord sheet with the current transposition applied (visible only when a transposition is active).
-- **Export as ChordPro** — generates a ChordPro-formatted file with proper directives (`{title:}`, `{artist:}`, section markers) for use in other chord sheet apps.
-- **Export transposed ChordPro** — exports with the transposition baked in (visible only when a transposition is active).
+- **ChordPro (.cho)** — generates a ChordPro-formatted file with proper directives (`{title:}`, `{artist:}`, section markers) for use in other chord sheet apps.
+- **Plain text** — sends the chord sheet as formatted text with chords displayed above lyrics, ready to share via any messaging or sharing app.
+- **Copy to clipboard** — copies the formatted chord sheet to the clipboard for quick pasting into messages, notes, or other apps.
+
+If a transposition is active, the exported or copied content uses the transposed chords automatically.
 
 ## Editing and Deleting
 

--- a/docs/manual/android/14-melody-notepad.md
+++ b/docs/manual/android/14-melody-notepad.md
@@ -1,6 +1,6 @@
 # Melody Notepad
 
-The Melody Notepad is a simple melody composer and sequencer. You can create short melodies by tapping notes or recording from your ukulele, then play them back at any tempo.
+The Melody Notepad is a melody composer and sequencer with two input modes — **Linear** (tap or record notes one at a time) and **Step Sequencer** (fill a grid of 8 or 16 steps). Create melodies, loops, and rhythmic patterns, then play them back at any tempo.
 
 ![Melody Notepad](screenshots/melody-notepad.png)
 
@@ -22,6 +22,18 @@ Notes appear in the sequence display at the top as colored blocks showing the no
 3. Play a note on your ukulele — the app detects the pitch and adds it to the sequence once the note stabilizes.
 4. Continue playing notes to build the melody.
 5. Tap stop when finished.
+
+### Step Sequencer Mode
+
+Toggle from Linear to **Step Sequencer** mode using the mode switch at the top.
+
+1. The sequencer shows a grid of **8 steps** by default. Tap **Expand** to switch to 16 steps, or **Shrink** to return to 8.
+2. Tap any step in the grid to open a **pitch picker**. Select a note name and octave to assign it to that step.
+3. Long-press a step to **clear** it (reset it to silence).
+4. Tap **Play** to loop the sequence continuously at the current BPM. The active step is highlighted as it plays.
+5. Tap **Stop** to end playback.
+
+The step sequencer is ideal for building rhythmic patterns and loop-based ideas without worrying about note durations — each step has equal timing determined by the BPM.
 
 ## Editing
 
@@ -50,6 +62,8 @@ Melodies are saved to the device and persist between sessions.
 
 - Use Tap mode for precise control over note placement and duration.
 - Use Record mode to quickly capture a melody idea by playing it on your ukulele.
+- Use Step Sequencer mode for rhythmic patterns and loop-based ideas — great for experimenting with riffs.
 - Start with quarter notes for simple melodies, then add eighth and sixteenth notes for faster passages.
 - Experiment with different octaves to create melodies that span the full ukulele range.
 - In Record mode, if the app picks up unwanted notes from background noise, increase the **Noise filtering** slider in Settings.
+- In the step sequencer, start with 8 steps for short loops and expand to 16 when you need a longer phrase.

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -22,7 +22,7 @@ Both editions cover the same features — the only differences are navigation st
 
 ## What's Inside
 
-Each manual covers 14 sections:
+Each manual covers 15 sections:
 
 <div class="manual-grid">
 
@@ -58,7 +58,12 @@ Each manual covers 14 sections:
 
   <div class="manual-card">
     <h3>Songs</h3>
-    <p>Creating chord sheets with auto-scroll, transpose, key detection, and ChordPro import/export.</p>
+    <p>Creating chord sheets with auto-scroll, transpose, "Save in this key", key detection, and export as ChordPro, plain text, or clipboard copy.</p>
+  </div>
+
+  <div class="manual-card">
+    <h3>Start a Song</h3>
+    <p>Guided songwriting flow — pick a key and scale, build a progression, write lyrics, transpose, and save to your songbook.</p>
   </div>
 
   <div class="manual-card">
@@ -93,7 +98,7 @@ Each manual covers 14 sections:
 
   <div class="manual-card">
     <h3>Melody Notepad</h3>
-    <p>Compose melodies by tapping notes or recording from your ukulele.</p>
+    <p>Compose melodies by tapping notes, recording from your ukulele, or using the step sequencer to build loops and rhythmic patterns.</p>
   </div>
 
 </div>

--- a/docs/manual/ios/01-getting-started.md
+++ b/docs/manual/ios/01-getting-started.md
@@ -41,7 +41,8 @@ The four tabs are:
 | Section | What It Does |
 |---------|-------------|
 | **Songs** | Personal songbook with chord sheets, ChordPro import/export |
-| **Melody Notepad** | Simple melody composition tool |
+| **Start a Song** | Guided songwriting flow — pick a key, build a progression, write lyrics, transpose, and save |
+| **Melody Notepad** | Melody composer with linear and step sequencer modes |
 | **Patterns** | Strumming and fingerpicking pattern reference |
 | **Progressions** | Common chord progressions in any key |
 

--- a/docs/manual/ios/05-progressions.md
+++ b/docs/manual/ios/05-progressions.md
@@ -34,6 +34,7 @@ Actions are organised in two rows at the bottom of the card:
 **Row 2 — secondary actions:**
 
 - **Share** — export the progression as text to share with others.
+- **Copy** — copy the progression to the clipboard with a single tap.
 - **Capo** — view capo positions that let you play the progression using simpler chord shapes.
 - **Voice Leading** — view smooth voice-leading suggestions between the chords.
 
@@ -44,6 +45,8 @@ The progression playback bar includes a BPM slider to control the playback speed
 ## Custom Progressions
 
 You can create your own custom progressions by tapping the **New Progression** button. Custom progressions can be edited, duplicated, and deleted.
+
+When creating or editing a custom progression, diatonic chord chips for the selected scale are displayed as suggestions. These chips show the chords that naturally fit the key, making it easy to build harmonically coherent progressions without memorising music theory.
 
 - **Edit** lets you change the name, chord sequence, or mode of an existing custom progression.
 - **Duplicate** creates a new independent copy you can modify separately.

--- a/docs/manual/ios/07-songs.md
+++ b/docs/manual/ios/07-songs.md
@@ -79,14 +79,19 @@ The song viewer includes **transpose controls** to shift all chords up or down b
 
 When a transposition is active, the app also displays an equivalent **capo suggestion**. For example, if you transpose up 5 semitones, the app shows "Or use Capo 5 with original chords" — so you can choose whichever approach you prefer.
 
+### Save in This Key
+
+If you want to keep the transposed version permanently, tap **Save in this key**. This rewrites the chord sheet with the new chord names and updates the stored key. The original chords are replaced — use this when you have found the right key and want to commit to it.
+
 ## Exporting and Sharing
 
-The share button in the song viewer offers several options:
+Tap the **share button** in the song viewer to open the export format picker. Choose one of three options:
 
-- **Share as text** — sends the chord sheet as plain text via any messaging or sharing app.
-- **Share transposed** — shares the chord sheet with the current transposition applied (visible only when a transposition is active).
-- **Export as ChordPro** — generates a ChordPro-formatted file with proper directives (`{title:}`, `{artist:}`, section markers) for use in other chord sheet apps.
-- **Export transposed ChordPro** — exports with the transposition baked in (visible only when a transposition is active).
+- **ChordPro (.cho)** — generates a ChordPro-formatted file with proper directives (`{title:}`, `{artist:}`, section markers) for use in other chord sheet apps.
+- **Plain text** — sends the chord sheet as formatted text with chords displayed above lyrics, ready to share via any messaging or sharing app.
+- **Copy to clipboard** — copies the formatted chord sheet to the clipboard for quick pasting into messages, notes, or other apps.
+
+If a transposition is active, the exported or copied content uses the transposed chords automatically.
 
 ## Editing and Deleting
 

--- a/docs/manual/ios/14-melody-notepad.md
+++ b/docs/manual/ios/14-melody-notepad.md
@@ -1,6 +1,6 @@
 # Melody Notepad
 
-The Melody Notepad is a simple melody composer and sequencer. You can create short melodies by tapping notes or recording from your ukulele, then play them back at any tempo.
+The Melody Notepad is a melody composer and sequencer with two input modes — **Linear** (tap or record notes one at a time) and **Step Sequencer** (fill a grid of 8 or 16 steps). Create melodies, loops, and rhythmic patterns, then play them back at any tempo.
 
 ![Melody Notepad](screenshots/melody-notepad.png)
 
@@ -22,6 +22,18 @@ Notes appear in the sequence display at the top as colored blocks showing the no
 3. Play a note on your ukulele — the app detects the pitch and adds it to the sequence once the note stabilizes.
 4. Continue playing notes to build the melody.
 5. Tap stop when finished.
+
+### Step Sequencer Mode
+
+Toggle from Linear to **Step Sequencer** mode using the mode switch at the top.
+
+1. The sequencer shows a grid of **8 steps** by default. Tap **Expand** to switch to 16 steps, or **Shrink** to return to 8.
+2. Tap any step in the grid to open a **pitch picker**. Select a note name and octave to assign it to that step.
+3. Use the context menu on a step to **clear** it (reset it to silence).
+4. Tap **Play** to loop the sequence continuously at the current BPM. The active step is highlighted as it plays.
+5. Tap **Stop** to end playback.
+
+The step sequencer is ideal for building rhythmic patterns and loop-based ideas without worrying about note durations — each step has equal timing determined by the BPM.
 
 ## Editing
 
@@ -50,6 +62,8 @@ Melodies are saved to the device and persist between sessions.
 
 - Use Tap mode for precise control over note placement and duration.
 - Use Record mode to quickly capture a melody idea by playing it on your ukulele.
+- Use Step Sequencer mode for rhythmic patterns and loop-based ideas — great for experimenting with riffs.
 - Start with quarter notes for simple melodies, then add eighth and sixteenth notes for faster passages.
 - Experiment with different octaves to create melodies that span the full ukulele range.
 - In Record mode, if the app picks up unwanted notes from background noise, increase the **Noise filtering** slider in Settings.
+- In the step sequencer, start with 8 steps for short loops and expand to 16 when you need a longer phrase.

--- a/docs/spec/14-composition-tools.md
+++ b/docs/spec/14-composition-tools.md
@@ -1,6 +1,6 @@
 # Feature: Composition Tools
 
-**Status: IN PROGRESS** *(updated after codebase audit — several ideas are already built)*
+**Status: DONE** *(all five ideas implemented on both platforms)*
 
 ## Summary
 
@@ -26,7 +26,7 @@ playback) to provide a more complete songwriting workflow.
 
 ## Idea 1: Chord Sheet Transpose
 
-**Status: Partially Built** *(both platforms have preview transpose; "Save in this key" commit flow missing on both)*
+**Status: Done** *(both platforms have preview transpose and "Save in this key" commit flow)*
 
 Both platforms call `ChordSheetTranspose.transpose()` for real-time preview.
 `ChordProParser` already parses `{key}` and `{capo}` directives.
@@ -89,7 +89,7 @@ fun resetTranspose() { _transposeOffset.value = 0 }
 
 ## Idea 2: Export & Share
 
-**Status: Needs Polish** *(infrastructure exists; format-picker and clipboard copy absent on both platforms)*
+**Status: Done** *(format-picker sheet and clipboard copy implemented on both platforms)*
 
 ### What Already Exists
 
@@ -165,7 +165,7 @@ object ChordSheetFormatter {
 
 ## Idea 3: Scale-Aware Chord Suggestions
 
-**Status: Needs Polish on Android; Done on iOS**
+**Status: Done** *(diatonic chord chips in progression builder on both platforms)*
 
 ### What Already Exists
 
@@ -230,7 +230,7 @@ LazyRow {
 
 ## Idea 4: Melody Notepad
 
-**Status: Partially Built** *(both platforms have basic tap/record melody notepad; step sequencer and linked-progression playback absent on both)*
+**Status: Done** *(step sequencer mode with 8/16-step grid implemented on both platforms)*
 
 ### What Already Exists
 
@@ -322,7 +322,7 @@ class MelodyViewModel : ViewModel() {
 
 ## Idea 5: Songwriter Mode — A Guided Composition Flow
 
-**Status: Proposed**
+**Status: Done** *("Start a Song" guided flow implemented on both platforms)*
 
 ### Problem
 

--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		A10077 /* ProgressionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10077 /* ProgressionsViewModelTests.swift */; };
 		A10078 /* ChordLibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10078 /* ChordLibraryViewModelTests.swift */; };
 		A10079 /* ChordVoicing+Frets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10079 /* ChordVoicing+Frets.swift */; };
+		A10080 /* SongwriterModeFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10080 /* SongwriterModeFlow.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
 		A20002 /* click_low.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20002 /* click_low.wav */; };
 		A20003 /* uke_a.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20003 /* uke_a.wav */; };
@@ -221,6 +222,7 @@
 		B10077 /* ProgressionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressionsViewModelTests.swift; sourceTree = "<group>"; };
 		B10078 /* ChordLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordLibraryViewModelTests.swift; sourceTree = "<group>"; };
 		B10079 /* ChordVoicing+Frets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChordVoicing+Frets.swift"; sourceTree = "<group>"; };
+		B10080 /* SongwriterModeFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongwriterModeFlow.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
 		B20002 /* click_low.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_low.wav; sourceTree = "<group>"; };
 		B20003 /* uke_a.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = uke_a.wav; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				B10023 /* SongbookView.swift */,
 				B10024 /* SongEditorView.swift */,
 				B10025 /* MelodyNotepadView.swift */,
+				B10080 /* SongwriterModeFlow.swift */,
 				B10029 /* LearnView.swift */,
 				B10030 /* TheoryLessonsView.swift */,
 				B10031 /* TheoryQuizView.swift */,
@@ -711,6 +714,7 @@
 				A10069 /* PlayAlongViewModel.swift in Sources */,
 				A10070 /* PatternPlayer.swift in Sources */,
 				A10071 /* FullScreenFretboardView.swift in Sources */,
+				A10080 /* SongwriterModeFlow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanion/ContentView.swift
+++ b/iosApp/UkuleleCompanion/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 enum SidebarDestination: String, Hashable {
     case explorer, tuner, pitchMonitor, metronome, chordLibrary, favorites
-    case progressions, strumPatterns, songbook, melodyNotepad
+    case songwriterMode, progressions, strumPatterns, songbook, melodyNotepad
     case dailyChallenge, practiceRoutine, chordTransitions, playAlong
     case intervalTrainer, chordEarTraining, noteQuiz, scalePractice
     case theoryLessons, theoryQuiz
@@ -118,6 +118,7 @@ struct ContentView: View {
             }
 
             Section {
+                sidebarLink(.songwriterMode, "Start a Song", icon: "wand.and.stars")
                 sidebarLink(.progressions, "Chord Progressions", icon: "play.circle")
                 sidebarLink(.strumPatterns, "Strumming Patterns", icon: "metronome")
                 sidebarLink(.songbook, "Songbook", icon: "music.note.list")
@@ -199,6 +200,7 @@ struct ContentView: View {
         case .metronome: MetronomeView()
         case .chordLibrary: ChordLibraryView()
         case .favorites: FavoritesView()
+        case .songwriterMode: SongwriterModeFlow()
         case .progressions: ProgressionsView()
         case .strumPatterns: StrumPatternsView()
         case .songbook: SongbookView()

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -73,6 +73,14 @@ final class MelodyViewModel: ObservableObject {
     @Published var lastAddedFeedback: String? = nil
     @Published var hasUnsavedChanges: Bool = false
     @Published var selectedNoteIndex: Int? = nil
+
+    static let stepCount8 = 8
+    static let stepCount16 = 16
+
+    @Published var isStepSequencerMode: Bool = false
+    @Published var steps: [MelodyNoteData?] = Array(repeating: nil, count: stepCount8)
+    @Published var stepLooping: Bool = true
+
     private var loadedMelodyId: String? = nil
     private static let stabilizationThreshold = 3
 
@@ -139,6 +147,73 @@ final class MelodyViewModel: ObservableObject {
         loadedMelodyId = nil
         hasUnsavedChanges = false
         selectedNoteIndex = nil
+    }
+
+    // MARK: - Step Sequencer
+
+    func toggleStepSequencerMode() {
+        isStepSequencerMode.toggle()
+    }
+
+    func setStep(index: Int, pitchClass: Int) {
+        guard index >= 0 && index < steps.count else { return }
+        let note = MelodyNoteData(
+            id: UUID().uuidString,
+            pitchClass: pitchClass,
+            octave: currentOctave,
+            duration: selectedDuration,
+            isRest: false
+        )
+        steps[index] = note
+        hasUnsavedChanges = true
+        tonePlayer.playNote(pitchClass: Int32(pitchClass))
+    }
+
+    func clearStep(index: Int) {
+        guard index >= 0 && index < steps.count else { return }
+        steps[index] = nil
+        hasUnsavedChanges = true
+    }
+
+    func expandSteps() {
+        if steps.count >= Self.stepCount16 {
+            steps = Array(steps.prefix(Self.stepCount8))
+        } else {
+            steps += Array(repeating: nil as MelodyNoteData?, count: Self.stepCount16 - steps.count)
+        }
+    }
+
+    func playSteps() {
+        let filled = steps.contains { $0 != nil }
+        guard filled else { return }
+        isPlaying = true
+        playingIndex = 0
+
+        playbackTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            repeat {
+                for i in 0..<self.steps.count {
+                    if Task.isCancelled { break }
+                    guard self.isPlaying else { break }
+                    self.playingIndex = i
+                    if let note = self.steps[i], let pc = note.pitchClass {
+                        self.tonePlayer.playNote(pitchClass: Int32(pc))
+                    }
+                    let duration = (self.steps[i]?.duration ?? self.selectedDuration).beats
+                    let ms = duration * 60_000.0 / Double(self.bpm)
+                    try? await Task.sleep(nanoseconds: UInt64(ms * 1_000_000))
+                }
+            } while self.isPlaying && self.stepLooping && !Task.isCancelled
+            self.isPlaying = false
+            self.playingIndex = nil
+        }
+    }
+
+    func clearAllSteps() {
+        for i in 0..<steps.count {
+            steps[i] = nil
+        }
+        hasUnsavedChanges = true
     }
 
     private func showFeedback(_ text: String) {

--- a/iosApp/UkuleleCompanion/Views/CreateView.swift
+++ b/iosApp/UkuleleCompanion/Views/CreateView.swift
@@ -7,6 +7,12 @@ struct CreateView: View {
         NavigationStack {
             List {
                 NavigationLink {
+                    SongwriterModeFlow()
+                } label: {
+                    Label("Start a Song", systemImage: "wand.and.stars")
+                }
+
+                NavigationLink {
                     ProgressionsView()
                 } label: {
                     Label("Chord Progressions", systemImage: "play.circle")

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -14,13 +14,19 @@ struct MelodyNotepadView: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            modeToggle
-            if viewModel.inputMode == .tap {
-                tapInput
+            sequencerModeToggle
+            if viewModel.isStepSequencerMode {
+                stepSequencerGrid
+                stepOctaveAndDuration
             } else {
-                recordInput
+                modeToggle
+                if viewModel.inputMode == .tap {
+                    tapInput
+                } else {
+                    recordInput
+                }
+                notesList
             }
-            notesList
             playbackControls
             persistenceControls
         }
@@ -284,6 +290,8 @@ struct MelodyNotepadView: View {
             Button {
                 if viewModel.isPlaying {
                     viewModel.stopPlayback()
+                } else if viewModel.isStepSequencerMode {
+                    viewModel.playSteps()
                 } else {
                     viewModel.playMelody()
                 }
@@ -294,7 +302,22 @@ struct MelodyNotepadView: View {
                 )
             }
             .buttonStyle(.bordered)
-            .disabled(viewModel.notes.isEmpty)
+            .disabled(
+                viewModel.isStepSequencerMode
+                    ? !viewModel.steps.contains(where: { $0 != nil })
+                    : viewModel.notes.isEmpty
+            )
+
+            if viewModel.isStepSequencerMode {
+                Button {
+                    viewModel.stepLooping.toggle()
+                } label: {
+                    Image(systemName: viewModel.stepLooping ? "repeat" : "repeat.1")
+                }
+                .buttonStyle(.bordered)
+                .tint(viewModel.stepLooping ? .accentColor : .secondary)
+                .accessibilityLabel(viewModel.stepLooping ? "Loop on" : "Loop off")
+            }
 
             Spacer()
 
@@ -315,24 +338,32 @@ struct MelodyNotepadView: View {
 
     private var persistenceControls: some View {
         HStack {
-            Button("New") {
-                guardUnsaved { viewModel.clearAll() }
-            }
-            .buttonStyle(.bordered)
-
-            Button("Save") { showingSaveDialog = true }
+            if viewModel.isStepSequencerMode {
+                Button("Clear") {
+                    viewModel.clearAllSteps()
+                }
                 .buttonStyle(.bordered)
-                .disabled(viewModel.notes.isEmpty)
+                .disabled(!viewModel.steps.contains(where: { $0 != nil }))
+            } else {
+                Button("New") {
+                    guardUnsaved { viewModel.clearAll() }
+                }
+                .buttonStyle(.bordered)
 
-            Button("Load") {
-                guardUnsaved { showingLoadSheet = true }
+                Button("Save") { showingSaveDialog = true }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.notes.isEmpty)
+
+                Button("Load") {
+                    guardUnsaved { showingLoadSheet = true }
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.savedMelodies.isEmpty)
             }
-            .buttonStyle(.bordered)
-            .disabled(viewModel.savedMelodies.isEmpty)
 
             Spacer()
 
-            if let name = viewModel.loadedMelodyName {
+            if !viewModel.isStepSequencerMode, let name = viewModel.loadedMelodyName {
                 Text(name)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -347,6 +378,174 @@ struct MelodyNotepadView: View {
         } else {
             action()
         }
+    }
+
+    // MARK: - Step Sequencer
+
+    private var sequencerModeToggle: some View {
+        Picker("Mode", selection: Binding(
+            get: { viewModel.isStepSequencerMode ? 1 : 0 },
+            set: { viewModel.isStepSequencerMode = $0 == 1 }
+        )) {
+            Text("Linear").tag(0)
+            Text("Step Sequencer").tag(1)
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("Sequencer mode")
+    }
+
+    @State private var stepPitchPickerIndex: Int? = nil
+
+    private var stepSequencerGrid: some View {
+        VStack(spacing: 8) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(0..<viewModel.steps.count, id: \.self) { i in
+                        let step = viewModel.steps[i]
+                        let isPlaying = viewModel.playingIndex == i
+
+                        Button {
+                            stepPitchPickerIndex = i
+                        } label: {
+                            VStack(spacing: 2) {
+                                if let note = step, let pc = note.pitchClass {
+                                    Text(viewModel.noteNames[pc])
+                                        .font(.caption.bold())
+                                    Text("\(note.octave)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    Text("—")
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
+                                }
+                            }
+                            .frame(width: 40, height: 48)
+                            .background(
+                                isPlaying ? Color.accentColor :
+                                step != nil ? Color.accentColor.opacity(0.15) :
+                                Color(.systemGray6)
+                            )
+                            .foregroundStyle(isPlaying ? .white : .primary)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(
+                                        isPlaying ? Color.accentColor : Color.clear,
+                                        lineWidth: 2
+                                    )
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(stepAccessibilityLabel(index: i, step: step))
+                        .contextMenu {
+                            if step != nil {
+                                Button(role: .destructive) {
+                                    viewModel.clearStep(index: i)
+                                } label: {
+                                    Label("Clear Step", systemImage: "xmark")
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 4)
+            }
+            .frame(minHeight: 56)
+
+            HStack {
+                Button {
+                    viewModel.expandSteps()
+                } label: {
+                    Text(viewModel.steps.count >= MelodyViewModel.stepCount16 ? "8 Steps" : "16 Steps")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel(viewModel.steps.count >= MelodyViewModel.stepCount16 ? "Shrink to 8 steps" : "Expand to 16 steps")
+            }
+        }
+        .sheet(item: Binding(
+            get: { stepPitchPickerIndex.map { StepPickerItem(index: $0) } },
+            set: { stepPitchPickerIndex = $0?.index }
+        )) { item in
+            stepPitchPicker(for: item.index)
+                .presentationDetents([.medium])
+        }
+    }
+
+    private func stepPitchPicker(for stepIndex: Int) -> some View {
+        NavigationStack {
+            List {
+                ForEach(0..<12, id: \.self) { pc in
+                    Button {
+                        viewModel.setStep(index: stepIndex, pitchClass: pc)
+                        stepPitchPickerIndex = nil
+                    } label: {
+                        Text(viewModel.noteNames[pc])
+                            .font(.body.bold())
+                    }
+                    .accessibilityHint("Selects this note for the step")
+                }
+            }
+            .navigationTitle("Choose Note")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { stepPitchPickerIndex = nil }
+                }
+                if viewModel.steps[stepIndex] != nil {
+                    ToolbarItem(placement: .destructiveAction) {
+                        Button("Clear", role: .destructive) {
+                            viewModel.clearStep(index: stepIndex)
+                            stepPitchPickerIndex = nil
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var stepOctaveAndDuration: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 4) {
+                Text("Octave:")
+                    .font(.caption)
+                Stepper("\(viewModel.currentOctave)", value: $viewModel.currentOctave, in: 3...6)
+                    .font(.caption)
+            }
+
+            HStack(spacing: 6) {
+                ForEach(NoteDuration.allCases, id: \.self) { duration in
+                    Button {
+                        viewModel.selectedDuration = duration
+                    } label: {
+                        VStack(spacing: 2) {
+                            Text(duration.rawValue)
+                                .font(.title3)
+                            Text(duration.label)
+                                .font(.caption2)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+                        .background(
+                            viewModel.selectedDuration == duration
+                                ? Color.accentColor.opacity(0.2)
+                                : Color(.systemGray6)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityAddTraits(viewModel.selectedDuration == duration ? .isSelected : [])
+                }
+            }
+        }
+    }
+
+    private func stepAccessibilityLabel(index: Int, step: MelodyNoteData?) -> String {
+        if let note = step, let pc = note.pitchClass {
+            return "Step \(index + 1), \(viewModel.noteNames[pc]) octave \(note.octave)"
+        }
+        return "Step \(index + 1), empty"
     }
 
     private var loadSheet: some View {
@@ -392,4 +591,9 @@ struct MelodyNotepadView: View {
             }
         }
     }
+}
+
+private struct StepPickerItem: Identifiable {
+    let index: Int
+    var id: Int { index }
 }

--- a/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
@@ -235,6 +235,15 @@ struct ProgressionsView: View {
                             .font(.caption)
                     }
                     .accessibilityLabel("Share \(name)")
+
+                    Button {
+                        UIPasteboard.general.string = shareText
+                        AccessibilityAnnouncer.shared.announce("Copied to clipboard")
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                            .font(.caption)
+                    }
+                    .accessibilityLabel("Copy \(name) to clipboard")
                 }
                 if let onEdit {
                     Button(action: onEdit) {

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -438,42 +438,64 @@ struct SongViewerView: View {
         .onDisappear { stopAutoScroll() }
     }
 
+    @State private var showShareSheet = false
+
     // MARK: - Share Menu
 
     private var shareMenu: some View {
-        Menu {
-            Button {
-                let formatted = viewModel.formattedDisplay(song: currentSong)
-                shareText(formatted)
-            } label: {
-                Label("Share as text", systemImage: "doc.plaintext")
-            }
-            if transposeSemitones != 0 {
-                Button {
-                    let formatted = viewModel.formattedDisplay(song: displaySong)
-                    shareText(formatted)
-                } label: {
-                    Label("Share transposed text", systemImage: "doc.plaintext")
-                }
-            }
-            Button {
-                let chordPro = viewModel.exportChordPro(song: currentSong)
-                shareText(chordPro)
-            } label: {
-                Label("Export ChordPro", systemImage: "square.and.arrow.up")
-            }
-            if transposeSemitones != 0 {
-                Button {
-                    let chordPro = viewModel.exportChordPro(song: displaySong)
-                    shareText(chordPro)
-                } label: {
-                    Label("Export transposed ChordPro", systemImage: "square.and.arrow.up")
-                }
-            }
-        } label: {
+        Button { showShareSheet = true } label: {
             Image(systemName: "square.and.arrow.up")
         }
         .accessibilityLabel("Share")
+        .accessibilityHint("Choose export format")
+        .sheet(isPresented: $showShareSheet) {
+            shareFormatPicker
+        }
+    }
+
+    private var shareFormatPicker: some View {
+        let effectiveSong = transposeSemitones != 0 ? displaySong : currentSong
+        return NavigationStack {
+            List {
+                Section {
+                    Button {
+                        showShareSheet = false
+                        let chordPro = viewModel.exportChordPro(song: effectiveSong)
+                        shareText(chordPro)
+                    } label: {
+                        Label("ChordPro (.cho)", systemImage: "music.note")
+                    }
+
+                    Button {
+                        showShareSheet = false
+                        let formatted = viewModel.formattedDisplay(song: effectiveSong)
+                        shareText(formatted)
+                    } label: {
+                        Label("Plain text", systemImage: "doc.plaintext")
+                    }
+
+                    Button {
+                        showShareSheet = false
+                        let formatted = viewModel.formattedDisplay(song: effectiveSong)
+                        UIPasteboard.general.string = formatted
+                        AccessibilityAnnouncer.shared.announce("Copied to clipboard")
+                    } label: {
+                        Label("Copy to clipboard", systemImage: "doc.on.doc")
+                    }
+                } header: {
+                    Text("Share chord sheet as")
+                        .accessibilityAddTraits(.isHeader)
+                }
+            }
+            .navigationTitle("Share")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { showShareSheet = false }
+                }
+            }
+        }
+        .presentationDetents([.medium])
     }
 
     private func shareText(_ text: String) {
@@ -662,6 +684,18 @@ struct SongViewerView: View {
                         .foregroundStyle(.orange)
                         .fontWeight(.semibold)
                 }
+
+                Button {
+                    let transposed = viewModel.transpose(song: currentSong, semitones: transposeSemitones)
+                    viewModel.save(song: transposed)
+                    transposeSemitones = 0
+                } label: {
+                    Text("Save in this key")
+                        .font(.caption.bold())
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .accessibilityLabel("Save song in transposed key")
             }
         }
     }

--- a/iosApp/UkuleleCompanion/Views/SongwriterModeFlow.swift
+++ b/iosApp/UkuleleCompanion/Views/SongwriterModeFlow.swift
@@ -1,0 +1,400 @@
+import SwiftUI
+import shared
+
+/// Guided songwriting flow: choose key → build progression → write lyrics → transpose → save.
+struct SongwriterModeFlow: View {
+    @StateObject private var songbookViewModel = SongbookViewModel()
+    @StateObject private var progressionsViewModel = ProgressionsViewModel()
+
+    @State private var currentStep = 0
+    @State private var selectedRoot: Int32 = 0
+    @State private var selectedScale: ScaleType = .major
+    @State private var chosenDegrees: [ChordDegree] = []
+    @State private var songTitle = ""
+    @State private var songContent = ""
+    @State private var transposeSemitones: Int = 0
+
+    private let totalSteps = 5
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ProgressView(value: Double(currentStep + 1), total: Double(totalSteps))
+                .padding(.horizontal)
+
+            Text("Step \(currentStep + 1) of \(totalSteps)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+                .accessibilityAddTraits(.updatesFrequently)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    stepContent
+                }
+                .padding()
+            }
+
+            Spacer()
+
+            navigationButtons
+                .padding()
+        }
+        .navigationTitle("Start a Song")
+        .onChange(of: selectedRoot) { _ in
+            chosenDegrees = []
+            transposeSemitones = 0
+        }
+        .onChange(of: selectedScale) { _ in
+            chosenDegrees = []
+            transposeSemitones = 0
+        }
+    }
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch currentStep {
+        case 0: stepChooseKeyScale
+        case 1: stepBuildProgression
+        case 2: stepAddLyrics
+        case 3: stepTranspose
+        case 4: stepReviewAndSave
+        default: EmptyView()
+        }
+    }
+
+    // MARK: - Step 1: Choose Key & Scale
+
+    private var stepChooseKeyScale: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Choose a key and scale")
+                .font(.title3.bold())
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Pick the musical key and scale for your song. This determines which chords will be suggested.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text("Root")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(0..<12, id: \.self) { pc in
+                        let name = Notes.shared.pitchClassToName(pitchClass: Int32(pc))
+                        Button(name) { selectedRoot = Int32(pc) }
+                            .buttonStyle(.bordered)
+                            .tint(selectedRoot == Int32(pc) ? .accentColor : .secondary)
+                    }
+                }
+            }
+
+            Text("Scale")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(progressionsViewModel.allScaleTypes, id: \.name) { scale in
+                        Button(scale.label) { selectedScale = scale }
+                            .buttonStyle(.bordered)
+                            .tint(selectedScale == scale ? .accentColor : .secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Step 2: Build Progression
+
+    private var stepBuildProgression: some View {
+        let degrees = progressionsViewModel.diatonicDegreesForScale(selectedScale)
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text("Build a chord progression")
+                .font(.title3.bold())
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Tap the diatonic chords below to build your progression.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Text("Tap chords to add")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(0..<degrees.count, id: \.self) { i in
+                        let degree = degrees[i]
+                        let chordRoot = (selectedRoot + degree.interval) % 12
+                        let chordName = Notes.shared.enharmonicForKey(
+                            pitchClass: Int32(chordRoot),
+                            keyRoot: KotlinInt(int: selectedRoot),
+                            isMinor: selectedScale == .minor
+                        ) + degree.quality
+                        Button(chordName) {
+                            chosenDegrees.append(degree)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+            }
+
+            if !chosenDegrees.isEmpty {
+                Text("Your progression (\(chosenDegrees.count) chords)")
+                    .font(.headline)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(0..<chosenDegrees.count, id: \.self) { i in
+                            let degree = chosenDegrees[i]
+                            let chordRoot = (selectedRoot + degree.interval) % 12
+                            let chordName = Notes.shared.enharmonicForKey(
+                                pitchClass: Int32(chordRoot),
+                                keyRoot: KotlinInt(int: selectedRoot),
+                                isMinor: selectedScale == .minor
+                            ) + degree.quality
+                            Button(chordName) {
+                                chosenDegrees.remove(at: i)
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
+                    }
+                }
+
+                Button("Reset") { chosenDegrees.removeAll() }
+                    .font(.caption)
+            } else {
+                Text("Tap the chords above to build your progression")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if chosenDegrees.count == 1 {
+                Text("Add at least 2 chords")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    // MARK: - Step 3: Add Lyrics
+
+    private var stepAddLyrics: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Add lyrics and chords")
+                .font(.title3.bold())
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Write your lyrics below. Tap the chord chips to insert [Chord] markers.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            TextField("Song title", text: $songTitle)
+                .textFieldStyle(.roundedBorder)
+
+            if !chosenDegrees.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 4) {
+                        ForEach(0..<chosenDegrees.count, id: \.self) { i in
+                            let degree = chosenDegrees[i]
+                            let chordRoot = (selectedRoot + degree.interval) % 12
+                            let chordName = Notes.shared.enharmonicForKey(
+                                pitchClass: Int32(chordRoot),
+                                keyRoot: KotlinInt(int: selectedRoot),
+                                isMinor: selectedScale == .minor
+                            ) + degree.quality
+                            Button(chordName) {
+                                songContent += "[\(chordName)]"
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .accessibilityHint("Inserts [\(chordName)] into lyrics")
+                        }
+                    }
+                }
+            }
+
+            TextEditor(text: $songContent)
+                .frame(minHeight: 200)
+                .accessibilityLabel("Song lyrics editor")
+                .accessibilityHint("Edit lyrics; chord buttons above insert bracketed chords")
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(.systemGray4), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Step 4: Transpose
+
+    private var stepTranspose: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Transpose (optional)")
+                .font(.title3.bold())
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Shift the key up or down if needed. The transposition will be applied when you save.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button { transposeSemitones -= 1 } label: {
+                    Image(systemName: "minus.circle")
+                }
+                .accessibilityLabel("Transpose down")
+
+                Text("\(transposeSemitones > 0 ? "+" : "")\(transposeSemitones)")
+                    .font(.headline.monospacedDigit())
+                    .frame(minWidth: 40)
+                    .multilineTextAlignment(.center)
+
+                Button { transposeSemitones += 1 } label: {
+                    Image(systemName: "plus.circle")
+                }
+                .accessibilityLabel("Transpose up")
+
+                if transposeSemitones != 0 {
+                    Button("Reset") { transposeSemitones = 0 }
+                        .font(.caption)
+                }
+                Spacer()
+            }
+
+            if !songContent.isEmpty && transposeSemitones != 0 {
+                Text("Preview:")
+                    .font(.headline)
+
+                let transposed = ChordSheetTranspose.shared.transpose(
+                    content: songContent,
+                    semitones: Int32(transposeSemitones)
+                )
+                Text(transposed)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Step 5: Review & Save
+
+    private var stepReviewAndSave: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Review and save")
+                .font(.title3.bold())
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Check your song below, then tap Save to add it to your songbook.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            let keyName = Notes.shared.pitchClassToName(pitchClass: selectedRoot)
+            Text("Key: \(keyName) \(selectedScale.label)")
+                .font(.subheadline.bold())
+                .foregroundStyle(Color.accentColor)
+
+            if !chosenDegrees.isEmpty {
+                let chordNames = chosenDegrees.map { degree -> String in
+                    let chordRoot = (selectedRoot + degree.interval) % 12
+                    return Notes.shared.enharmonicForKey(
+                        pitchClass: Int32(chordRoot),
+                        keyRoot: KotlinInt(int: selectedRoot),
+                        isMinor: selectedScale == .minor
+                    ) + degree.quality
+                }
+                Text("Progression: \(chordNames.joined(separator: " – "))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if transposeSemitones != 0 {
+                Text("Transpose: \(transposeSemitones > 0 ? "+" : "")\(transposeSemitones) semitones")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
+            Divider()
+
+            Text(songTitle.isEmpty ? "Untitled" : songTitle)
+                .font(.headline)
+
+            let finalContent: String = {
+                if transposeSemitones != 0 {
+                    return ChordSheetTranspose.shared.transpose(
+                        content: songContent,
+                        semitones: Int32(transposeSemitones)
+                    )
+                }
+                return songContent
+            }()
+            Text(finalContent.isEmpty ? "(no lyrics yet)" : finalContent)
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Navigation Buttons
+
+    private var navigationButtons: some View {
+        HStack {
+            if currentStep > 0 {
+                Button("Back") { currentStep -= 1 }
+                    .buttonStyle(.bordered)
+            }
+
+            Spacer()
+
+            if currentStep < totalSteps - 1 {
+                Button("Next") { currentStep += 1 }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(currentStep == 1 && chosenDegrees.count < 2)
+            } else {
+                Button("Save") {
+                    let finalContent: String
+                    if transposeSemitones != 0 {
+                        finalContent = ChordSheetTranspose.shared.transpose(
+                            content: songContent,
+                            semitones: Int32(transposeSemitones)
+                        )
+                    } else {
+                        finalContent = songContent
+                    }
+
+                    let finalRoot = (selectedRoot + Int32(transposeSemitones) % 12 + 12) % 12
+                    let finalKey = Notes.shared.pitchClassToName(pitchClass: finalRoot) + " " + selectedScale.label
+
+                    let song = StoredSong(
+                        id: UUID().uuidString,
+                        title: songTitle.isEmpty ? "My Song" : songTitle,
+                        artist: "",
+                        content: finalContent,
+                        key: finalKey,
+                        capo: 0,
+                        strumPatternName: "",
+                        labels: [],
+                        createdAt: Date().timeIntervalSince1970 * 1000,
+                        updatedAt: Date().timeIntervalSince1970 * 1000
+                    )
+                    songbookViewModel.save(song: song)
+
+                    if chosenDegrees.count >= 2 {
+                        let keyName = Notes.shared.pitchClassToName(pitchClass: selectedRoot)
+                        progressionsViewModel.createCustomFromDegrees(
+                            name: "\(keyName) \(selectedScale.label) song progression",
+                            description: "Created in Songwriter Mode",
+                            degrees: chosenDegrees,
+                            scaleType: selectedScale
+                        )
+                    }
+
+                    currentStep = 0
+                    songTitle = ""
+                    songContent = ""
+                    chosenDegrees = []
+                    transposeSemitones = 0
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(songTitle.isEmpty && songContent.isEmpty)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Save in this key**: adds a button on transposed chord sheets (Android + iOS) to permanently save the transposition
- **Export/share format picker**: replaces the old share menu with a bottom sheet / format picker offering ChordPro, plain text, and clipboard copy for both chord sheets and progressions
- **Step sequencer**: adds an 8/16-step grid mode to the Melody Notepad with tap-to-set pitch, long-press clear, loop toggle, and expand/shrink controls
- **Songwriter Mode**: new guided multi-step flow (choose key/scale → build progression → add lyrics → transpose → review & save) accessible from the Create section drawer/sidebar
- **Scale-aware chord suggestions**: verified already complete on both platforms — no code changes needed

Implements [spec 14 – Composition Tools](docs/spec/14-composition-tools.md).

### Files changed

| Area | Files |
|------|-------|
| Android UI | `SongbookTab.kt`, `ProgressionsTab.kt`, `MelodyNotepadView.kt`, `FretboardScreen.kt`, new `SongwriterModeFlow.kt` |
| Android VM | `SongbookViewModel.kt`, `MelodyViewModel.kt` |
| Android res | `strings.xml` |
| iOS UI | `SongbookView.swift`, `ProgressionsView.swift`, `MelodyNotepadView.swift`, `CreateView.swift`, `ContentView.swift`, new `SongwriterModeFlow.swift` |
| iOS VM | `MelodyViewModel.swift` |

## Test plan

- [ ] Android: open a chord sheet, transpose it, tap "Save in this key", verify the key persists after navigating away
- [ ] Android: tap share on a chord sheet, verify ChordPro / plain text / clipboard options work
- [ ] Android: tap copy icon on a progression card, verify clipboard contains formatted progression
- [ ] Android: open Melody Notepad, toggle to "Step Sequencer", tap cells to assign pitches, play with loop
- [ ] Android: open "Start a Song" from the Create drawer, walk through all 5 steps, save
- [ ] Android: verify TalkBack reads all new controls correctly
- [ ] iOS: same flow for Save in this key, share format picker, clipboard copy
- [ ] iOS: same flow for Step Sequencer mode in Melody Notepad
- [ ] iOS: open "Start a Song" from Create tab, complete the flow
- [ ] iOS: verify VoiceOver reads all new controls correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Start a Song" 5‑step songwriting flow (key/scale, progression builder, lyrics, transpose, save).
  * Step Sequencer mode: expandable 8/16‑step grid with per‑step pitch/duration editing, playback and looping.

* **Improvements**
  * Copy‑to‑clipboard for progressions and sheets.
  * Unified share/export modal with ChordPro and plain‑text options and transpose preview.
  * "Save in this key" persists transposed songs and shows confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->