### PR TITLE
Fix: guard all MonkeyTest cases behind RUN_STRESS_TESTS (iOS CI flakiness)

### DIFF
--- a/iosApp/UkuleleCompanionUITests/MonkeyTest.swift
+++ b/iosApp/UkuleleCompanionUITests/MonkeyTest.swift
@@ -58,7 +58,7 @@ final class MonkeyTest: XCTestCase {
 
     override func tearDownWithError() throws {
         XCUIDevice.shared.orientation = .portrait
-        app.terminate()
+        app?.terminate()
     }
 
     // MARK: - Main Monkey Test


### PR DESCRIPTION
## Summary
- Add `RUN_STRESS_TESTS` guard to `setUpWithError()` so the app launch and retry logic is skipped entirely when stress tests are disabled, eliminating "background assertion timeout" failures
- Add `RUN_STRESS_TESTS` guard to `testAllScreensNavigation()` — the only test method missing the check, causing it to run and flake in every CI build

Closes #71

## Test plan
- [ ] iOS CI workflow (`ios.yml`) passes without `RUN_STRESS_TESTS` — all MonkeyTest cases should be skipped
- [ ] iOS stress workflow (`ios-stress.yml`) with `RUN_STRESS_TESTS=1` — all MonkeyTest cases should execute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added ability to skip stress/monkey UI tests unless a specific environment flag is set, making test runs more predictable.
  * Improved test teardown to avoid crashes when the app instance was not initialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->