### PR TITLE
Add: coverage reporting for Android instrumented tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -140,13 +140,13 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run instrumented tests
+      - name: Run instrumented tests with coverage
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          script: ./gradlew connectedAndroidTest
+          script: ./gradlew createDebugAndroidTestCoverageReport
 
       - name: Upload instrumented test report
         if: always()
@@ -154,6 +154,14 @@ jobs:
         with:
           name: instrumented-test-report-api${{ matrix.api-level }}
           path: app/build/reports/androidTests/connected/
+
+      - name: Upload instrumented test coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: app/build/reports/coverage/androidTest/debug/report.xml
+          flags: android-instrumented-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   dependency-review:
     name: Dependency Review

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ android {
     buildTypes {
         debug {
             enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
         }
         release {
             isMinifyEnabled = true

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,10 @@ flags:
       - app/src/main/
       - shared/src/
     carryforward: true
+  android-instrumented-tests:
+    paths:
+      - app/src/main/
+    carryforward: true
   ios-tests:
     paths:
       - iosApp/UkuleleCompanion/


### PR DESCRIPTION
## Summary

- Enables JaCoCo coverage collection for Android instrumented tests (`connectedAndroidTest`) and uploads reports to Codecov
- Adds `enableAndroidTestCoverage = true` to the debug build type in `app/build.gradle.kts`
- Switches the CI emulator runner script to `createDebugAndroidTestCoverageReport` (runs tests AND generates JaCoCo XML report)
- Adds a Codecov upload step with `android-instrumented-tests` flag and carryforward support in `codecov.yml`

Closes #69

## Test plan

- [ ] CI `instrumented-tests` job passes with the new Gradle task
- [ ] Codecov receives the instrumented test coverage report with the `android-instrumented-tests` flag
- [ ] Existing unit test coverage upload continues working unchanged
- [ ] Coverage report appears in Codecov PR comment with the new flag

Made with [Cursor](https://cursor.com)