### PR TITLE
Add: Kover coverage for shared KMP module

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,6 +37,40 @@ jobs:
           name: lint-report
           path: app/build/reports/lint-results-debug.html
 
+  shared-tests:
+    name: Shared Module Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run shared tests with coverage
+        run: ./gradlew :shared:koverXmlReport
+
+      - name: Upload shared coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shared-coverage-report
+          path: shared/build/reports/kover/report.xml
+
+      - name: Upload shared coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: shared/build/reports/kover/report.xml
+          flags: shared-tests
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.kover) apply false
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,6 +19,10 @@ flags:
     paths:
       - app/src/main/
     carryforward: true
+  shared-tests:
+    paths:
+      - shared/src/
+    carryforward: true
   ios-tests:
     paths:
       - iosApp/UkuleleCompanion/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ junit5 = "5.11.4"
 material = "1.13.0"
 kotest = "6.1.7"
 jazzer = "0.22.1"
+kover = "0.9.7"
 
 [libraries]
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
@@ -55,3 +56,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,9 +2,12 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kmp.library)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 kotlin {
+    jvm()
+
     androidLibrary {
         namespace = "com.baijum.ukufretboard.shared"
         compileSdk = 36

--- a/shared/src/jvmMain/kotlin/com/baijum/ukufretboard/platform/PlatformUtils.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/baijum/ukufretboard/platform/PlatformUtils.jvm.kt
@@ -1,0 +1,12 @@
+package com.baijum.ukufretboard.platform
+
+import java.util.Calendar
+import java.util.UUID
+
+actual fun generateUuid(): String = UUID.randomUUID().toString()
+
+actual fun currentTimeMillis(): Long = System.currentTimeMillis()
+
+actual fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)
+
+actual fun currentDayOfYear(): Int = Calendar.getInstance().get(Calendar.DAY_OF_YEAR)


### PR DESCRIPTION
## Summary
- Adds JetBrains Kover (v0.9.7) plugin to the `:shared` module for coverage reporting of `commonMain` business logic
- Adds a JVM target to the shared module so `commonTest` tests run on JVM, enabling Kover bytecode instrumentation
- Adds JVM `actual` implementations for the 4 `expect` platform functions (identical to Android actuals)
- Adds `shared-tests` CI job to the Android workflow that runs `./gradlew :shared:koverXmlReport` and uploads to Codecov
- Adds `shared-tests` Codecov flag covering `shared/src/`

Closes #70

## Test plan
- [x] `./gradlew :shared:koverXmlReport` generates XML report at `shared/build/reports/kover/report.xml` with coverage data
- [x] `./gradlew :app:assembleDebug` still builds successfully
- [x] `./gradlew :app:testDebugUnitTest` passes all existing tests
- [ ] CI `shared-tests` job passes and uploads coverage to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JVM platform support to the shared module.

* **Tests**
  * Established automated code coverage reporting and analysis pipeline for the shared module with Codecov integration.

* **Chores**
  * Added code coverage tool plugin to the build configuration with version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->