### PR TITLE
Move: domain tests to shared commonTest for Kover coverage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,7 +114,6 @@ dependencies {
     implementation(libs.play.review)
     implementation(libs.play.review.ktx)
     testImplementation(libs.junit)
-    testImplementation(libs.kotest.property)
     testImplementation(libs.jazzer.junit)
     testImplementation(libs.jazzer.api)
     testRuntimeOnly(libs.junit.vintage.engine)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ lifecycleViewmodelCompose = "2.10.0"
 appcompat = "1.7.1"
 coreKtx = "1.18.0"
 
+kotlinxCoroutines = "1.10.2"
 kotlinxSerializationJson = "1.10.0"
 kotlinxSerialization = "2.3.10"
 reorderable = "3.0.0"
@@ -36,6 +37,7 @@ material-icons-extended = { group = "androidx.compose.material", name = "materia
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 onnxruntime-android = { group = "com.microsoft.onnxruntime", name = "onnxruntime-android", version.ref = "onnxruntime" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -31,6 +31,8 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotest.property)
+            implementation(libs.kotlinx.coroutines.core)
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/AudioResamplerTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/AudioResamplerTest.kt
@@ -1,11 +1,11 @@
 package com.baijum.ukufretboard.domain
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [AudioResampler].
@@ -14,6 +14,10 @@ import kotlin.math.sin
  * low-frequency content while attenuating high frequencies.
  */
 class AudioResamplerTest {
+
+    private fun assertApproxEquals(expected: Float, actual: Float, tolerance: Float, message: String? = null) {
+        assertTrue(abs(expected - actual) <= tolerance, message ?: "Expected $expected ± $tolerance but was $actual")
+    }
 
     @Test
     fun outputLengthIsCorrect() {
@@ -46,8 +50,8 @@ class AudioResamplerTest {
         // Check that it's not all zeros and has reasonable amplitude
         val maxAbs = output.maxOf { abs(it) }
         assertTrue(
-            "Low-frequency content should be preserved (max amplitude $maxAbs)",
             maxAbs > 0.7f,
+            "Low-frequency content should be preserved (max amplitude $maxAbs)",
         )
     }
 
@@ -57,11 +61,11 @@ class AudioResamplerTest {
         val output = AudioResampler.downsample44kTo16k(input)
 
         for (i in output.indices) {
-            assertEquals(
-                "DC level should be preserved at sample $i",
+            assertApproxEquals(
                 0.75f,
                 output[i],
                 0.05f,
+                "DC level should be preserved at sample $i",
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/CapoCalculatorPropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/CapoCalculatorPropertyTest.kt
@@ -1,14 +1,13 @@
 package com.baijum.ukufretboard.domain
 
 import com.baijum.ukufretboard.data.ChordFormulas
-import com.baijum.ukufretboard.viewmodel.UkuleleString
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class CapoCalculatorPropertyTest {
 
@@ -28,8 +27,8 @@ class CapoCalculatorPropertyTest {
                 val results = CapoCalculator.forSingleChord(root, formula, standardTuning)
                 for (result in results) {
                     assertTrue(
-                        "Capo fret ${result.capoFret} should be in 0..11",
                         result.capoFret in 0..11,
+                        "Capo fret ${result.capoFret} should be in 0..11",
                     )
                 }
             }
@@ -43,8 +42,8 @@ class CapoCalculatorPropertyTest {
                 val results = CapoCalculator.forSingleChord(root, formula, standardTuning)
                 for (i in 1 until results.size) {
                     assertTrue(
-                        "Results should be sorted by score descending",
                         results[i - 1].score >= results[i].score,
+                        "Results should be sorted by score descending",
                     )
                 }
             }
@@ -58,8 +57,8 @@ class CapoCalculatorPropertyTest {
                 val results = CapoCalculator.forSingleChord(root, formula, standardTuning)
                 for (result in results) {
                     assertTrue(
-                        "Sounding name '${result.soundingName}' should end with '${formula.symbol}'",
                         result.soundingName.endsWith(formula.symbol),
+                        "Sounding name '${result.soundingName}' should end with '${formula.symbol}'",
                     )
                 }
             }
@@ -83,8 +82,8 @@ class CapoCalculatorPropertyTest {
                 for (result in results) {
                     for (fret in result.bestVoicing.frets) {
                         assertTrue(
-                            "Fret $fret should be >= -1 (muted) and <= 15",
                             fret in -1..15,
+                            "Fret $fret should be >= -1 (muted) and <= 15",
                         )
                     }
                 }
@@ -99,8 +98,8 @@ class CapoCalculatorPropertyTest {
                 val results = CapoCalculator.forSingleChord(root, formula, standardTuning)
                 if (results.isNotEmpty()) {
                     assertTrue(
-                        "Capo 0 (no capo) should be among results",
                         results.any { it.capoFret == 0 },
+                        "Capo 0 (no capo) should be among results",
                     )
                 }
             }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordDetectorPropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordDetectorPropertyTest.kt
@@ -7,8 +7,8 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class ChordDetectorPropertyTest {
 
@@ -24,8 +24,8 @@ class ChordDetectorPropertyTest {
             checkAll(Arb.int(0..11)) { pc ->
                 val result = ChordDetector.detect(listOf(pc))
                 assertTrue(
-                    "Single pitch class $pc should yield SingleNote, got $result",
                     result is ChordDetector.DetectionResult.SingleNote,
+                    "Single pitch class $pc should yield SingleNote, got $result",
                 )
             }
         }
@@ -38,8 +38,8 @@ class ChordDetectorPropertyTest {
                 if (a != b) {
                     val result = ChordDetector.detect(listOf(a, b))
                     assertTrue(
-                        "Two distinct pitch classes should yield Interval, got $result",
                         result is ChordDetector.DetectionResult.Interval,
+                        "Two distinct pitch classes should yield Interval, got $result",
                     )
                 }
             }
@@ -53,8 +53,8 @@ class ChordDetectorPropertyTest {
                 val duplicated = List(count) { pc }
                 val result = ChordDetector.detect(duplicated)
                 assertTrue(
-                    "Duplicated single pitch class should yield SingleNote, got $result",
                     result is ChordDetector.DetectionResult.SingleNote,
+                    "Duplicated single pitch class should yield SingleNote, got $result",
                 )
             }
         }
@@ -76,8 +76,8 @@ class ChordDetectorPropertyTest {
                 val pitchClasses = formula.intervals.map { (root + it) % 12 }
                 val result = ChordDetector.detect(pitchClasses)
                 assertTrue(
-                    "Root $root + ${formula.symbol} should yield ChordFound, got $result",
                     result is ChordDetector.DetectionResult.ChordFound,
+                    "Root $root + ${formula.symbol} should yield ChordFound, got $result",
                 )
             }
         }
@@ -91,8 +91,8 @@ class ChordDetectorPropertyTest {
                 val result = ChordDetector.detect(pitchClasses)
                 if (result is ChordDetector.DetectionResult.ChordFound) {
                     assertTrue(
-                        "Root ${result.result.root.pitchClass} should be in input $pitchClasses",
                         result.result.root.pitchClass in pitchClasses,
+                        "Root ${result.result.root.pitchClass} should be in input $pitchClasses",
                     )
                 }
             }
@@ -109,8 +109,8 @@ class ChordDetectorPropertyTest {
                     val detectedPcs = result.result.notes.map { it.pitchClass }.toSet()
                     val inputPcs = pitchClasses.toSet()
                     assertTrue(
-                        "Detected pitch classes $detectedPcs should equal input $inputPcs",
                         detectedPcs == inputPcs,
+                        "Detected pitch classes $detectedPcs should equal input $inputPcs",
                     )
                 }
             }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordNameParserPropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordNameParserPropertyTest.kt
@@ -8,10 +8,10 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class ChordNameParserPropertyTest {
 
@@ -45,7 +45,7 @@ class ChordNameParserPropertyTest {
             ) { root, symbol ->
                 val input = "$root$symbol"
                 val result = ChordNameParser.parse(input)
-                assertNotNull("Should parse '$input'", result)
+                assertNotNull(result, "Should parse '$input'")
             }
         }
     }
@@ -59,8 +59,8 @@ class ChordNameParserPropertyTest {
             ) { root, symbol ->
                 val result = ChordNameParser.parse("$root$symbol") ?: return@checkAll
                 assertTrue(
-                    "rootPitchClass ${result.rootPitchClass} should be in 0..11",
                     result.rootPitchClass in 0..11,
+                    "rootPitchClass ${result.rootPitchClass} should be in 0..11",
                 )
             }
         }
@@ -75,8 +75,8 @@ class ChordNameParserPropertyTest {
             ) { root, symbol ->
                 val result = ChordNameParser.parse("$root$symbol") ?: return@checkAll
                 assertTrue(
-                    "displayName '${result.displayName}' should contain symbol '$symbol'",
                     result.displayName.contains(symbol),
+                    "displayName '${result.displayName}' should contain symbol '$symbol'",
                 )
             }
         }
@@ -98,8 +98,8 @@ class ChordNameParserPropertyTest {
             checkAll(Arb.element(allRootNames)) { root ->
                 val results = ChordNameParser.suggestions(root)
                 assertTrue(
-                    "Root-only query '$root' should return multiple suggestions, got ${results.size}",
                     results.size > 1,
+                    "Root-only query '$root' should return multiple suggestions, got ${results.size}",
                 )
             }
         }
@@ -112,9 +112,9 @@ class ChordNameParserPropertyTest {
                 val results = ChordNameParser.suggestions(root)
                 val symbols = results.map { it.formula.symbol }
                 assertEquals(
-                    "Suggestions for '$root' should have unique symbols",
                     symbols.size,
                     symbols.distinct().size,
+                    "Suggestions for '$root' should have unique symbols",
                 )
             }
         }
@@ -127,12 +127,12 @@ class ChordNameParserPropertyTest {
             checkAll(Arb.element(roots)) { lowerRoot ->
                 val lower = ChordNameParser.parse(lowerRoot)
                 val upper = ChordNameParser.parse(lowerRoot.uppercase())
-                assertNotNull("Should parse lowercase root '$lowerRoot'", lower)
-                assertNotNull("Should parse uppercase root '${lowerRoot.uppercase()}'", upper)
+                assertNotNull(lower, "Should parse lowercase root '$lowerRoot'")
+                assertNotNull(upper, "Should parse uppercase root '${lowerRoot.uppercase()}'")
                 assertEquals(
+                    lower.rootPitchClass,
+                    upper.rootPitchClass,
                     "Case should not affect pitch class",
-                    lower!!.rootPitchClass,
-                    upper!!.rootPitchClass,
                 )
             }
         }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
@@ -7,9 +7,9 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ChordSheetTransposePropertyTest {
 
@@ -48,9 +48,9 @@ class ChordSheetTransposePropertyTest {
                 val transposed = ChordSheetTranspose.transpose(content, semitones)
                 val roundTrip = ChordSheetTranspose.transpose(transposed, -semitones)
                 assertEquals(
-                    "Transpose +$semitones then -$semitones should round-trip",
                     content,
                     roundTrip,
+                    "Transpose +$semitones then -$semitones should round-trip",
                 )
             }
         }
@@ -68,9 +68,9 @@ class ChordSheetTransposePropertyTest {
             )
             checkAll(Arb.element(plainTexts), Arb.int(-11..11)) { text, semitones ->
                 assertEquals(
-                    "Plain text should be unchanged",
                     text,
                     ChordSheetTranspose.transpose(text, semitones),
+                    "Plain text should be unchanged",
                 )
             }
         }
@@ -88,8 +88,8 @@ class ChordSheetTransposePropertyTest {
                 val content = "[$root$suffix]"
                 val transposed = ChordSheetTranspose.transpose(content, semitones)
                 assertTrue(
-                    "Transposed '$transposed' should still contain suffix '$suffix'",
                     transposed.contains("$suffix]"),
+                    "Transposed '$transposed' should still contain suffix '$suffix'",
                 )
             }
         }
@@ -117,8 +117,8 @@ class ChordSheetTransposePropertyTest {
                 val transposed = ChordSheetTranspose.transpose(content, semitones)
                 val newRoot = transposed.removePrefix("[").removeSuffix("]")
                 assertTrue(
-                    "'$newRoot' should be a valid note name",
                     newRoot in validRoots,
+                    "'$newRoot' should be a valid note name",
                 )
             }
         }
@@ -130,11 +130,11 @@ class ChordSheetTransposePropertyTest {
             checkAll(Arb.int(-24..24)) { semitones ->
                 val label = ChordSheetTranspose.semitoneLabel(semitones)
                 if (semitones > 0) {
-                    assertTrue("Positive should start with +", label.startsWith("+"))
+                    assertTrue(label.startsWith("+"), "Positive should start with +")
                 }
                 assertTrue(
-                    "Label should contain the number",
                     label.contains(semitones.toString().trimStart('-')),
+                    "Label should contain the number",
                 )
             }
         }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FFTProcessorPropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FFTProcessorPropertyTest.kt
@@ -5,12 +5,13 @@ import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.float
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sin
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FFTProcessorPropertyTest {
 
@@ -23,7 +24,7 @@ class FFTProcessorPropertyTest {
         runBlocking {
             val sizes = listOf(64, 128, 256, 512)
             checkAll(100, Arb.element(sizes)) { n ->
-                val original = FloatArray(n) { (Math.random() * 2 - 1).toFloat() }
+                val original = FloatArray(n) { (Random.nextDouble() * 2 - 1).toFloat() }
                 val real = original.copyOf()
                 val imag = FloatArray(n)
 
@@ -32,8 +33,8 @@ class FFTProcessorPropertyTest {
 
                 for (i in 0 until n) {
                     assertTrue(
-                        "Sample $i: expected ${original[i]}, got ${real[i]}",
                         abs(real[i] - original[i]) < TOLERANCE,
+                        "Sample $i: expected ${original[i]}, got ${real[i]}",
                     )
                 }
             }
@@ -52,12 +53,12 @@ class FFTProcessorPropertyTest {
 
                 for (i in 0 until n) {
                     assertTrue(
-                        "Bin $i real should be ~0, was ${real[i]}",
                         abs(real[i]) < 1e-6f,
+                        "Bin $i real should be ~0, was ${real[i]}",
                     )
                     assertTrue(
-                        "Bin $i imag should be ~0, was ${imag[i]}",
                         abs(imag[i]) < 1e-6f,
+                        "Bin $i imag should be ~0, was ${imag[i]}",
                     )
                 }
             }
@@ -83,7 +84,7 @@ class FFTProcessorPropertyTest {
                         maxBin = i
                     }
                 }
-                assertEquals("Peak should be at bin $bin", bin, maxBin)
+                assertEquals(bin, maxBin, "Peak should be at bin $bin")
             }
         }
     }
@@ -105,14 +106,14 @@ class FFTProcessorPropertyTest {
     fun magnitudeSpectrumValuesAreNonNegative() {
         runBlocking {
             checkAll(100, Arb.element(listOf(64, 128, 256))) { n ->
-                val real = FloatArray(n) { (Math.random() * 2 - 1).toFloat() }
+                val real = FloatArray(n) { (Random.nextDouble() * 2 - 1).toFloat() }
                 val imag = FloatArray(n)
 
                 FFTProcessor.fft(real, imag)
                 val mag = FFTProcessor.magnitudeSpectrum(real, imag)
 
                 for (i in mag.indices) {
-                    assertTrue("Magnitude[$i] should be >= 0, was ${mag[i]}", mag[i] >= 0f)
+                    assertTrue(mag[i] >= 0f, "Magnitude[$i] should be >= 0, was ${mag[i]}")
                 }
             }
         }
@@ -139,8 +140,8 @@ class FFTProcessorPropertyTest {
                     val windowed = FFTProcessor.hanningWindow(samples)
                     for (i in windowed.indices) {
                         assertTrue(
-                            "Windowed[$i]=${windowed[i]} should not exceed abs(input)=${abs(value)}",
                             abs(windowed[i]) <= abs(value) + 1e-6f,
+                            "Windowed[$i]=${windowed[i]} should not exceed abs(input)=${abs(value)}",
                         )
                     }
                 }
@@ -154,7 +155,7 @@ class FFTProcessorPropertyTest {
         for (n in badSizes) {
             try {
                 FFTProcessor.fft(FloatArray(n), FloatArray(n))
-                assertTrue("Should have thrown for size $n", false)
+                assertTrue(false, "Should have thrown for size $n")
             } catch (_: IllegalArgumentException) {
                 // expected
             }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FFTProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FFTProcessorTest.kt
@@ -1,11 +1,11 @@
 package com.baijum.ukufretboard.domain
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [FFTProcessor].
@@ -19,6 +19,10 @@ class FFTProcessorTest {
         private const val TOLERANCE = 1e-3f
     }
 
+    private fun assertApproxEquals(expected: Float, actual: Float, tolerance: Float, message: String? = null) {
+        assertTrue(abs(expected - actual) <= tolerance, message ?: "Expected $expected ± $tolerance but was $actual")
+    }
+
     @Test
     fun fftOfDcSignalHasEnergyOnlyInBinZero() {
         val n = 256
@@ -27,18 +31,18 @@ class FFTProcessorTest {
 
         FFTProcessor.fft(real, imag)
 
-        assertEquals("DC component should equal N", n.toFloat(), real[0], TOLERANCE)
-        assertEquals("Imaginary DC should be 0", 0f, imag[0], TOLERANCE)
+        assertApproxEquals(n.toFloat(), real[0], TOLERANCE, "DC component should equal N")
+        assertApproxEquals(0f, imag[0], TOLERANCE, "Imaginary DC should be 0")
 
         // All other bins should be near zero
         for (i in 1 until n) {
             assertTrue(
-                "Bin $i real should be near zero, was ${real[i]}",
                 abs(real[i]) < TOLERANCE,
+                "Bin $i real should be near zero, was ${real[i]}",
             )
             assertTrue(
-                "Bin $i imag should be near zero, was ${imag[i]}",
                 abs(imag[i]) < TOLERANCE,
+                "Bin $i imag should be near zero, was ${imag[i]}",
             )
         }
     }
@@ -67,7 +71,7 @@ class FFTProcessorTest {
                 maxBin = i
             }
         }
-        assertEquals("Peak should be at bin $binIndex", binIndex, maxBin)
+        assertEquals(binIndex, maxBin, "Peak should be at bin $binIndex")
     }
 
     @Test
@@ -86,11 +90,11 @@ class FFTProcessorTest {
         FFTProcessor.ifft(real, imag)
 
         for (i in 0 until n) {
-            assertEquals(
-                "Sample $i should be recovered after FFT→IFFT",
+            assertApproxEquals(
                 original[i],
                 real[i],
                 TOLERANCE,
+                "Sample $i should be recovered after FFT→IFFT",
             )
         }
     }
@@ -110,10 +114,10 @@ class FFTProcessorTest {
         val samples = FloatArray(n) { 1.0f }
         val windowed = FFTProcessor.hanningWindow(samples)
 
-        assertEquals("First sample should be near zero", 0f, windowed[0], 0.01f)
-        assertEquals("Last sample should be near zero", 0f, windowed[n - 1], 0.01f)
+        assertApproxEquals(0f, windowed[0], 0.01f, "First sample should be near zero")
+        assertApproxEquals(0f, windowed[n - 1], 0.01f, "Last sample should be near zero")
         // Middle should be near 1.0
-        assertTrue("Middle sample should be near 1.0", windowed[n / 2] > 0.9f)
+        assertTrue(windowed[n / 2] > 0.9f, "Middle sample should be near 1.0")
     }
 
     @Test
@@ -129,8 +133,8 @@ class FFTProcessorTest {
         FFTProcessor.fft(real2, imag2)
 
         for (i in 0 until n) {
-            assertEquals("Real[$i] should match", real1[i], real2[i], 1e-6f)
-            assertEquals("Imag[$i] should match", imag1[i], imag2[i], 1e-6f)
+            assertApproxEquals(real1[i], real2[i], 1e-6f, "Real[$i] should match")
+            assertApproxEquals(imag1[i], imag2[i], 1e-6f, "Imag[$i] should match")
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PitchDetectorPropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PitchDetectorPropertyTest.kt
@@ -6,13 +6,14 @@ import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sin
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PitchDetectorPropertyTest {
 
@@ -64,11 +65,11 @@ class PitchDetectorPropertyTest {
             checkAll(Arb.element(ukuleleFrequencies)) { freq ->
                 val samples = generateSine(freq, SAMPLE_RATE, BUFFER_SIZE)
                 val result = PitchDetector.detect(samples, SAMPLE_RATE)
-                assertNotNull("Should detect pitch for ${freq}Hz", result)
-                val error = abs(result!!.frequencyHz - freq)
+                assertNotNull(result, "Should detect pitch for ${freq}Hz")
+                val error = abs(result.frequencyHz - freq)
                 assertTrue(
-                    "Detected ${result.frequencyHz}Hz should be within 2% of ${freq}Hz (error=$error)",
                     error / freq < 0.02,
+                    "Detected ${result.frequencyHz}Hz should be within 2% of ${freq}Hz (error=$error)",
                 )
             }
         }
@@ -83,12 +84,12 @@ class PitchDetectorPropertyTest {
                 val result = PitchDetector.detect(samples, SAMPLE_RATE)
                 if (result != null) {
                     assertTrue(
-                        "Frequency ${result.frequencyHz} should be >= 65Hz",
                         result.frequencyHz >= 65.0,
+                        "Frequency ${result.frequencyHz} should be >= 65Hz",
                     )
                     assertTrue(
-                        "Frequency ${result.frequencyHz} should be <= 1100Hz",
                         result.frequencyHz <= 1100.0,
+                        "Frequency ${result.frequencyHz} should be <= 1100Hz",
                     )
                 }
             }
@@ -104,8 +105,8 @@ class PitchDetectorPropertyTest {
                 val result = PitchDetector.detect(samples, SAMPLE_RATE)
                 if (result != null) {
                     assertTrue(
-                        "Confidence ${result.confidence} should be >= 0",
                         result.confidence >= 0.0,
+                        "Confidence ${result.confidence} should be >= 0",
                     )
                 }
             }
@@ -122,7 +123,7 @@ class PitchDetectorPropertyTest {
     fun rmsIsNonNegative() {
         runBlocking {
             checkAll(100, Arb.int(10..1000)) { size ->
-                val samples = FloatArray(size) { (Math.random() * 2 - 1).toFloat() }
+                val samples = FloatArray(size) { (Random.nextDouble() * 2 - 1).toFloat() }
                 assertTrue(PitchDetector.rms(samples) >= 0f)
             }
         }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PitchDetectorTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PitchDetectorTest.kt
@@ -1,13 +1,13 @@
 package com.baijum.ukufretboard.domain
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [PitchDetector] using synthetic sine waves.
@@ -32,6 +32,14 @@ class PitchDetectorTest {
         private const val AMPLITUDE = 0.5f
     }
 
+    private fun assertApproxEquals(expected: Double, actual: Double, tolerance: Double, message: String? = null) {
+        assertTrue(abs(expected - actual) <= tolerance, message ?: "Expected $expected ± $tolerance but was $actual")
+    }
+
+    private fun assertApproxEquals(expected: Float, actual: Float, tolerance: Float, message: String? = null) {
+        assertTrue(abs(expected - actual) <= tolerance, message ?: "Expected $expected ± $tolerance but was $actual")
+    }
+
     /** Generates a pure sine wave at [frequencyHz]. */
     private fun sineWave(
         frequencyHz: Double,
@@ -53,32 +61,32 @@ class PitchDetectorTest {
     fun detectsA4_440Hz() {
         val samples = sineWave(440.0)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect A4 (440 Hz)", result)
-        assertEquals(440.0, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect A4 (440 Hz)")
+        assertApproxEquals(440.0, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
     fun detectsC4_262Hz() {
         val samples = sineWave(261.63)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect C4 (~262 Hz)", result)
-        assertEquals(261.63, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect C4 (~262 Hz)")
+        assertApproxEquals(261.63, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
     fun detectsE4_330Hz() {
         val samples = sineWave(329.63)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect E4 (~330 Hz)", result)
-        assertEquals(329.63, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect E4 (~330 Hz)")
+        assertApproxEquals(329.63, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
     fun detectsG4_392Hz() {
         val samples = sineWave(392.0)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect G4 (392 Hz)", result)
-        assertEquals(392.0, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect G4 (392 Hz)")
+        assertApproxEquals(392.0, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
@@ -86,17 +94,17 @@ class PitchDetectorTest {
         // Lowest standard ukulele string (Baritone)
         val samples = sineWave(146.83)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect D3 (~147 Hz)", result)
-        assertEquals(146.83, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect D3 (~147 Hz)")
+        assertApproxEquals(146.83, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
     fun detectsHighFrequency_880Hz() {
         val samples = sineWave(880.0)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect A5 (880 Hz)", result)
+        assertNotNull(result, "Should detect A5 (880 Hz)")
         // Higher frequencies have less lag resolution → wider tolerance.
-        assertEquals(880.0, result!!.frequencyHz, 5.0)
+        assertApproxEquals(880.0, result.frequencyHz, 5.0)
     }
 
     @Test
@@ -104,8 +112,8 @@ class PitchDetectorTest {
         // G3 = 196 Hz — Low-G ukulele tuning string
         val samples = sineWave(196.0)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNotNull("Should detect G3 (196 Hz)", result)
-        assertEquals(196.0, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect G3 (196 Hz)")
+        assertApproxEquals(196.0, result.frequencyHz, TOLERANCE_HZ)
     }
 
     // --- Silence / noise rejection -------------------------------------------
@@ -114,7 +122,7 @@ class PitchDetectorTest {
     fun rejectsSilence() {
         val samples = FloatArray(FRAME_SIZE) // all zeros
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNull("Should return null for silence", result)
+        assertNull(result, "Should return null for silence")
     }
 
     @Test
@@ -122,7 +130,7 @@ class PitchDetectorTest {
         // Below the silence threshold (RMS < 0.01)
         val samples = sineWave(440.0, amplitude = 0.005f)
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNull("Should return null for very quiet signal", result)
+        assertNull(result, "Should return null for very quiet signal")
     }
 
     // --- Confidence ----------------------------------------------------------
@@ -133,8 +141,8 @@ class PitchDetectorTest {
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
         assertNotNull(result)
         assertTrue(
-            "Confidence (CMND dip) should be low for a clean sine wave, was ${result!!.confidence}",
             result.confidence < 0.1,
+            "Confidence (CMND dip) should be low for a clean sine wave, was ${result.confidence}",
         )
     }
 
@@ -149,8 +157,8 @@ class PitchDetectorTest {
             SAMPLE_RATE,
             previousFrequency = 435.0,
         )
-        assertNotNull("Should detect with continuity constraint", result)
-        assertEquals(440.0, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should detect with continuity constraint")
+        assertApproxEquals(440.0, result.frequencyHz, TOLERANCE_HZ)
     }
 
     @Test
@@ -162,8 +170,8 @@ class PitchDetectorTest {
             SAMPLE_RATE,
             previousFrequency = 440.0,
         )
-        assertNotNull("Should fall back to full range on string switch", result)
-        assertEquals(261.63, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Should fall back to full range on string switch")
+        assertApproxEquals(261.63, result.frequencyHz, TOLERANCE_HZ)
     }
 
     // --- RMS utility ---------------------------------------------------------
@@ -171,7 +179,7 @@ class PitchDetectorTest {
     @Test
     fun rmsOfSilenceIsZero() {
         val samples = FloatArray(1024)
-        assertEquals(0f, PitchDetector.rms(samples), 1e-6f)
+        assertApproxEquals(0f, PitchDetector.rms(samples), 1e-6f)
     }
 
     @Test
@@ -179,7 +187,7 @@ class PitchDetectorTest {
         val samples = sineWave(440.0, numSamples = 1024, amplitude = 1.0f)
         val rms = PitchDetector.rms(samples)
         // RMS of a sine wave with amplitude A is A / sqrt(2) ≈ 0.707
-        assertEquals(0.707f, rms, 0.02f)
+        assertApproxEquals(0.707f, rms, 0.02f)
     }
 
     // --- Edge cases ----------------------------------------------------------
@@ -188,7 +196,7 @@ class PitchDetectorTest {
     fun handlesTinyBuffer() {
         val samples = FloatArray(2) { 0.5f }
         val result = PitchDetector.detect(samples, SAMPLE_RATE)
-        assertNull("Should return null for a buffer too small for YIN", result)
+        assertNull(result, "Should return null for a buffer too small for YIN")
     }
 
     @Test
@@ -196,7 +204,7 @@ class PitchDetectorTest {
         val samples = sineWave(440.0)
         // Very strict threshold — clean sine should still pass
         val result = PitchDetector.detect(samples, SAMPLE_RATE, threshold = 0.05)
-        assertNotNull("Clean sine should pass strict threshold", result)
-        assertEquals(440.0, result!!.frequencyHz, TOLERANCE_HZ)
+        assertNotNull(result, "Clean sine should pass strict threshold")
+        assertApproxEquals(440.0, result.frequencyHz, TOLERANCE_HZ)
     }
 }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/TransposePropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/TransposePropertyTest.kt
@@ -5,9 +5,9 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TransposePropertyTest {
 
@@ -17,8 +17,8 @@ class TransposePropertyTest {
             checkAll(Arb.int(-1000..1000), Arb.int(-1000..1000)) { pitchClass, semitones ->
                 val result = Transpose.transposePitchClass(pitchClass, semitones)
                 assertTrue(
-                    "Result $result should be in 0..11",
                     result in 0..11,
+                    "Result $result should be in 0..11",
                 )
             }
         }
@@ -80,8 +80,8 @@ class TransposePropertyTest {
                 for (symbol in symbols) {
                     val result = Transpose.transposeChordName(rootPc, symbol, semitones)
                     assertTrue(
-                        "Chord name '$result' should end with '$symbol'",
                         result.endsWith(symbol),
+                        "Chord name '$result' should end with '$symbol'",
                     )
                 }
             }
@@ -94,8 +94,8 @@ class TransposePropertyTest {
             checkAll(Arb.int(0..11), Arb.int(-24..24)) { rootPc, semitones ->
                 val result = Transpose.transposeChordName(rootPc, "", semitones)
                 assertTrue(
-                    "'$result' should be a valid note name",
                     result in Notes.NOTE_NAMES_STANDARD,
+                    "'$result' should be a valid note name",
                 )
             }
         }
@@ -107,8 +107,8 @@ class TransposePropertyTest {
             checkAll(Arb.int(0..11), Arb.int(0..11)) { original, target ->
                 val capo = Transpose.capoFret(original, target)
                 assertTrue(
-                    "Capo fret $capo should be in 0..11",
                     capo in 0..11,
+                    "Capo fret $capo should be in 0..11",
                 )
             }
         }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapperTest.kt
@@ -1,12 +1,13 @@
 package com.baijum.ukufretboard.domain
 
 import com.baijum.ukufretboard.data.UkuleleTuning
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
 import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [TunerNoteMapper].
@@ -26,10 +27,10 @@ class TunerNoteMapperTest {
     fun mapsA4Correctly() {
         val note = TunerNoteMapper.mapFrequency(440.0)
         assertNotNull(note)
-        assertEquals("A", note!!.noteName)
+        assertEquals("A", note.noteName)
         assertEquals(4, note.octave)
         assertEquals(9, note.pitchClass) // A = 9
-        assertTrue("Cents should be near zero", abs(note.centsDeviation) < 0.5)
+        assertTrue(abs(note.centsDeviation) < 0.5, "Cents should be near zero")
     }
 
     @Test
@@ -37,7 +38,7 @@ class TunerNoteMapperTest {
         // C4 = 261.63 Hz
         val note = TunerNoteMapper.mapFrequency(261.63)
         assertNotNull(note)
-        assertEquals("C", note!!.noteName)
+        assertEquals("C", note.noteName)
         assertEquals(4, note.octave)
         assertEquals(0, note.pitchClass)
     }
@@ -47,7 +48,7 @@ class TunerNoteMapperTest {
         // E4 = 329.63 Hz
         val note = TunerNoteMapper.mapFrequency(329.63)
         assertNotNull(note)
-        assertEquals("E", note!!.noteName)
+        assertEquals("E", note.noteName)
         assertEquals(4, note.octave)
         assertEquals(4, note.pitchClass)
     }
@@ -57,7 +58,7 @@ class TunerNoteMapperTest {
         // G4 = 392.00 Hz
         val note = TunerNoteMapper.mapFrequency(392.0)
         assertNotNull(note)
-        assertEquals("G", note!!.noteName)
+        assertEquals("G", note.noteName)
         assertEquals(4, note.octave)
         assertEquals(7, note.pitchClass)
     }
@@ -67,7 +68,7 @@ class TunerNoteMapperTest {
         // D3 = 146.83 Hz (Baritone lowest string)
         val note = TunerNoteMapper.mapFrequency(146.83)
         assertNotNull(note)
-        assertEquals("D", note!!.noteName)
+        assertEquals("D", note.noteName)
         assertEquals(3, note.octave)
         assertEquals(2, note.pitchClass)
     }
@@ -85,22 +86,22 @@ class TunerNoteMapperTest {
     @Test
     fun detectsSharpDeviation() {
         // 5 cents sharp of A4 = 440 * 2^(5/1200)
-        val sharpA4 = 440.0 * Math.pow(2.0, 5.0 / 1200.0)
+        val sharpA4 = 440.0 * 2.0.pow(5.0 / 1200.0)
         val note = TunerNoteMapper.mapFrequency(sharpA4)
         assertNotNull(note)
-        assertEquals("A", note!!.noteName)
-        assertTrue("Should be sharp", note.centsDeviation > 4.0)
-        assertTrue("Should be around 5 cents", abs(note.centsDeviation - 5.0) < 1.0)
+        assertEquals("A", note.noteName)
+        assertTrue(note.centsDeviation > 4.0, "Should be sharp")
+        assertTrue(abs(note.centsDeviation - 5.0) < 1.0, "Should be around 5 cents")
     }
 
     @Test
     fun detectsFlatDeviation() {
         // 10 cents flat of A4 = 440 * 2^(-10/1200)
-        val flatA4 = 440.0 * Math.pow(2.0, -10.0 / 1200.0)
+        val flatA4 = 440.0 * 2.0.pow(-10.0 / 1200.0)
         val note = TunerNoteMapper.mapFrequency(flatA4)
         assertNotNull(note)
-        assertEquals("A", note!!.noteName)
-        assertTrue("Should be flat", note.centsDeviation < -9.0)
+        assertEquals("A", note.noteName)
+        assertTrue(note.centsDeviation < -9.0, "Should be flat")
     }
 
     @Test
@@ -108,8 +109,8 @@ class TunerNoteMapperTest {
         // With A4 = 442 Hz, playing 442 Hz should map to A4 with ~0 cents
         val note = TunerNoteMapper.mapFrequency(442.0, a4Reference = 442.0)
         assertNotNull(note)
-        assertEquals("A", note!!.noteName)
-        assertTrue("Cents should be near zero", abs(note.centsDeviation) < 0.5)
+        assertEquals("A", note.noteName)
+        assertTrue(abs(note.centsDeviation) < 0.5, "Cents should be near zero")
     }
 
     // --- findNearestString ---------------------------------------------------
@@ -167,12 +168,6 @@ class TunerNoteMapperTest {
 
     @Test
     fun hysteresisKeepsPreviousString() {
-        // E4 (329.63 Hz) is close to both E string (329.63 Hz) and C string (261.63 Hz).
-        // When exactly at E4, best match is E. With hysteresis and previous=C,
-        // a small deviation toward C should keep C as the target.
-        //
-        // Use a frequency between C4 and E4 but closer to E — hysteresis
-        // should keep the previous string if within tolerance.
         val noteInfo = TunerNoteMapper.mapFrequency(329.63)!! // Exactly E4
 
         val match = TunerNoteMapper.findNearestStringWithHysteresis(
@@ -181,7 +176,7 @@ class TunerNoteMapperTest {
             previousStringIndex = 2, // E string was previous
             switchHysteresisCents = 4.0,
         )
-        assertEquals("E string should stay locked", 2, match.stringIndex)
+        assertEquals(2, match.stringIndex, "E string should stay locked")
     }
 
     @Test
@@ -195,7 +190,7 @@ class TunerNoteMapperTest {
             previousStringIndex = 2, // E string was previous
             switchHysteresisCents = 4.0,
         )
-        assertEquals("Should switch to C string", 1, match.stringIndex)
+        assertEquals(1, match.stringIndex, "Should switch to C string")
     }
 
     @Test
@@ -219,27 +214,27 @@ class TunerNoteMapperTest {
         val noteA4 = TunerNoteMapper.mapFrequency(440.0)!!
         val match = TunerNoteMapper.findNearestString(noteA4, UkuleleTuning.HIGH_G)
         assertTrue(
-            "Cents from target should be near zero, was ${match.centsFromTarget}",
             abs(match.centsFromTarget) < 1.0,
+            "Cents from target should be near zero, was ${match.centsFromTarget}",
         )
     }
 
     @Test
     fun centsFromTargetPositiveForSharp() {
         // 10 cents sharp of A4
-        val sharpA4 = 440.0 * Math.pow(2.0, 10.0 / 1200.0)
+        val sharpA4 = 440.0 * 2.0.pow(10.0 / 1200.0)
         val note = TunerNoteMapper.mapFrequency(sharpA4)!!
         val match = TunerNoteMapper.findNearestString(note, UkuleleTuning.HIGH_G)
-        assertTrue("Should be sharp (positive cents)", match.centsFromTarget > 9.0)
+        assertTrue(match.centsFromTarget > 9.0, "Should be sharp (positive cents)")
     }
 
     @Test
     fun centsFromTargetNegativeForFlat() {
         // 15 cents flat of A4
-        val flatA4 = 440.0 * Math.pow(2.0, -15.0 / 1200.0)
+        val flatA4 = 440.0 * 2.0.pow(-15.0 / 1200.0)
         val note = TunerNoteMapper.mapFrequency(flatA4)!!
         val match = TunerNoteMapper.findNearestString(note, UkuleleTuning.HIGH_G)
-        assertTrue("Should be flat (negative cents)", match.centsFromTarget < -14.0)
+        assertTrue(match.centsFromTarget < -14.0, "Should be flat (negative cents)")
     }
 
     // --- Custom A4 reference with string matching ----------------------------
@@ -250,6 +245,6 @@ class TunerNoteMapperTest {
         val note = TunerNoteMapper.mapFrequency(442.0, a4Reference = 442.0)!!
         val match = TunerNoteMapper.findNearestString(note, UkuleleTuning.HIGH_G, a4Reference = 442.0)
         assertEquals("A", match.stringName)
-        assertTrue("Cents from target should be near zero", abs(match.centsFromTarget) < 1.0)
+        assertTrue(abs(match.centsFromTarget) < 1.0, "Cents from target should be near zero")
     }
 }


### PR DESCRIPTION
## Summary
- Moves 11 domain test files (4 unit + 7 property-based) from `app/src/test/` to `shared/src/commonTest/` so they contribute to the shared module's Kover coverage report
- Adapts JUnit 4 → `kotlin.test`, `Math.pow` → `kotlin.math.pow`, `Math.random` → `kotlin.random.Random`
- Adds `kotest-property` and `kotlinx-coroutines-core` as shared commonTest dependencies
- Removes unused `kotest-property` from app module
- **Shared module Kover coverage: 76.3% → 86.8%** (+10.5pp)

## Test plan
- [x] `./gradlew :shared:jvmTest` — all moved tests pass on JVM
- [x] `./gradlew :shared:koverXmlReport` — coverage at 86.8%
- [x] `./gradlew :app:testDebugUnitTest` — remaining app tests (fuzz + TTS) pass
- [ ] CI passes all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build configuration with improved dependency management.
  * Added coroutines library support for asynchronous operations.

* **Tests**
  * Migrated test suite from legacy framework to Kotlin test framework.
  * Enhanced floating-point assertions with tolerance-based comparison for improved numerical accuracy testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->