### PR TITLE
Add: App Store link and badge across project

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: Suggest an Idea
     url: https://github.com/baijum/ukulele-companion/discussions/categories/ideas
     about: Share feature ideas or suggestions in Discussions before opening an issue.
-  - name: Beta Testing (iOS)
-    url: https://testflight.apple.com/join/Zpq8kzm6
-    about: Join the iOS beta via TestFlight to try new features and help test pre-release builds.
+  - name: Download on the App Store (iOS)
+    url: https://apps.apple.com/app/id6760328302
+    about: Get Ukulele Companion for iPhone and iPad on the App Store.
   - name: Contributing Guide
     url: https://github.com/baijum/ukulele-companion/blob/main/CONTRIBUTING.md
     about: Read the contributing guidelines before opening an issue or PR.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
     <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
          alt="Get it on Google Play" height="60">
   </a>
+  <a href="https://apps.apple.com/app/id6760328302">
+    <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+         alt="Download on the App Store" height="44">
+  </a>
 </p>
 
 <p align="center">
@@ -366,17 +370,20 @@ Detailed feature documentation and a user manual are available in the [`docs/`](
 
 ---
 
-## 🧪 Beta Testing (iOS)
+## 📲 Download
 
-The Android app is available on the [Google Play Store](https://play.google.com/store/apps/details?id=com.baijum.ukufretboard).
+Ukulele Companion is free on both platforms:
 
-Want to try new iOS features before they go live? Join the beta via
-[TestFlight](https://testflight.apple.com/join/Zpq8kzm6).
-
-As a tester you can:
-- Install pre-release iOS builds through TestFlight
-- Try new features before they are publicly available
-- Report bugs or share feedback directly to help improve the app
+<p align="center">
+  <a href="https://play.google.com/store/apps/details?id=com.baijum.ukufretboard">
+    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+         alt="Get it on Google Play" height="60">
+  </a>
+  <a href="https://apps.apple.com/app/id6760328302">
+    <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+         alt="Download on the App Store" height="44">
+  </a>
+</p>
 
 ---
 

--- a/docs/css/landing.css
+++ b/docs/css/landing.css
@@ -539,7 +539,7 @@
   font-size: 1.1rem;
 }
 
-.cta-testflight {
+.cta-appstore {
   margin-left: calc(50% - 50vw);
   width: 100vw;
   margin-top: 0;
@@ -548,21 +548,21 @@
   color: #fff;
 }
 
-.cta-testflight h2 {
+.cta-appstore h2 {
   color: #fff;
   margin: 0 0 0.75rem;
   font-size: 1.85rem;
   font-weight: 800;
 }
 
-.cta-testflight p {
+.cta-appstore p {
   color: rgba(255, 255, 255, 0.85);
   margin: 0 auto 1.5rem;
   max-width: 55ch;
   font-size: 1.1rem;
 }
 
-.cta-testflight .md-button--primary {
+.cta-appstore .md-button--primary {
   background: var(--uc-coral);
   border-color: var(--uc-coral);
   color: #fff;
@@ -570,7 +570,7 @@
   box-shadow: 0 4px 16px rgba(255, 112, 67, 0.4);
 }
 
-.cta-testflight .md-button--primary:hover {
+.cta-appstore .md-button--primary:hover {
   box-shadow: 0 6px 24px rgba(255, 112, 67, 0.5);
   transform: translateY(-2px);
 }
@@ -762,7 +762,7 @@
   }
 
   .cta-playstore,
-  .cta-testflight,
+  .cta-appstore,
   .cta-manual {
     padding: 2.5rem 1.5rem;
   }
@@ -906,12 +906,12 @@
   background: linear-gradient(135deg, #111 0%, #222 100%);
 }
 
-/* CTA testflight: brighter gradient */
-[data-md-color-scheme="slate"] .cta-testflight {
+/* CTA appstore: brighter gradient */
+[data-md-color-scheme="slate"] .cta-appstore {
   background: linear-gradient(135deg, #00796B 0%, #26A69A 100%);
 }
 
-/* CTA manual: distinct from testflight, visible against page */
+/* CTA manual: distinct from appstore, visible against page */
 [data-md-color-scheme="slate"] .cta-manual {
   background: linear-gradient(135deg, #00695C 0%, #00897B 100%);
 }
@@ -929,13 +929,13 @@
 
 /* CTA headings must stay white (override teal heading color above) */
 .cta-playstore h2,
-.cta-testflight h2,
+.cta-appstore h2,
 .cta-manual h2 {
   color: #fff;
 }
 
 .cta-playstore p,
-.cta-testflight p,
+.cta-appstore p,
 .cta-manual p {
   color: rgba(255, 255, 255, 0.9);
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,10 @@ hide:
         <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
              alt="Get it on Google Play">
       </a>
+      <a href="https://apps.apple.com/app/id6760328302" class="store-badge">
+        <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+             alt="Download on the App Store">
+      </a>
       <a href="manual/" class="md-button md-button--primary">Start with the Manual</a>
       <a href="https://github.com/baijum/ukulele-companion" class="md-button">View on GitHub</a>
     </div>
@@ -162,11 +166,14 @@ hide:
   </div>
 </section>
 
-<section class="cta-panel cta-testflight">
-  <h2>Try the iOS beta via TestFlight</h2>
-  <p>Get early access to new features on iPhone and iPad before they go live.</p>
+<section class="cta-panel cta-appstore">
+  <h2>Download on iOS</h2>
+  <p>Free, offline, and ad-free. Available now on the App Store for iPhone and iPad.</p>
   <div class="hero-cta">
-    <a href="https://testflight.apple.com/join/Zpq8kzm6" class="md-button md-button--primary">Join the TestFlight Beta</a>
+    <a href="https://apps.apple.com/app/id6760328302" class="store-badge">
+      <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg"
+           alt="Download on the App Store">
+    </a>
   </div>
 </section>
 

--- a/docs/manual/ios/01-getting-started.md
+++ b/docs/manual/ios/01-getting-started.md
@@ -2,7 +2,7 @@
 
 ## Installing the App
 
-Ukulele Companion is available on the App Store. Install it on any iPhone or iPad running iOS 17.0 or later. No account or login is required — just install and open.
+Ukulele Companion is available on the [App Store](https://apps.apple.com/app/id6760328302). Install it on any iPhone or iPad running iOS 17.0 or later. No account or login is required — just install and open.
 
 ## First Launch
 


### PR DESCRIPTION
## Summary

- Added the App Store badge (`Download on the App Store`) next to the Google Play badge in both the README hero section and the website landing page hero CTA
- Replaced the README "Beta Testing (iOS)" section with a "Download" section showing both store badges
- Replaced the website TestFlight CTA panel with an "Download on iOS" App Store panel (renamed CSS class `.cta-testflight` to `.cta-appstore`)
- Added a direct App Store link in the iOS manual getting-started page
- Updated the GitHub issue template to replace the TestFlight contact link with an App Store download link
- Removed all user-facing TestFlight references (internal/historical mentions in talk slides and maintainer skills are intentionally kept)

App Store listing: https://apps.apple.com/app/id6760328302

## Files changed

| File | Change |
|------|--------|
| `README.md` | Added App Store badge in hero; replaced "Beta Testing" with "Download" section |
| `docs/index.md` | Added App Store badge in hero CTA; replaced TestFlight panel with App Store panel |
| `docs/css/landing.css` | Renamed `.cta-testflight` to `.cta-appstore` (9 occurrences + comments) |
| `docs/manual/ios/01-getting-started.md` | Added hyperlink to "App Store" text |
| `.github/ISSUE_TEMPLATE/config.yml` | Replaced TestFlight entry with App Store download link |

## Test plan

- [ ] Verify README renders correctly on GitHub (both badge images load, links work)
- [ ] Build docs site locally with `mkdocs serve` and verify landing page hero shows both badges, App Store CTA panel renders correctly, and dark mode styling is intact
- [ ] Confirm iOS manual getting-started page shows clickable App Store link
- [ ] Check issue template config renders correctly on GitHub (new issues page)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS application is now available on the official App Store with integrated download links and badges across the platform

* **Documentation**
  * Updated iOS getting started guide with direct App Store installation link
  * Website resources now prominently display App Store availability alongside Google Play

<!-- end of auto-generated comment: release notes by coderabbit.ai -->