### PR TITLE
Fix: reverse iOS fretboard string order to show A on top

### DIFF
--- a/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
@@ -63,7 +63,7 @@ struct FretboardNoteMapView: View {
                     let pitchClasses = tuning.pitchClasses as! [NSNumber]
                     let stringNames = tuning.stringNames as! [String]
 
-                    ForEach(0..<4, id: \.self) { stringIndex in
+                    ForEach(Array((0..<4).reversed()), id: \.self) { stringIndex in
                         HStack(spacing: 0) {
                             Text(stringNames[stringIndex])
                                 .font(.caption.bold())

--- a/iosApp/UkuleleCompanion/Views/FretboardView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardView.swift
@@ -76,7 +76,7 @@ struct FretboardView: View {
 
     private var stringLabelsColumn: some View {
         VStack(spacing: 0) {
-            ForEach(0..<FretboardViewModel.stringCount, id: \.self) { stringIndex in
+            ForEach(Array((0..<FretboardViewModel.stringCount).reversed()), id: \.self) { stringIndex in
                 Text(viewModel.tuning[stringIndex].name)
                     .font(.caption.bold())
                     .frame(width: 32, height: cellSize)
@@ -99,7 +99,7 @@ struct FretboardView: View {
             .accessibilityHidden(true)
 
             VStack(spacing: 0) {
-                ForEach(0..<FretboardViewModel.stringCount, id: \.self) { stringIndex in
+                ForEach(Array((0..<FretboardViewModel.stringCount).reversed()), id: \.self) { stringIndex in
                     HStack(spacing: 0) {
                         ForEach(fretOrder, id: \.self) { fret in
                             let noteInfo = viewModel.getNoteAt(stringIndex: stringIndex, fret: fret)

--- a/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
+++ b/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
@@ -28,7 +28,7 @@ struct FullScreenFretboardView: View {
                 VStack(spacing: 0) {
                     fretNumberRow(cellW: cellW, labelWidth: labelWidth)
 
-                    ForEach(0..<4, id: \.self) { stringIdx in
+                    ForEach(Array((0..<4).reversed()), id: \.self) { stringIdx in
                         stringRow(stringIdx: stringIdx, cellW: cellW, cellH: cellH, labelWidth: labelWidth)
                     }
                 }

--- a/iosApp/UkuleleCompanion/Views/ScalePracticeView.swift
+++ b/iosApp/UkuleleCompanion/Views/ScalePracticeView.swift
@@ -161,7 +161,7 @@ struct ScalePracticeView: View {
         let tuning: [Int] = [7, 0, 4, 9] // G C E A (High-G)
 
         VStack(spacing: 0) {
-            ForEach(0..<4, id: \.self) { stringIdx in
+            ForEach(Array((0..<4).reversed()), id: \.self) { stringIdx in
                 HStack(spacing: 0) {
                     ForEach(Array(fretRange), id: \.self) { fret in
                         let pc = (tuning[stringIdx] + fret) % 12


### PR DESCRIPTION
## Summary

- Reverses the vertical string order in all iOS fretboard views from G-C-E-A (top-to-bottom) to A-E-C-G, matching the Android app and the standard convention for fretboard/tablature diagrams.
- Addresses Reddit user feedback that the Explorer fretboard had strings in the wrong order.
- Four views updated: `FretboardView`, `FullScreenFretboardView`, `FretboardNoteMapView`, `ScalePracticeView`.

## Test plan

- [ ] Open Explorer tab and verify strings show A, E, C, G from top to bottom
- [ ] Open full-screen fretboard and verify same A-on-top order
- [ ] Open Note Map (Reference section) and verify A-on-top order
- [ ] Open Scale Practice and verify mini-fretboard uses A-on-top order
- [ ] Tap frets to confirm selections map to the correct string
- [ ] Toggle left-handed mode and verify fret reversal still works correctly
- [ ] Test with VoiceOver to confirm accessibility labels still announce the correct string name

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the fretboard string rendering order across multiple views to ensure consistent visual display of string orientation throughout the app, affecting the note map, main fretboard, full-screen fretboard, and scale practice interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->