### PR TITLE
Fix: ConcurrentModificationException in TunerViewModel and MelodyViewModel

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -446,6 +446,20 @@ class MelodyViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Stops recording and releases the microphone.
+     *
+     * Internal processing state ([recentFrequencies], [previousFrequency], etc.)
+     * is deliberately **not** cleared here because [processRecordingBuffer] may
+     * still be executing on a background thread
+     * ([kotlinx.coroutines.Dispatchers.Default]). Clearing a non-thread-safe
+     * [ArrayDeque] from the main thread while the background thread iterates it
+     * causes a [ConcurrentModificationException] (or [IndexOutOfBoundsException])
+     * that crashes the Activity.
+     *
+     * The internal state is reset in [startRecording] instead, before any
+     * new background work begins.
+     */
     fun stopRecording() {
         AudioCaptureEngine.stop()
         _uiState.update {
@@ -456,7 +470,6 @@ class MelodyViewModel : ViewModel() {
                 lastAddedFeedback = null,
             )
         }
-        resetRecordingState()
     }
 
     private fun resetRecordingState() {
@@ -469,7 +482,17 @@ class MelodyViewModel : ViewModel() {
         awaitingSilence = false
     }
 
+    /**
+     * Processes a single audio buffer through pitch detection for note recording.
+     *
+     * Called on [kotlinx.coroutines.Dispatchers.Default] from the capture
+     * coroutine. A final buffer may arrive after [stopRecording] has already
+     * set [MelodyUiState.isRecording] to `false`; the early-return guard
+     * below prevents stale data from briefly flashing in the UI and avoids
+     * a [ConcurrentModificationException] on [recentFrequencies].
+     */
     private fun processRecordingBuffer(samples: FloatArray) {
+        if (!_uiState.value.isRecording) return
         val currentRms = PitchDetector.rms(samples)
         if (previousRms > 0f && currentRms / previousRms > ONSET_RATIO_THRESHOLD) {
             blankingFramesRemaining = BLANKING_FRAMES

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -373,6 +373,16 @@ class TunerViewModel : ViewModel() {
 
     /**
      * Stops listening and releases the microphone.
+     *
+     * Internal processing state ([recentFrequencies], [previousFrequency], etc.)
+     * is deliberately **not** cleared here because [processBuffer] may still
+     * be executing on a background thread ([kotlinx.coroutines.Dispatchers.Default]).
+     * Clearing a non-thread-safe [ArrayDeque] from the main thread while the
+     * background thread iterates it causes a [ConcurrentModificationException]
+     * (or [IndexOutOfBoundsException]) that crashes the Activity.
+     *
+     * The internal state is reset in [startTuning] instead, before any
+     * new background work begins.
      */
     fun stopTuning() {
         AudioCaptureEngine.stop()
@@ -389,23 +399,6 @@ class TunerViewModel : ViewModel() {
                 lastSettledCents = 0.0,
             )
         }
-        recentFrequencies.clear()
-        inTuneFrames = 0
-        previousRms = 0f
-        rmsEma = 0f
-        blankingFramesRemaining = 0
-        lostSignalFrames = 0
-        previousFrequency = null
-        displayCentsFiltered = 0.0
-        settledNoteName = null
-        settledNoteFrames = 0
-        settledNoteCents = 0.0
-        neuralFrameCounter = 0
-        lastNeuralResult = null
-        neuralResultAgeFrames = Int.MAX_VALUE
-        consecutiveNeuralFailures = 0
-        lastNeuralFrequencyForConsistency = null
-        neuralConsistencyFrames = 0
     }
 
     /**
@@ -432,8 +425,15 @@ class TunerViewModel : ViewModel() {
 
     /**
      * Processes a single audio buffer through pitch detection and note mapping.
+     *
+     * Called on [kotlinx.coroutines.Dispatchers.Default] from the capture
+     * coroutine. A final buffer may arrive after [stopTuning] has already
+     * set [TunerUiState.isListening] to `false`; the early-return guard
+     * below prevents stale data from briefly flashing in the UI and avoids
+     * a [ConcurrentModificationException] on [recentFrequencies].
      */
     private fun processBuffer(samples: FloatArray) {
+        if (!_uiState.value.isListening) return
         // --- Onset detection (adaptive) -------------------------------------
         // Detect sudden energy spikes (pluck attacks) using an adaptive
         // threshold based on a running EMA of recent RMS values. This makes


### PR DESCRIPTION
## Summary

- Fix thread-safety crash in `TunerViewModel` and `MelodyViewModel` where `stopTuning()`/`stopRecording()` cleared `recentFrequencies` (a non-thread-safe `ArrayDeque`) on the main thread while `processBuffer()` was still running on `Dispatchers.Default`
- Apply the same fix pattern already proven in `PitchMonitorViewModel` (lines 294-349): add an `isListening`/`isRecording` early-return guard in the buffer processor and move shared-state clearing to the start methods only

## Details

**TunerViewModel.kt:**
- Added `if (!_uiState.value.isListening) return` guard at the top of `processBuffer()` to discard post-stop audio buffers
- Removed 17 lines of shared-state clearing from `stopTuning()` (already reset in `startTuning()` before capture begins)

**MelodyViewModel.kt:**
- Added `if (!_uiState.value.isRecording) return` guard at the top of `processRecordingBuffer()`
- Removed `resetRecordingState()` call from `stopRecording()` (already called in `startRecording()` before capture begins)

## Test plan

- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes (no new warnings)
- [ ] Manual: open Tuner, rapidly stop/start — no crash
- [ ] Manual: open Melody Notepad, rapidly stop/start recording — no crash
- [ ] Manual: start Tuner, navigate away mid-tuning, return, start again — works correctly

Closes #106

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Melody recording now stops cleanly without detecting stale notes
  * Tuner no longer displays outdated pitch readings after stopping
  * Improved app stability when switching between recording and tuning operations
  * Better handling of background audio processing during state transitions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/baijum/ukulele-companion/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->