### PR TITLE
Fix: Melody recording missing mic permission and leaks mic on navigation

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -105,6 +106,10 @@ fun MelodyNotepadView(
     var showRenameDialog by remember { mutableStateOf<Melody?>(null) }
     var showMenu by remember { mutableStateOf(false) }
     var bpmSliderValue by remember(state.bpm) { mutableFloatStateOf(state.bpm.toFloat()) }
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.stopRecording() }
+    }
 
     Column(
         modifier = modifier
@@ -692,11 +697,13 @@ private fun InputModeSection(
             onOctaveUp = onOctaveUp,
             onOctaveDown = onOctaveDown,
         )
-        MelodyInputMode.RECORD -> RecordInputContent(
-            state = state,
-            onStartRecording = onStartRecording,
-            onStopRecording = onStopRecording,
-        )
+        MelodyInputMode.RECORD -> RequireMicPermission {
+            RecordInputContent(
+                state = state,
+                onStartRecording = onStartRecording,
+                onStopRecording = onStopRecording,
+            )
+        }
     }
 }
 

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -267,7 +267,24 @@ final class MelodyViewModel: ObservableObject {
     }
 
     func startRecording() {
-        isRecording = true
+        Task { @MainActor in
+            let granted: Bool
+            if #available(iOS 17.0, *) {
+                granted = await AVAudioApplication.requestRecordPermission()
+            } else {
+                granted = await withCheckedContinuation { continuation in
+                    AVAudioSession.sharedInstance().requestRecordPermission { g in
+                        continuation.resume(returning: g)
+                    }
+                }
+            }
+            if granted {
+                beginCapture()
+            }
+        }
+    }
+
+    private func beginCapture() {
         stableCount = 0
         lastDetectedPitchClass = nil
 
@@ -330,6 +347,7 @@ final class MelodyViewModel: ObservableObject {
         }
 
         audioEngine.start()
+        isRecording = true
     }
 
     func stopRecording() {

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -70,6 +70,11 @@ struct MelodyNotepadView: View {
                 renameName = ""
             }
         }
+        .onDisappear {
+            if viewModel.isRecording {
+                viewModel.stopRecording()
+            }
+        }
     }
 
     private var modeToggle: some View {


### PR DESCRIPTION
## Summary

- Add microphone permission handling and lifecycle cleanup to Melody Notepad on both Android and iOS, matching the established patterns from Tuner and Pitch Monitor
- Fix mic leak where navigating away while recording left the singleton AudioCaptureEngine active with the Melody callback, blocking other features from using the mic

## Details

**Android (`MelodyNotepadView.kt`):**
- Added `DisposableEffect` to call `viewModel.stopRecording()` on dispose
- Wrapped `RecordInputContent` with `RequireMicPermission` -- permission rationale shows only when switching to Record mode; TAP mode remains unaffected

**iOS (`MelodyNotepadView.swift`):**
- Added `.onDisappear` to stop recording when leaving the screen

**iOS (`MelodyViewModel.swift`):**
- Refactored `startRecording()` to request mic permission first using `AVAudioApplication.requestRecordPermission()` (iOS 17+) with `AVAudioSession` fallback
- Extracted capture logic into `private func beginCapture()`, called only after permission granted
- Moved `isRecording = true` to after `audioEngine.start()` so UI doesn't falsely show "recording"

## Test plan

- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew lintDebug` passes (no new warnings)
- [ ] Android: Open Melody in TAP mode (no permission prompt). Switch to RECORD (rationale card appears). Grant, record, navigate away (mic released). Return and record again.
- [ ] iOS: Tap Record (permission dialog appears). Grant, record, navigate away (mic released). Deny permission (recording does not start).

Closes #107

Made with [Cursor](https://cursor.com)