### PR TITLE
Fix: Backup/restore omits setlists, resets settings, and loses achievements (#108)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
@@ -117,7 +117,10 @@ class PracticeTimerRepository(context: Context) {
             putInt(KEY_TOTAL_SESSIONS, maxOf(totalSessions(), data.totalSessions))
             putInt(KEY_LONGEST_SESSION, maxOf(longestSession(), data.longestSession))
             putLong(KEY_LAST_SESSION, maxOf(lastSessionTime(), data.lastSessionTime))
-            putInt(KEY_DAILY_GOAL, data.dailyGoal)
+            val incomingGoal = data.dailyGoal.coerceIn(5, 120)
+            if (incomingGoal != DEFAULT_DAILY_GOAL) {
+                putInt(KEY_DAILY_GOAL, incomingGoal)
+            }
             data.dailyMinutes.forEach { (day, minutes) ->
                 val key = "$KEY_DAY_MINUTES$day"
                 val existing = prefs.getInt(key, 0)

--- a/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
@@ -92,6 +92,41 @@ class PracticeTimerRepository(context: Context) {
         lastSessionTime = lastSessionTime(),
     )
 
+    /** Exports all practice timer data for backup. */
+    fun exportAll(): PracticeTimerExport {
+        val dailyMinutes = mutableMapOf<String, Int>()
+        prefs.all.forEach { (key, value) ->
+            if (key.startsWith(KEY_DAY_MINUTES) && value is Int) {
+                dailyMinutes[key.removePrefix(KEY_DAY_MINUTES)] = value
+            }
+        }
+        return PracticeTimerExport(
+            totalMinutes = totalMinutes(),
+            totalSessions = totalSessions(),
+            longestSession = longestSession(),
+            lastSessionTime = lastSessionTime(),
+            dailyGoal = dailyGoal(),
+            dailyMinutes = dailyMinutes,
+        )
+    }
+
+    /** Imports practice timer data from backup, using max-merge for cumulative stats. */
+    fun importAll(data: PracticeTimerExport) {
+        prefs.edit().apply {
+            putInt(KEY_TOTAL_MINUTES, maxOf(totalMinutes(), data.totalMinutes))
+            putInt(KEY_TOTAL_SESSIONS, maxOf(totalSessions(), data.totalSessions))
+            putInt(KEY_LONGEST_SESSION, maxOf(longestSession(), data.longestSession))
+            putLong(KEY_LAST_SESSION, maxOf(lastSessionTime(), data.lastSessionTime))
+            putInt(KEY_DAILY_GOAL, data.dailyGoal)
+            data.dailyMinutes.forEach { (day, minutes) ->
+                val key = "$KEY_DAY_MINUTES$day"
+                val existing = prefs.getInt(key, 0)
+                putInt(key, maxOf(existing, minutes))
+            }
+            apply()
+        }
+    }
+
     /** Clears all practice time data. */
     fun clearAll() {
         prefs.edit().clear().apply()
@@ -113,6 +148,18 @@ class PracticeTimerRepository(context: Context) {
         private const val DEFAULT_DAILY_GOAL = 15
     }
 }
+
+/**
+ * All practice timer data for backup export/import.
+ */
+data class PracticeTimerExport(
+    val totalMinutes: Int = 0,
+    val totalSessions: Int = 0,
+    val longestSession: Int = 0,
+    val lastSessionTime: Long = 0L,
+    val dailyGoal: Int = 15,
+    val dailyMinutes: Map<String, Int> = emptyMap(),
+)
 
 /**
  * Snapshot of practice time statistics.

--- a/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
@@ -1,6 +1,7 @@
 package com.baijum.ukufretboard.data.sync
 
 import android.content.Context
+import com.baijum.ukufretboard.data.AchievementRepository
 import com.baijum.ukufretboard.data.ChordSheetRepository
 import com.baijum.ukufretboard.data.CustomFingerpickingPatternRepository
 import com.baijum.ukufretboard.data.CustomProgressionRepository
@@ -13,13 +14,10 @@ import com.baijum.ukufretboard.data.Melody
 import com.baijum.ukufretboard.data.MelodyNote
 import com.baijum.ukufretboard.data.MelodyRepository
 import com.baijum.ukufretboard.data.NoteDuration
-import com.baijum.ukufretboard.data.AppSettings
-import com.baijum.ukufretboard.data.SoundSettings
-import com.baijum.ukufretboard.data.DisplaySettings
-import com.baijum.ukufretboard.data.FretboardSettings
-
+import com.baijum.ukufretboard.data.PracticeTimerRepository
+import com.baijum.ukufretboard.data.Setlist
+import com.baijum.ukufretboard.data.SetlistRepository
 import com.baijum.ukufretboard.data.ThemeMode
-import com.baijum.ukufretboard.data.TuningSettings
 import com.baijum.ukufretboard.data.UkuleleTuning
 import com.baijum.ukufretboard.viewmodel.SettingsViewModel
 import kotlinx.serialization.json.Json
@@ -48,6 +46,9 @@ class BackupRestoreManager(
     private val fingerpickingRepo by lazy { CustomFingerpickingPatternRepository(context) }
     private val learningProgressRepo by lazy { LearningProgressRepository(context) }
     private val melodyRepo by lazy { MelodyRepository(context) }
+    private val setlistRepo by lazy { SetlistRepository(context) }
+    private val achievementRepo by lazy { AchievementRepository(context) }
+    private val practiceTimerRepo by lazy { PracticeTimerRepository(context) }
     /**
      * Collects all user data from all repositories and serializes to JSON.
      *
@@ -157,6 +158,26 @@ class BackupRestoreManager(
             learningProgress = BackupLearningProgress(
                 entries = learningProgressRepo.exportAll(),
             ),
+            setlists = setlistRepo.getAll().map { sl ->
+                BackupSetlist(
+                    id = sl.id,
+                    name = sl.name,
+                    songIds = sl.songIds,
+                    createdAt = sl.createdAt,
+                    updatedAt = sl.updatedAt,
+                )
+            },
+            achievements = achievementRepo.exportAll(),
+            practiceTimer = practiceTimerRepo.exportAll().let { pt ->
+                BackupPracticeTimer(
+                    totalMinutes = pt.totalMinutes,
+                    totalSessions = pt.totalSessions,
+                    longestSession = pt.longestSession,
+                    lastSessionTime = pt.lastSessionTime,
+                    dailyGoal = pt.dailyGoal,
+                    dailyMinutes = pt.dailyMinutes,
+                )
+            },
             settings = settingsViewModel.exportSettings().let { s ->
                 BackupSettings(
                     soundEnabled = s.sound.enabled,
@@ -184,10 +205,13 @@ class BackupRestoreManager(
      * Deserializes a JSON backup string and imports all data into local storage.
      *
      * Merge strategy:
-     * - Favorites, folders, chord sheets, progressions, patterns: union merge
+     * - Favorites, folders, chord sheets, progressions, patterns, setlists: union merge
      *   (existing data is preserved, new data is added).
-     * - Learning progress: merged (entries are combined).
-     * - Settings: replaced with backup values.
+     * - Learning progress, achievements: merged (entries are combined).
+     * - Practice timer: max-merge (cumulative stats keep the higher value).
+     * - Settings: backup fields are merged into the current settings so that
+     *   settings not covered by the backup (scale practice, tuner, noise gate,
+     *   onboarding, etc.) are preserved at their current values.
      *
      * @param jsonContent The JSON string from a backup file.
      */
@@ -254,11 +278,39 @@ class BackupRestoreManager(
         // --- Learning progress ---
         learningProgressRepo.importAll(backup.learningProgress.entries)
 
-        // --- Settings (replace) ---
+        // --- Setlists ---
+        setlistRepo.importAll(backup.setlists.map { sl ->
+            Setlist(
+                id = sl.id,
+                name = sl.name,
+                songIds = sl.songIds,
+                createdAt = sl.createdAt,
+                updatedAt = sl.updatedAt,
+            )
+        })
+
+        // --- Achievements ---
+        achievementRepo.importAll(backup.achievements)
+
+        // --- Practice timer ---
+        practiceTimerRepo.importAll(
+            com.baijum.ukufretboard.data.PracticeTimerExport(
+                totalMinutes = backup.practiceTimer.totalMinutes,
+                totalSessions = backup.practiceTimer.totalSessions,
+                longestSession = backup.practiceTimer.longestSession,
+                lastSessionTime = backup.practiceTimer.lastSessionTime,
+                dailyGoal = backup.practiceTimer.dailyGoal,
+                dailyMinutes = backup.practiceTimer.dailyMinutes,
+            )
+        )
+
+        // --- Settings (merge into current -- backup only covers a subset of
+        //     AppSettings, so we must preserve fields that were never exported) ---
+        val current = settingsViewModel.exportSettings()
         val bs = backup.settings
         settingsViewModel.replaceAll(
-            AppSettings(
-                sound = SoundSettings(
+            current.copy(
+                sound = current.sound.copy(
                     enabled = bs.soundEnabled,
                     volume = bs.volume,
                     noteDurationMs = bs.noteDurationMs,
@@ -266,24 +318,24 @@ class BackupRestoreManager(
                     strumDown = bs.strumDown,
                     playOnTap = bs.playOnTap,
                 ),
-                display = DisplaySettings(
+                display = current.display.copy(
                     themeMode = try {
                         ThemeMode.valueOf(bs.themeMode)
                     } catch (_: Exception) {
-                        ThemeMode.SYSTEM
+                        current.display.themeMode
                     },
                     showExplorerTips = bs.showExplorerTips,
                     showLearnSection = bs.showLearnSection,
                     showReferenceSection = bs.showReferenceSection,
                 ),
-                tuning = TuningSettings(
+                tuning = current.tuning.copy(
                     tuning = try {
                         UkuleleTuning.valueOf(bs.tuning)
                     } catch (_: Exception) {
-                        UkuleleTuning.HIGH_G
+                        current.tuning.tuning
                     },
                 ),
-                fretboard = FretboardSettings(
+                fretboard = current.fretboard.copy(
                     leftHanded = bs.leftHanded,
                     lastFret = bs.lastFret,
                     showNoteNames = bs.showNoteNames,

--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -12,6 +12,7 @@ final class BackupRestoreManager: ObservableObject {
     private let learnVM: LearnViewModel
     private let practiceTimerVM: PracticeTimerViewModel
     private let customPatternsVM: CustomPatternsViewModel
+    private let setlistVM: SetlistViewModel
     private let settingsVM: SettingsViewModel
 
     init(
@@ -22,6 +23,7 @@ final class BackupRestoreManager: ObservableObject {
         learnVM: LearnViewModel,
         practiceTimerVM: PracticeTimerViewModel,
         customPatternsVM: CustomPatternsViewModel,
+        setlistVM: SetlistViewModel,
         settingsVM: SettingsViewModel
     ) {
         self.favoritesVM = favoritesVM
@@ -31,6 +33,7 @@ final class BackupRestoreManager: ObservableObject {
         self.learnVM = learnVM
         self.practiceTimerVM = practiceTimerVM
         self.customPatternsVM = customPatternsVM
+        self.setlistVM = setlistVM
         self.settingsVM = settingsVM
     }
 
@@ -50,6 +53,7 @@ final class BackupRestoreManager: ObservableObject {
             "practice_timer": practiceTimerVM.exportData(),
             "custom_strum_patterns": customPatternsVM.exportStrumData(),
             "custom_fingerpicking_patterns": customPatternsVM.exportFingerpickData(),
+            "setlists": setlistVM.exportData(),
         ]
         return (try? JSONSerialization.data(withJSONObject: backup, options: .prettyPrinted)) ?? Data()
     }
@@ -88,6 +92,9 @@ final class BackupRestoreManager: ObservableObject {
         }
         if let fpData = json["custom_fingerpicking_patterns"] as? [[String: Any]] {
             customPatternsVM.importFingerpickData(fpData)
+        }
+        if let setlists = json["setlists"] as? [[String: Any]] {
+            setlistVM.importData(setlists)
         }
     }
 

--- a/iosApp/UkuleleCompanion/Views/SettingsView.swift
+++ b/iosApp/UkuleleCompanion/Views/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @StateObject private var learnVM = LearnViewModel()
     @StateObject private var practiceTimerVM = PracticeTimerViewModel()
     @EnvironmentObject var customPatternsVM: CustomPatternsViewModel
+    @StateObject private var setlistVM = SetlistViewModel()
     @State private var backupManager: BackupRestoreManager?
     @State private var backupDocument: BackupDocument?
     @State private var showExporter = false
@@ -292,6 +293,7 @@ struct SettingsView: View {
                 learnVM: learnVM,
                 practiceTimerVM: practiceTimerVM,
                 customPatternsVM: customPatternsVM,
+                setlistVM: setlistVM,
                 settingsVM: viewModel
             )
         }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupData.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupData.kt
@@ -35,6 +35,8 @@ data class BackupData(
     val melodies: List<BackupMelody> = emptyList(),
     val learningProgress: BackupLearningProgress = BackupLearningProgress(),
     val settings: BackupSettings = BackupSettings(),
+    val achievements: Map<String, Long> = emptyMap(),
+    val practiceTimer: BackupPracticeTimer = BackupPracticeTimer(),
     val knownChords: List<String> = emptyList(),
 ) {
     companion object {
@@ -231,6 +233,27 @@ data class BackupMelodyNote(
 @Serializable
 data class BackupLearningProgress(
     val entries: Map<String, String> = emptyMap(),
+)
+
+// =============================================================================
+// Practice Timer
+// =============================================================================
+
+/**
+ * Serializable snapshot of practice timer statistics for backup.
+ *
+ * Import uses max-merge for cumulative stats so restoring never loses progress.
+ *
+ * @property dailyMinutes Per-day practice minutes keyed by "yyyy-MM-dd".
+ */
+@Serializable
+data class BackupPracticeTimer(
+    val totalMinutes: Int = 0,
+    val totalSessions: Int = 0,
+    val longestSession: Int = 0,
+    val lastSessionTime: Long = 0L,
+    val dailyGoal: Int = 15,
+    val dailyMinutes: Map<String, Int> = emptyMap(),
 )
 
 // =============================================================================

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
@@ -5,6 +5,7 @@ import com.baijum.ukufretboard.data.sync.BackupData
 import com.baijum.ukufretboard.data.sync.BackupFavorite
 import com.baijum.ukufretboard.data.sync.BackupFavoriteFolder
 import com.baijum.ukufretboard.data.sync.BackupLearningProgress
+import com.baijum.ukufretboard.data.sync.BackupPracticeTimer
 import com.baijum.ukufretboard.data.sync.BackupSetlist
 import com.baijum.ukufretboard.data.sync.BackupSettings
 import kotlinx.serialization.encodeToString
@@ -99,6 +100,7 @@ class BackupDataTest {
         assertTrue(data.melodies.isEmpty())
         assertTrue(data.knownChords.isEmpty())
         assertTrue(data.setlists.isEmpty())
+        assertTrue(data.achievements.isEmpty())
     }
 
     @Test
@@ -183,5 +185,58 @@ class BackupDataTest {
         assertEquals(0L, decoded.chordSheets[0].lastViewedAt)
         assertEquals(0L, decoded.chordSheets[0].totalViewTimeMs)
         assertTrue(decoded.setlists.isEmpty())
+        assertTrue(decoded.achievements.isEmpty())
+        assertEquals(BackupPracticeTimer(), decoded.practiceTimer)
+    }
+
+    @Test
+    fun backupWithAchievementsRoundTrips() {
+        val achievements = mapOf(
+            "first_chord" to 1000L,
+            "ten_songs" to 2000L,
+        )
+        val data = BackupData(
+            exportedAt = 12345L,
+            achievements = achievements,
+        )
+        val jsonStr = json.encodeToString(data)
+        val decoded = json.decodeFromString<BackupData>(jsonStr)
+        assertEquals(2, decoded.achievements.size)
+        assertEquals(1000L, decoded.achievements["first_chord"])
+        assertEquals(2000L, decoded.achievements["ten_songs"])
+    }
+
+    @Test
+    fun backupWithPracticeTimerRoundTrips() {
+        val timer = BackupPracticeTimer(
+            totalMinutes = 120,
+            totalSessions = 15,
+            longestSession = 30,
+            lastSessionTime = 99999L,
+            dailyGoal = 20,
+            dailyMinutes = mapOf("2026-06-01" to 25, "2026-06-02" to 15),
+        )
+        val data = BackupData(
+            exportedAt = 12345L,
+            practiceTimer = timer,
+        )
+        val jsonStr = json.encodeToString(data)
+        val decoded = json.decodeFromString<BackupData>(jsonStr)
+        assertEquals(120, decoded.practiceTimer.totalMinutes)
+        assertEquals(15, decoded.practiceTimer.totalSessions)
+        assertEquals(30, decoded.practiceTimer.longestSession)
+        assertEquals(99999L, decoded.practiceTimer.lastSessionTime)
+        assertEquals(20, decoded.practiceTimer.dailyGoal)
+        assertEquals(2, decoded.practiceTimer.dailyMinutes.size)
+        assertEquals(25, decoded.practiceTimer.dailyMinutes["2026-06-01"])
+    }
+
+    @Test
+    fun defaultAchievementsAndPracticeTimerAreEmpty() {
+        val data = BackupData()
+        assertTrue(data.achievements.isEmpty())
+        assertEquals(0, data.practiceTimer.totalMinutes)
+        assertEquals(0, data.practiceTimer.totalSessions)
+        assertTrue(data.practiceTimer.dailyMinutes.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #108 (data-loss bugs only; cross-platform format and iOS error surfacing deferred).

- **Setlists now backed up and restored** on both Android and iOS. `BackupData` already defined a `setlists` field and both platforms had import methods, but neither `BackupRestoreManager` was wired up.
- **Android settings restore no longer wipes unrelated settings**. Previously, `importBackup()` built a fresh `AppSettings` from only the backed-up subset (sound, display, tuning, fretboard) and called `replaceAll()`, which reset scale practice prefs, tuner prefs, noise gate, onboarding state, etc. to Kotlin defaults. Now merges backup fields into the current settings via `copy()`.
- **Achievements and practice timer added to Android backup**. `AchievementRepository.exportAll()/importAll()` existed but was never called. `PracticeTimerRepository` had no export/import at all -- added `exportAll()/importAll()` with max-merge strategy (matching iOS). Both are now wired into `BackupRestoreManager`.
- **KMP schema extended** with `achievements: Map<String, Long>` and `practiceTimer: BackupPracticeTimer` fields (backward compatible via default values).

## Test plan

- [ ] Android: Export backup, verify JSON contains `setlists`, `achievements`, and `practiceTimer` keys
- [ ] Android: Restore a backup and verify setlists, achievements, and practice stats are imported
- [ ] Android: Customize scale practice / tuner / noise gate settings, restore a backup, verify those settings are preserved
- [ ] iOS: Export backup, verify JSON contains `setlists` key
- [ ] iOS: Restore a backup with setlists data, verify setlists appear
- [ ] Shared module tests pass (`./gradlew :shared:build`)
- [ ] Android lint clean (`./gradlew lintDebug`)
- [ ] Android unit tests pass (`./gradlew testDebugUnitTest`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended backup/restore functionality to preserve practice timer statistics, achievements, and setlists.
  * Practice timer backups intelligently merge data to retain maximum session values.
  * Backup/restore now operates consistently across Android and iOS platforms.

* **Tests**
  * Added comprehensive test coverage for new backup fields and backward compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->