### PR TITLE
Fix: Negative modulo in Note/ChordInfo causes IndexOutOfBoundsException (#109)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
@@ -306,7 +306,7 @@ class FretboardViewModel : ViewModel() {
                     .sortedBy { it.key }
                     .mapNotNull { (i, fret) ->
                         fret?.let {
-                            val pc = (tuning[i].openPitchClass + it) % Notes.PITCH_CLASS_COUNT
+                            val pc = ((tuning[i].openPitchClass + it) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
                             Note(pitchClass = pc, name = Notes.pitchClassToName(pc))
                         }
                     }
@@ -437,7 +437,7 @@ class FretboardViewModel : ViewModel() {
     fun getNoteAt(stringIndex: Int, fret: Int): Note {
         val openPitchClass = tuning[stringIndex].openPitchClass
         val capo = _uiState.value.capoFret
-        val pitchClass = (openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT
+        val pitchClass = ((openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
         val overlay = _uiState.value.scaleOverlay
         val name = if (overlay.enabled && overlay.scale != null) {
             // Use key-aware enharmonic spelling when a scale is active
@@ -471,7 +471,7 @@ class FretboardViewModel : ViewModel() {
             .filter { it.value != null }
             .map { (stringIndex, fret) ->
                 val string = tuning[stringIndex]
-                val pitchClass = (string.openPitchClass + fret!! + capo) % Notes.PITCH_CLASS_COUNT
+                val pitchClass = ((string.openPitchClass + fret!! + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
                 val octave = computeOctave(string.openPitchClass, string.octave, fret + capo)
                 pitchClass to octave
             }
@@ -502,7 +502,7 @@ class FretboardViewModel : ViewModel() {
         val notes = voicing.frets.mapIndexedNotNull { index, fret ->
             if (fret == com.baijum.ukufretboard.domain.ChordVoicing.MUTED) return@mapIndexedNotNull null
             val string = tuning[index]
-            val pitchClass = (string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT
+            val pitchClass = ((string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
             val octave = computeOctave(string.openPitchClass, string.octave, fret)
             pitchClass to octave
         }
@@ -553,7 +553,7 @@ class FretboardViewModel : ViewModel() {
                 val notes = voicing.frets.mapIndexedNotNull { index, fret ->
                     if (fret == com.baijum.ukufretboard.domain.ChordVoicing.MUTED) return@mapIndexedNotNull null
                     val string = tuning[index]
-                    val pitchClass = (string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT
+                    val pitchClass = ((string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
                     val octave = computeOctave(string.openPitchClass, string.octave, fret)
                     pitchClass to octave
                 }
@@ -579,7 +579,7 @@ class FretboardViewModel : ViewModel() {
     private fun playNoteAt(stringIndex: Int, fret: Int) {
         val string = tuning[stringIndex]
         val capo = _uiState.value.capoFret
-        val pitchClass = (string.openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT
+        val pitchClass = ((string.openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
         val octave = computeOctave(string.openPitchClass, string.octave, fret + capo)
         viewModelScope.launch {
             ToneGenerator.playNote(
@@ -641,7 +641,7 @@ class FretboardViewModel : ViewModel() {
             .filter { it.value != null }
             .map { (stringIndex, fret) ->
                 val openPitchClass = tuning[stringIndex].openPitchClass
-                (openPitchClass + fret!! + capo) % Notes.PITCH_CLASS_COUNT
+                ((openPitchClass + fret!! + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
             }
         return ChordDetector.detect(pitchClasses)
     }

--- a/iosApp/UkuleleCompanion/ViewModels/FretboardViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/FretboardViewModel.swift
@@ -105,7 +105,7 @@ final class FretboardViewModel: ObservableObject {
     func getNoteAt(stringIndex: Int, fret: Int) -> (pitchClass: Int32, name: String) {
         let openPC = tuning[stringIndex].openPitchClass
         let effectiveFret = Int32(fret) + Int32(capoFret)
-        let pc = (openPC + effectiveFret) % Int32(Notes.shared.PITCH_CLASS_COUNT)
+        let pc = ((openPC + effectiveFret) % 12 + 12) % 12
 
         if scaleOverlay.enabled, scaleOverlay.scale != nil {
             let isMinor = scaleOverlay.scale!.intervals.count > 2
@@ -133,7 +133,7 @@ final class FretboardViewModel: ObservableObject {
         let pitchClasses: [Int32] = ordered.compactMap { (stringIndex, maybeFret) in
             guard let fret = maybeFret else { return nil }
             let openPC = tuning[stringIndex].openPitchClass
-            return (openPC + Int32(fret) + Int32(capoFret)) % 12
+            return ((openPC + Int32(fret) + Int32(capoFret)) % 12 + 12) % 12
         }
 
         tonePlayer.playChord(
@@ -152,7 +152,7 @@ final class FretboardViewModel: ObservableObject {
             let fret = frets[stringIndex]
             guard fret >= 0 else { return nil }
             let openPC = tuning[stringIndex].openPitchClass
-            return (openPC + Int32(fret) + Int32(capoFret)) % 12
+            return ((openPC + Int32(fret) + Int32(capoFret)) % 12 + 12) % 12
         }
 
         tonePlayer.playChord(
@@ -224,7 +224,7 @@ final class FretboardViewModel: ObservableObject {
 
     private func playNoteAt(stringIndex: Int, fret: Int) {
         let openPC = tuning[stringIndex].openPitchClass
-        let pc = (openPC + Int32(fret) + Int32(capoFret)) % 12
+        let pc = ((openPC + Int32(fret) + Int32(capoFret)) % 12 + 12) % 12
         tonePlayer.playNote(pitchClass: pc)
     }
 
@@ -232,7 +232,7 @@ final class FretboardViewModel: ObservableObject {
         selections.sorted(by: { $0.key < $1.key }).compactMap { (stringIndex, fret) in
             guard let f = fret else { return nil }
             let openPC = tuning[stringIndex].openPitchClass
-            return (openPC + Int32(f) + Int32(capoFret)) % 12
+            return ((openPC + Int32(f) + Int32(capoFret)) % 12 + 12) % 12
         }
     }
 
@@ -240,7 +240,7 @@ final class FretboardViewModel: ObservableObject {
         selections.sorted(by: { $0.key < $1.key }).compactMap { (stringIndex, fret) in
             guard let f = fret else { return nil }
             let openPC = tuning[stringIndex].openPitchClass
-            let pc = (openPC + Int32(f) + Int32(capoFret)) % 12
+            let pc = ((openPC + Int32(f) + Int32(capoFret)) % 12 + 12) % 12
             return (pc, Notes.shared.pitchClassToName(pitchClass: pc))
         }
     }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
@@ -232,7 +232,8 @@ object ChordInfo {
     fun bassPitchClass(frets: List<Int>, tuning: List<UkuleleString>): Int {
         val bassIndex = findBassStringIndex(frets, tuning)
         val string = tuning[bassIndex]
-        return (string.openPitchClass + frets[bassIndex]) % Notes.PITCH_CLASS_COUNT
+        val raw = string.openPitchClass + frets[bassIndex]
+        return ((raw % Notes.PITCH_CLASS_COUNT) + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
@@ -1,6 +1,7 @@
 package com.baijum.ukufretboard.domain
 
 import kotlin.math.log2
+import kotlin.math.roundToInt
 
 /**
  * Extracts a 12-bin chromagram (pitch-class energy profile) from an FFT
@@ -56,7 +57,7 @@ object Chromagram {
             // Map frequency → pitch class using equal temperament.
             // pitchClass = round(12 * log2(freq / C0)) mod 12
             val semitones = (12.0 * log2(freq.toDouble() / C0_HZ)).toFloat()
-            val pitchClass = ((semitones.toInt() % 12) + 12) % 12
+            val pitchClass = ((semitones.roundToInt() % 12) + 12) % 12
 
             // Accumulate squared magnitude for better energy representation.
             chroma[pitchClass] += magnitudes[bin] * magnitudes[bin]

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Note.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Note.kt
@@ -34,7 +34,7 @@ data class Note(
  * @return A [Note] representing the pitch at the given string/fret position.
  */
 fun calculateNote(openStringPitchClass: Int, fret: Int): Note {
-    val pitchClass = (openStringPitchClass + fret) % Notes.PITCH_CLASS_COUNT
+    val pitchClass = ((openStringPitchClass + fret) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
     return Note(
         pitchClass = pitchClass,
         name = Notes.pitchClassToName(pitchClass),

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordInfoTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordInfoTest.kt
@@ -291,6 +291,15 @@ class ChordInfoTest {
         assertEquals(2, ChordInfo.bassPitchClass(listOf(0, 2, 0, 0), highG))
     }
 
+    @Test
+    fun bassPitchClassNeverNegativeWithMutedStrings() {
+        // findBassStringIndex filters MUTED (-1) strings, but if a non-muted
+        // fret produces a negative sum the result must still be 0..11
+        val frets = listOf(-1, 0, 0, 0) // G muted, C/E/A open
+        val result = ChordInfo.bassPitchClass(frets, highG)
+        assertTrue(result in 0..11, "bassPitchClass=$result should be in 0..11")
+    }
+
     // --- slashNotation() ---
 
     @Test

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NoteTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NoteTest.kt
@@ -1,0 +1,48 @@
+package com.baijum.ukufretboard.domain
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NoteTest {
+
+    @Test
+    fun calculateNoteWithNegativeFretReturnsValidPitchClass() {
+        // C string (pc 0) at fret -1 should wrap to 11 (B), not -1
+        val note = calculateNote(0, -1)
+        assertEquals(11, note.pitchClass)
+        assertEquals("B", note.name)
+    }
+
+    @Test
+    fun calculateNoteWithZeroReturnsOpenString() {
+        // G string (pc 7) at fret 0 = G
+        val note = calculateNote(7, 0)
+        assertEquals(7, note.pitchClass)
+        assertEquals("G", note.name)
+    }
+
+    @Test
+    fun calculateNoteWrapsAtOctave() {
+        // C string (pc 0) at fret 12 wraps back to C
+        val note = calculateNote(0, 12)
+        assertEquals(0, note.pitchClass)
+    }
+
+    @Test
+    fun calculateNoteAlwaysReturnsValidRange() {
+        runBlocking {
+            checkAll(Arb.int(-100..100), Arb.int(-100..100)) { openPC, fret ->
+                val note = calculateNote(openPC, fret)
+                assertTrue(
+                    note.pitchClass in 0..11,
+                    "pitchClass ${note.pitchClass} out of range for openPC=$openPC, fret=$fret",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Apply the safe double-modulo pattern `((value % 12) + 12) % 12` to all pitch-class computations that used single `%` on potentially negative values, preventing `IndexOutOfBoundsException` when used as array indices
- Fix `calculateNote` (shared), `bassPitchClass` (shared), 7 sites in Android `FretboardViewModel`, and 6 sites in iOS `FretboardViewModel`
- Replace `toInt()` with `roundToInt()` in `Chromagram.compute()` to fix pitch-class boundary misclassification for frequencies near semitone edges
- Add `NoteTest` with property tests for negative inputs and a negative-case test to `ChordInfoTest`

Closes #109

## Test plan

- [x] `./gradlew :shared:build` passes (includes new NoteTest + updated ChordInfoTest)
- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Verify fretboard note display on device/emulator with capo settings
- [ ] Verify chord detection still works correctly after Chromagram rounding change

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of note pitch calculations across fretboard display and audio playback for all devices.
  * Enhanced handling of edge cases involving capo positions and muted strings.
  * Refined frequency-to-pitch detection precision for chord recognition.

* **Tests**
  * Expanded test coverage for note and chord pitch calculations to ensure consistency across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->