### PR TITLE
Fix: Voicing preview playback ignores capo offset (#118)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
@@ -498,12 +498,13 @@ class FretboardViewModel : ViewModel() {
      */
     fun playVoicing(voicing: com.baijum.ukufretboard.domain.ChordVoicing) {
         if (!soundSettings.enabled) return
+        val capo = _uiState.value.capoFret
 
         val notes = voicing.frets.mapIndexedNotNull { index, fret ->
             if (fret == com.baijum.ukufretboard.domain.ChordVoicing.MUTED) return@mapIndexedNotNull null
             val string = tuning[index]
-            val pitchClass = ((string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
-            val octave = computeOctave(string.openPitchClass, string.octave, fret)
+            val pitchClass = ((string.openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
+            val octave = computeOctave(string.openPitchClass, string.octave, fret + capo)
             pitchClass to octave
         }
 
@@ -547,14 +548,15 @@ class FretboardViewModel : ViewModel() {
         pauseMs: Long = 1000L,
     ) {
         if (!soundSettings.enabled || voicings.isEmpty()) return
+        val capo = _uiState.value.capoFret
 
         viewModelScope.launch {
             voicings.forEach { voicing ->
                 val notes = voicing.frets.mapIndexedNotNull { index, fret ->
                     if (fret == com.baijum.ukufretboard.domain.ChordVoicing.MUTED) return@mapIndexedNotNull null
                     val string = tuning[index]
-                    val pitchClass = ((string.openPitchClass + fret) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
-                    val octave = computeOctave(string.openPitchClass, string.octave, fret)
+                    val pitchClass = ((string.openPitchClass + fret + capo) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
+                    val octave = computeOctave(string.openPitchClass, string.octave, fret + capo)
                     pitchClass to octave
                 }
                 ToneGenerator.playChord(


### PR DESCRIPTION
## Summary

- Add `capoFret` to pitch-class and octave computation in `playVoicing()` and `playVoicingsSequentially()` in Android `FretboardViewModel`
- Matches the pattern already used in `playNoteAt()` and `getNoteAt()`; iOS equivalents already include capo correctly

Closes #118

## Test plan

- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Set a capo on the fretboard, tap a chord voicing preview -- should sound at the correct capo-shifted pitch

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chord voicing playback to correctly account for capo position when calculating pitches, ensuring accurate audio output with capo placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->