### PR TITLE
Fix: Android real-time practice features inaccessible to TalkBack users (#110)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionView.kt
@@ -44,7 +44,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -207,6 +210,12 @@ fun ChordTransitionView(
                     } else {
                         MaterialTheme.colorScheme.onSurface
                     },
+                    modifier = Modifier.semantics {
+                        if (currentChord == 0 && isPlaying) {
+                            liveRegion = LiveRegionMode.Assertive
+                        }
+                        contentDescription = chordNameA
+                    },
                 )
                 if (voicingA != null) {
                     VerticalChordDiagram(
@@ -227,6 +236,12 @@ fun ChordTransitionView(
                         MaterialTheme.colorScheme.primary
                     } else {
                         MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier.semantics {
+                        if (currentChord == 1 && isPlaying) {
+                            liveRegion = LiveRegionMode.Assertive
+                        }
+                        contentDescription = chordNameB
                     },
                 )
                 if (voicingB != null) {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -52,11 +52,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.baijum.ukufretboard.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import com.baijum.ukufretboard.audio.AudioCaptureEngine
 import com.baijum.ukufretboard.audio.MetronomeEngine
 import com.baijum.ukufretboard.data.ChordFormulas
@@ -146,12 +152,14 @@ fun PlayAlongView(
             AudioCaptureEngine.start(scope) { samples ->
                 val result = AudioChordDetector.detect(samples)
                 val chordFound = result.detection as? ChordDetector.DetectionResult.ChordFound
-                if (chordFound != null && result.confidence > 0.3f) {
-                    detectedChord = chordFound.result.name
-                    detectionConfidence = result.confidence
-                } else {
-                    detectedChord = null
-                    detectionConfidence = 0f
+                scope.launch(Dispatchers.Main) {
+                    if (chordFound != null && result.confidence > 0.3f) {
+                        detectedChord = chordFound.result.name
+                        detectionConfidence = result.confidence
+                    } else {
+                        detectedChord = null
+                        detectionConfidence = 0f
+                    }
                 }
             }
         }
@@ -266,11 +274,16 @@ fun PlayAlongView(
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
                 )
+                val currentChordName = chordNames.getOrElse(currentChordIndex) { "?" }
                 Text(
-                    text = chordNames.getOrElse(currentChordIndex) { "?" },
+                    text = currentChordName,
                     style = MaterialTheme.typography.displaySmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Assertive
+                        contentDescription = currentChordName
+                    },
                 )
 
                 if (isPlaying && detectedChord != null) {
@@ -303,6 +316,9 @@ fun PlayAlongView(
                                 MaterialTheme.colorScheme.primary
                             } else {
                                 MaterialTheme.colorScheme.error
+                            },
+                            modifier = Modifier.semantics {
+                                liveRegion = LiveRegionMode.Polite
                             },
                         )
                     }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPracticeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPracticeView.kt
@@ -46,6 +46,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -240,6 +244,12 @@ fun ProgressionPracticeView(
                                 MaterialTheme.colorScheme.onPrimary
                             } else {
                                 MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                            modifier = Modifier.semantics {
+                                if (isCurrent && isPlaying) {
+                                    liveRegion = LiveRegionMode.Assertive
+                                }
+                                contentDescription = chordName
                             },
                         )
                         Text(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
@@ -33,7 +33,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -471,6 +474,10 @@ private fun PlayAlongContent(
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                        contentDescription = currentName
+                    },
                 )
                 Text(
                     text = stringResource(R.string.scale_practice_note_of, state.currentNoteIndex + 1, state.playAlongNotes.size),


### PR DESCRIPTION
## Summary

- **Thread-safety fix**: `PlayAlongView` audio detection callback now dispatches state mutations to `Dispatchers.Main` via `scope.launch`, preventing `IllegalStateException` from updating Compose state off the main thread
- **TalkBack live regions**: Added `LiveRegionMode.Assertive` to chord name texts in `PlayAlongView`, `ChordTransitionView`, and `ProgressionPracticeView` so chord changes are announced on each beat; added `LiveRegionMode.Polite` to detection feedback and scale note text in `PlayAlongView` and `ScalePracticeView`
- **Content descriptions**: Added `contentDescription` semantics to dynamic text elements so TalkBack reads meaningful chord/note names

## Test plan

- [x] `./gradlew lintDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [ ] Manual: Enable TalkBack, run each practice mode (Play Along, Chord Transition, Progression Practice, Scale Practice), confirm chord/note changes are announced

Closes #110

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced screen reader support with live region announcements for chord names, detected chords, and current notes during playback and practice modes.
  * Improved semantic labeling across learning views to better assist users relying on assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->