### PR TITLE
Fix: iOS Songbook chords not reachable via VoiceOver (#111)

### DIFF
--- a/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
+++ b/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
@@ -38,6 +38,7 @@ struct FullScreenFretboardView: View {
                 }
             }
             .onTapGesture { showOverlayBriefly() }
+            .accessibilityHint("Double tap to show or hide controls")
         }
         .statusBarHidden(true)
         .onAppear { scheduleOverlayHide() }
@@ -150,8 +151,11 @@ struct FullScreenFretboardView: View {
                 Text(name).font(.title2.bold()).foregroundStyle(.white)
                 Text(quality).font(.caption).foregroundStyle(.gray)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(name) \(quality)")
         case .singleNote(let name, _):
             Text(name).font(.title2.bold()).foregroundStyle(.white)
+                .accessibilityLabel("Note: \(name)")
         default:
             Text("Tap frets").font(.subheadline).foregroundStyle(.gray)
         }
@@ -171,6 +175,7 @@ struct FullScreenFretboardView: View {
     }
 
     private func scheduleOverlayHide() {
+        guard !UIAccessibility.isVoiceOverRunning else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + autoHideDelay) {
             showOverlay = false
         }

--- a/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
+++ b/iosApp/UkuleleCompanion/Views/FullScreenFretboardView.swift
@@ -38,7 +38,7 @@ struct FullScreenFretboardView: View {
                 }
             }
             .onTapGesture { showOverlayBriefly() }
-            .accessibilityHint("Double tap to show or hide controls")
+            .accessibilityHint(UIAccessibility.isVoiceOverRunning ? "Controls remain visible for VoiceOver" : "Double tap to show or hide controls")
         }
         .statusBarHidden(true)
         .onAppear { scheduleOverlayHide() }

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -1293,8 +1293,14 @@ struct PerformanceModeView: View {
             }
         }
         .background(Color(uiColor: .systemBackground))
-        .onTapGesture { showControls.toggle() }
-        .accessibilityHint("Tap anywhere to show or hide controls")
+        .onTapGesture {
+            if UIAccessibility.isVoiceOverRunning {
+                showControls = true
+            } else {
+                showControls.toggle()
+            }
+        }
+        .accessibilityHint(UIAccessibility.isVoiceOverRunning ? "Controls remain visible for VoiceOver" : "Tap anywhere to show or hide controls")
         .statusBarHidden(true)
         .onAppear {
             if UIAccessibility.isVoiceOverRunning {

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -1104,14 +1104,16 @@ struct SongViewerView: View {
                                 .foregroundColor(.accentColor)
                                 .bold()
                                 .onTapGesture { tappedChord = element.text }
+                                .accessibilityLabel(element.text)
+                                .accessibilityAddTraits(.isButton)
+                                .accessibilityHint("Show chord diagram")
                         } else {
                             Text(element.text)
                                 .font(songFont)
+                                .accessibilityHidden(true)
                         }
                     }
                 }
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel("Chords: \(result.chordNames.joined(separator: ", "))")
 
                 if !result.lyrics.trimmingCharacters(in: .whitespaces).isEmpty {
                     Text(result.lyrics)
@@ -1255,6 +1257,7 @@ struct PerformanceModeView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
+                    .accessibilityLabel(isAutoScrolling ? "Pause auto-scroll" : "Start auto-scroll")
 
                     if isAutoScrolling {
                         Button { scrollSpeed = max(0.5, scrollSpeed - 0.5) } label: {
@@ -1262,15 +1265,18 @@ struct PerformanceModeView: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .accessibilityLabel("Decrease speed")
 
                         Text(String(format: "%.1fx", scrollSpeed))
                             .font(.caption.monospacedDigit())
+                            .accessibilityLabel("Speed \(String(format: "%.1f", scrollSpeed))x")
 
                         Button { scrollSpeed = min(5.0, scrollSpeed + 0.5) } label: {
                             Text("+")
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .accessibilityLabel("Increase speed")
                     }
 
                     Button { dismiss() } label: {
@@ -1288,6 +1294,17 @@ struct PerformanceModeView: View {
         }
         .background(Color(uiColor: .systemBackground))
         .onTapGesture { showControls.toggle() }
+        .accessibilityHint("Tap anywhere to show or hide controls")
         .statusBarHidden(true)
+        .onAppear {
+            if UIAccessibility.isVoiceOverRunning {
+                showControls = true
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIAccessibility.voiceOverStatusDidChangeNotification)) { _ in
+            if UIAccessibility.isVoiceOverRunning {
+                showControls = true
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Songbook chord row**: Replaced `.accessibilityElement(children: .ignore)` with per-chord `.accessibilityAddTraits(.isButton)`, `.accessibilityLabel`, and `.accessibilityHint("Show chord diagram")` so VoiceOver users can reach and activate individual chords to open diagrams. Non-chord spacer text is hidden from VoiceOver.
- **Full-screen fretboard overlay**: `scheduleOverlayHide()` now skips auto-hide when `UIAccessibility.isVoiceOverRunning` is true, keeping play/reset/close buttons always reachable. Added accessibility hint on the root ZStack and labels on the chord detection display.
- **Performance mode controls**: Controls stay visible when VoiceOver is active via `.onAppear` check and `voiceOverStatusDidChangeNotification` listener. Added `.accessibilityLabel` to scroll/pause, speed decrease/increase buttons, speed display, and an accessibility hint for toggling controls.

## Test plan

- [x] iOS build verified -- no new errors (pre-existing `PatternPlayer.swift` Swift 6 errors tracked in #126)
- [ ] Manual: Enable VoiceOver, navigate to Songbook, verify individual chords are reachable and activatable
- [ ] Manual: Open full-screen fretboard with VoiceOver, verify overlay stays visible and close button is reachable
- [ ] Manual: Enter performance mode with VoiceOver, verify controls are labeled and always visible

Closes #111

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver support across the full-screen fretboard and song/performance views with clearer accessibility labels for chord detection and single-note results.
  * Performance controls (scroll toggle, speed ±, speed display, exit) now have explicit accessibility labels and hints.
  * Controls remain visible while VoiceOver is active; non-essential text is hidden to reduce screen‑reader noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->