### PR TITLE
Fix: iOS AudioCaptureEngine ring buffer data race and session leak (#112)

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -14,6 +14,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
 
     private let engine = AVAudioEngine()
     private let sessionQueue = DispatchQueue(label: "com.baijum.ukufretboard.audiocapture")
+    private let bufferLock = NSLock()
     private var _isRunning = false  // only accessed on sessionQueue
     private var hardwareSampleRate: Double = sampleRate
     private var resampleAccumulator: Double = 0.0
@@ -37,7 +38,6 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             guard !_isRunning else { return false }
 
             #if !targetEnvironment(simulator)
-            // Upgrade audio session for recording
             let session = AVAudioSession.sharedInstance()
             do {
                 try session.setCategory(.playAndRecord, mode: .measurement,
@@ -53,6 +53,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             let inputFormat = inputNode.inputFormat(forBus: 0)
             guard inputFormat.channelCount > 0, inputFormat.sampleRate > 0 else {
                 print("AudioCaptureEngine: invalid input format (channels=\(inputFormat.channelCount), rate=\(inputFormat.sampleRate))")
+                deactivateRecordingSession()
                 return false
             }
             hardwareSampleRate = inputFormat.sampleRate
@@ -65,7 +66,10 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
                 sampleRate: hardwareSampleRate,
                 channels: 1,
                 interleaved: false
-            ) else { return false }
+            ) else {
+                deactivateRecordingSession()
+                return false
+            }
 
             inputNode.installTap(onBus: 0, bufferSize: AVAudioFrameCount(Self.hopSize), format: tapFormat) { [weak self] buffer, _ in
                 self?.processBuffer(buffer)
@@ -78,6 +82,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             } catch {
                 print("AudioCaptureEngine failed to start: \(error)")
                 inputNode.removeTap(onBus: 0)
+                deactivateRecordingSession()
                 return false
             }
         }
@@ -96,26 +101,14 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             engine.stop()
             _isRunning = false
 
-            #if !targetEnvironment(simulator)
-            // Deactivate recording session, then downgrade to playback-only
-            let session = AVAudioSession.sharedInstance()
-            do {
-                try session.setActive(false, options: .notifyOthersOnDeactivation)
-            } catch {
-                print("AudioCaptureEngine: failed to deactivate audio session: \(error)")
-            }
-            do {
-                try session.setCategory(.playback, mode: .default, options: [.defaultToSpeaker])
-                try session.setActive(true)
-            } catch {
-                print("AudioCaptureEngine: failed to downgrade audio session: \(error)")
-            }
-            #endif
+            deactivateRecordingSession()
 
+            bufferLock.lock()
             writePos = 0
             filled = 0
             resampleAccumulator = 0.0
             ringBuffer = [Float](repeating: 0, count: Self.frameSize)
+            bufferLock.unlock()
             return true
         }
         if didStop {
@@ -130,11 +123,12 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
         let samples = channelData[0]
         let count = Int(buffer.frameLength)
 
+        bufferLock.lock()
+        defer { bufferLock.unlock() }
+
         let needsResample = abs(hardwareSampleRate - Self.sampleRate) > 1.0
 
         if needsResample {
-            // Resample from hardware rate to 44.1kHz via linear interpolation.
-            // srcPos tracks fractional position in the input buffer, carried across calls.
             let step = hardwareSampleRate / Self.sampleRate
             var srcPos = resampleAccumulator
             while Int(srcPos) + 1 < count {
@@ -165,6 +159,24 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             onBuffer?(analysisBuf)
             filled -= Self.hopSize
         }
+    }
+
+    /// Deactivates the recording audio session and restores playback-only mode.
+    private func deactivateRecordingSession() {
+        #if !targetEnvironment(simulator)
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("AudioCaptureEngine: failed to deactivate audio session: \(error)")
+        }
+        do {
+            try session.setCategory(.playback, mode: .default, options: [.defaultToSpeaker])
+            try session.setActive(true)
+        } catch {
+            print("AudioCaptureEngine: failed to restore playback session: \(error)")
+        }
+        #endif
     }
 
     deinit {


### PR DESCRIPTION
## Summary

- **Ring buffer data race**: Added `NSLock` (`bufferLock`) to synchronize access between the audio tap thread (`processBuffer`) and `stop()` on `sessionQueue`. The lock protects `ringBuffer`, `writePos`, `filled`, and `resampleAccumulator` from concurrent mutation when an in-flight tap callback races with `stop()`.
- **Audio session leak**: Extracted `deactivateRecordingSession()` helper that deactivates the recording session and restores `.playback` mode. Called on all three error paths in `start()` where the session was previously left in `.playAndRecord` mode after a failed start (invalid input format, AVAudioFormat creation failure, engine.start() failure).
- **Code deduplication**: Replaced inline session cleanup in `stop()` with the shared helper.

Note: Problem #3 from the issue (PatternPlayer timer race) was already resolved in PR #128 / issue #126.

## Test plan

- [x] iOS build verified -- no new errors (pre-existing `SongbookView.swift` error tracked in #129)
- [ ] Manual: test tuner, play-along, and pitch monitor to verify audio capture works
- [ ] Manual: verify metronome/tone playback works after a failed audio capture attempt

Closes #112

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio capture reliability by fixing concurrency-related issues in audio processing.
  * Enhanced error recovery and resource management during audio session initialization and shutdown to prevent crashes and ensure proper cleanup across various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->