### PR TITLE
Fix: Kotlin serialization plugin version to match compiler (#132)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ coreKtx = "1.18.0"
 
 kotlinxCoroutines = "1.11.0"
 kotlinxSerializationJson = "1.11.0"
-kotlinxSerialization = "2.3.20"
 reorderable = "3.1.0"
 onnxruntime = "1.24.3"
 playPublisher = "4.0.0"
@@ -54,7 +53,7 @@ junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engi
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinxSerialization" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "playPublisher" }


### PR DESCRIPTION
## Summary
- Aligned the `kotlin-serialization` plugin version with the Kotlin compiler (`2.4.0`) — it was previously pinned to `kotlinxSerialization = "2.3.20"`, causing a version mismatch
- Removed the now-unused `kotlinxSerialization` version entry from `libs.versions.toml`

Closes #132

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aligned Kotlin serialization plugin version to match the Kotlin compiler version (2.4.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->