### PR TITLE
Fix: Add SDK-conditional FRAMEWORK_SEARCH_PATHS to Release configs (#133)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -902,9 +902,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 9QBV46NATP;
-				FRAMEWORK_SEARCH_PATHS = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../shared/build/bin/iosArm64/releaseFramework",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/bin/iosSimulatorArm64/releaseFramework",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UkuleleCompanion/Info.plist;
@@ -960,9 +964,13 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 11;
-				FRAMEWORK_SEARCH_PATHS = (
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../shared/build/bin/iosArm64/releaseFramework",
+				);
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/bin/iosSimulatorArm64/releaseFramework",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;


### PR DESCRIPTION
## Summary
- Replaced unconditional `FRAMEWORK_SEARCH_PATHS` in both Release build configurations (app target and test target) with SDK-conditional paths matching the Debug config pattern
- Device builds use `iosArm64/releaseFramework`, simulator builds now correctly use `iosSimulatorArm64/releaseFramework`

Closes #133

## Test plan
- [x] iOS simulator build succeeds (`xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` -- BUILD SUCCEEDED)

Made with [Cursor](https://cursor.com)