### PR TITLE
Fix: Add kotlinx.serialization ProGuard/R8 keep rules (#134)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -5,3 +5,20 @@
 # ONNX Runtime
 -keep class ai.onnxruntime.** { *; }
 -keepclassmembers class ai.onnxruntime.** { *; }
+
+# kotlinx.serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.baijum.ukufretboard.**$$serializer { *; }
+-keepclassmembers class com.baijum.ukufretboard.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.baijum.ukufretboard.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}


### PR DESCRIPTION
## Summary
- Added kotlinx.serialization keep rules to `app/proguard-rules.pro` to prevent R8 from stripping serializer companions, `$$serializer` classes, and `@SerialName` annotations during release minification
- Covers both the `kotlinx.serialization.json` library classes and all 16 `@Serializable` data classes under `com.baijum.ukufretboard`

Closes #134

## Test plan
- [x] `./gradlew assembleRelease` passes (BUILD SUCCESSFUL)

Made with [Cursor](https://cursor.com)