### PR TITLE
Fix: Add thread synchronization to FFTProcessor and PitchDetector (#135)

### DIFF
--- a/shared/src/androidMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.android.kt
+++ b/shared/src/androidMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.android.kt
@@ -1,0 +1,9 @@
+package com.baijum.ukufretboard.platform
+
+import java.util.concurrent.locks.ReentrantLock
+
+actual class PlatformLock {
+    private val lock = ReentrantLock()
+    actual fun lock() = lock.lock()
+    actual fun unlock() = lock.unlock()
+}

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FFTProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FFTProcessor.kt
@@ -1,5 +1,7 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.platform.PlatformLock
+import com.baijum.ukufretboard.platform.withLock
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -25,6 +27,7 @@ object FFTProcessor {
      * Key: FFT size N. Value: array of pairs (wReal, wImag) indexed by
      * stage length. Lazily populated on first use and reused thereafter.
      */
+    private val cacheLock = PlatformLock()
     private val twiddleCache = HashMap<Int, TwiddleFactors>()
 
     /**
@@ -61,7 +64,9 @@ object FFTProcessor {
     }
 
     private fun getTwiddle(n: Int): TwiddleFactors {
-        return twiddleCache.getOrPut(n) { TwiddleFactors(n) }
+        return cacheLock.withLock {
+            twiddleCache.getOrPut(n) { TwiddleFactors(n) }
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
@@ -1,5 +1,7 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.platform.PlatformLock
+import com.baijum.ukufretboard.platform.withLock
 import kotlin.math.abs
 import kotlin.math.pow
 
@@ -89,6 +91,7 @@ object PitchDetector {
     // --- Pre-allocated FFT work buffers ------------------------------------
     // These are reused across frames (~43/sec) to avoid GC pressure from
     // allocating 4 large arrays per frame in computeDifferenceFunctionFFT.
+    private val bufferLock = PlatformLock()
     private var cachedFftSize = 0
     private var fftRefReal = FloatArray(0)
     private var fftRefImag = FloatArray(0)
@@ -324,40 +327,43 @@ object PitchDetector {
 
         // --- FFT-based cross-correlation ------------------------------------
         val fftSize = nextPow2(n * 2) // zero-pad to avoid circular aliasing
-        ensureFftBuffers(fftSize)
 
-        // Reference window: x[0..W-1], zero-padded
-        for (i in 0 until halfLen) fftRefReal[i] = samples[i]
-        // fftRefImag already zeroed by ensureFftBuffers
+        return bufferLock.withLock {
+            ensureFftBuffers(fftSize)
 
-        // Full signal: x[0..N-1], zero-padded
-        for (i in 0 until n) fftSigReal[i] = samples[i]
-        // fftSigImag already zeroed by ensureFftBuffers
+            // Reference window: x[0..W-1], zero-padded
+            for (i in 0 until halfLen) fftRefReal[i] = samples[i]
+            // fftRefImag already zeroed by ensureFftBuffers
 
-        FFTProcessor.fft(fftRefReal, fftRefImag)
-        FFTProcessor.fft(fftSigReal, fftSigImag)
+            // Full signal: x[0..N-1], zero-padded
+            for (i in 0 until n) fftSigReal[i] = samples[i]
+            // fftSigImag already zeroed by ensureFftBuffers
 
-        // Cross-spectrum: conj(Ref) * Sig
-        // Reuse fftRefReal/fftRefImag to store the result.
-        for (i in 0 until fftSize) {
-            val ar = fftRefReal[i]; val ai = fftRefImag[i]
-            val br = fftSigReal[i]; val bi = fftSigImag[i]
-            fftRefReal[i] = ar * br + ai * bi   // real part of conj(A)*B
-            fftRefImag[i] = ai * br - ar * bi   // imag part of conj(A)*B
+            FFTProcessor.fft(fftRefReal, fftRefImag)
+            FFTProcessor.fft(fftSigReal, fftSigImag)
+
+            // Cross-spectrum: conj(Ref) * Sig
+            // Reuse fftRefReal/fftRefImag to store the result.
+            for (i in 0 until fftSize) {
+                val ar = fftRefReal[i]; val ai = fftRefImag[i]
+                val br = fftSigReal[i]; val bi = fftSigImag[i]
+                fftRefReal[i] = ar * br + ai * bi   // real part of conj(A)*B
+                fftRefImag[i] = ai * br - ar * bi   // imag part of conj(A)*B
+            }
+
+            FFTProcessor.ifft(fftRefReal, fftRefImag)
+            // fftRefReal[tau] now contains r(tau) = sum_{j=0}^{W-1} x[j]*x[j+tau]
+
+            // --- Assemble SDF ---------------------------------------------------
+            val diff = FloatArray(maxLag + 1)
+            for (tau in 1..maxLag) {
+                val energyTau = prefixSq[tau + halfLen] - prefixSq[tau]
+                diff[tau] = (energy0 + energyTau - 2.0 * fftRefReal[tau].toDouble())
+                    .coerceAtLeast(0.0) // clamp tiny negative values from FP rounding
+                    .toFloat()
+            }
+            diff
         }
-
-        FFTProcessor.ifft(fftRefReal, fftRefImag)
-        // fftRefReal[tau] now contains r(tau) = sum_{j=0}^{W-1} x[j]*x[j+tau]
-
-        // --- Assemble SDF ---------------------------------------------------
-        val diff = FloatArray(maxLag + 1)
-        for (tau in 1..maxLag) {
-            val energyTau = prefixSq[tau + halfLen] - prefixSq[tau]
-            diff[tau] = (energy0 + energyTau - 2.0 * fftRefReal[tau].toDouble())
-                .coerceAtLeast(0.0) // clamp tiny negative values from FP rounding
-                .toFloat()
-        }
-        return diff
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.kt
@@ -1,0 +1,15 @@
+package com.baijum.ukufretboard.platform
+
+expect class PlatformLock() {
+    fun lock()
+    fun unlock()
+}
+
+inline fun <T> PlatformLock.withLock(block: () -> T): T {
+    lock()
+    try {
+        return block()
+    } finally {
+        unlock()
+    }
+}

--- a/shared/src/iosMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.ios.kt
+++ b/shared/src/iosMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.ios.kt
@@ -1,0 +1,9 @@
+package com.baijum.ukufretboard.platform
+
+import platform.Foundation.NSRecursiveLock
+
+actual class PlatformLock {
+    private val lock = NSRecursiveLock()
+    actual fun lock() = lock.lock()
+    actual fun unlock() = lock.unlock()
+}

--- a/shared/src/jvmMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/baijum/ukufretboard/platform/PlatformLock.jvm.kt
@@ -1,0 +1,9 @@
+package com.baijum.ukufretboard.platform
+
+import java.util.concurrent.locks.ReentrantLock
+
+actual class PlatformLock {
+    private val lock = ReentrantLock()
+    actual fun lock() = lock.lock()
+    actual fun unlock() = lock.unlock()
+}


### PR DESCRIPTION
## Summary
- Added a KMP-compatible `expect/actual PlatformLock` (`ReentrantLock` on JVM/Android, `NSRecursiveLock` on iOS) in the shared `platform` package
- Protected `FFTProcessor.getTwiddle()` with a lock to prevent `HashMap` corruption from concurrent `getOrPut()` calls
- Protected `PitchDetector.computeDifferenceFunctionFFT()` with a lock to prevent concurrent corruption of the pre-allocated FFT work buffers

Closes #135

## Test plan
- [x] `./gradlew :shared:build` passes (all KMP targets)
- [x] `./gradlew testDebugUnitTest` passes (FFT + PitchDetector tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safety for audio processing operations across Android, iOS, and JVM platforms to prevent concurrent access conflicts and ensure reliable signal analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->