### PR TITLE
Add: Release build verification to CI workflows (#138)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,15 +27,20 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run lint
+      - name: Run Debug lint
         run: ./gradlew lintDebug
 
-      - name: Upload lint report
+      - name: Run Release lint
+        run: ./gradlew lintRelease
+
+      - name: Upload lint reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: lint-report
-          path: app/build/reports/lint-results-debug.html
+          name: lint-reports
+          path: |
+            app/build/reports/lint-results-debug.html
+            app/build/reports/lint-results-release.html
 
   shared-tests:
     name: Shared Module Tests
@@ -131,6 +136,40 @@ jobs:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk
 
+  release-build:
+    name: Release Build
+    needs: [ lint, unit-tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Upload R8 mapping file
+        uses: actions/upload-artifact@v7
+        with:
+          name: r8-mapping
+          path: app/build/outputs/mapping/release/mapping.txt
+
+      - name: Report release APK size
+        run: |
+          APK=$(find app/build/outputs/apk/release -name '*.apk' | head -1)
+          SIZE_BYTES=$(stat -c%s "$APK")
+          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1048576}")
+          echo "### Release APK Size" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release APK**: ${SIZE_MB} MB (${SIZE_BYTES} bytes)" >> "$GITHUB_STEP_SUMMARY"
+
   apk-size:
     name: APK Size
     needs: build
@@ -154,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [33]
+        api-level: [26, 33, 35]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -88,6 +88,18 @@ jobs:
             -enableCodeCoverage YES \
             -resultBundlePath TestResults
 
+      - name: Build shared Release framework
+        run: ./gradlew :shared:linkReleaseFrameworkIosSimulatorArm64
+
+      - name: Build iOS app (Release)
+        run: |
+          xcodebuild build \
+            -project iosApp/UkuleleCompanion.xcodeproj \
+            -scheme UkuleleCompanion \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -configuration Release \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -96,7 +96,7 @@ jobs:
           xcodebuild build \
             -project iosApp/UkuleleCompanion.xcodeproj \
             -scheme UkuleleCompanion \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest,arch=arm64' \
             -configuration Release \
             CODE_SIGNING_ALLOWED=NO
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -96,8 +96,9 @@ jobs:
           xcodebuild build \
             -project iosApp/UkuleleCompanion.xcodeproj \
             -scheme UkuleleCompanion \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest,arch=arm64' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -configuration Release \
+            ONLY_ACTIVE_ARCH=YES \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Upload test results


### PR DESCRIPTION
## Summary

- Add **Release Build** job to `android.yml` — runs `assembleRelease` (unsigned APK) to verify R8/ProGuard rules, uploads `mapping.txt` as artifact, reports release APK size in step summary
- Add **`lintRelease`** step alongside existing `lintDebug` in the Lint job
- Expand instrumented test **matrix from API 33 to [26, 33, 35]** (minSdk, current, targetSdk)
- Add **KMP Release framework** build and **iOS Release `xcodebuild`** to `ios.yml`

These additions would have caught issues #132 (serialization mismatch), #133 (iOS Release framework paths), and #134 (missing ProGuard rules) before they reached `main`.

Closes #138

## Test plan

- [ ] New `Release Build` job passes in Android CI (assembleRelease succeeds without signing secrets)
- [ ] `r8-mapping` artifact is uploaded
- [ ] Release APK size appears in step summary
- [ ] `lintRelease` passes alongside `lintDebug`
- [ ] Instrumented tests pass on API 26, 33, and 35
- [ ] iOS Release framework build + xcodebuild Release succeed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android CI now runs and publishes both Debug and Release lint reports, builds Release APKs, uploads mapping files, and reports APK size.
  * Android instrumented tests expanded to additional emulator API levels (26, 33, 35).
  * iOS CI now adds Release build steps for simulator and builds the shared Release framework and Release app alongside existing Debug runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->