### PR TITLE
Test: Add AchievementChecker and TunerViewModel arbitration tests (#136)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -198,6 +198,19 @@ class TunerViewModel : ViewModel() {
         private const val TELEMETRY_LOG_INTERVAL_FRAMES = 25L
 
         private const val TAG = "TunerViewModel"
+
+        @androidx.annotation.VisibleForTesting
+        internal fun semitoneDistance(aHz: Double, bHz: Double): Double {
+            if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
+            return abs(12.0 * log2(aHz / bHz))
+        }
+
+        @androidx.annotation.VisibleForTesting
+        internal fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
+            if (aHz <= 0.0 || bHz <= 0.0) return false
+            val semitones = semitoneDistance(aHz, bHz)
+            return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
+        }
     }
 
     // --- State ---------------------------------------------------------------
@@ -799,16 +812,11 @@ class TunerViewModel : ViewModel() {
         }
     }
 
-    private fun semitoneDistance(aHz: Double, bHz: Double): Double {
-        if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
-        return abs(12.0 * log2(aHz / bHz))
-    }
+    private fun semitoneDistance(aHz: Double, bHz: Double): Double =
+        Companion.semitoneDistance(aHz, bHz)
 
-    private fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
-        if (aHz <= 0.0 || bHz <= 0.0) return false
-        val semitones = semitoneDistance(aHz, bHz)
-        return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
-    }
+    private fun isOctaveRelation(aHz: Double, bHz: Double): Boolean =
+        Companion.isOctaveRelation(aHz, bHz)
 
     private fun updateNeuralConsistency(neuralFrequencyHz: Double) {
         if (neuralFrequencyHz <= 0.0) {

--- a/app/src/test/java/com/baijum/ukufretboard/domain/AchievementCheckerTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/domain/AchievementCheckerTest.kt
@@ -1,0 +1,202 @@
+package com.baijum.ukufretboard.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AchievementCheckerTest {
+
+    @Test
+    fun totalCountMatchesDefinedAchievements() {
+        assertEquals(AchievementChecker.ALL.size, AchievementChecker.totalCount())
+    }
+
+    @Test
+    fun allIdsAreUnique() {
+        val ids = AchievementChecker.ALL.map { it.id }
+        assertEquals("Achievement IDs must be unique", ids.size, ids.toSet().size)
+    }
+
+    // ── Practice streak achievements ─────────────────────────────────
+
+    @Test
+    fun streak3UnlocksAtThreeDays() {
+        val ctx2 = AchievementContext(currentStreak = 2)
+        val ctx3 = AchievementContext(currentStreak = 3)
+        val ach = AchievementChecker.ALL.first { it.id == "streak_3" }
+        assertFalse(ach.condition(ctx2))
+        assertTrue(ach.condition(ctx3))
+    }
+
+    @Test
+    fun streak7UnlocksAtSevenDays() {
+        val ach = AchievementChecker.ALL.first { it.id == "streak_7" }
+        assertFalse(ach.condition(AchievementContext(currentStreak = 6)))
+        assertTrue(ach.condition(AchievementContext(currentStreak = 7)))
+    }
+
+    @Test
+    fun streak30UnlocksAtThirtyDays() {
+        val ach = AchievementChecker.ALL.first { it.id == "streak_30" }
+        assertFalse(ach.condition(AchievementContext(currentStreak = 29)))
+        assertTrue(ach.condition(AchievementContext(currentStreak = 30)))
+    }
+
+    // ── Theory lesson achievements ───────────────────────────────────
+
+    @Test
+    fun firstLessonUnlocksAtOne() {
+        val ach = AchievementChecker.ALL.first { it.id == "first_lesson" }
+        assertFalse(ach.condition(AchievementContext(completedLessons = 0)))
+        assertTrue(ach.condition(AchievementContext(completedLessons = 1)))
+    }
+
+    @Test
+    fun halfLessonsRequiresHalf() {
+        val ach = AchievementChecker.ALL.first { it.id == "half_lessons" }
+        assertFalse(ach.condition(AchievementContext(completedLessons = 4, totalLessons = 10)))
+        assertTrue(ach.condition(AchievementContext(completedLessons = 5, totalLessons = 10)))
+    }
+
+    @Test
+    fun halfLessonsDoesNotUnlockWithZeroTotal() {
+        val ach = AchievementChecker.ALL.first { it.id == "half_lessons" }
+        assertFalse(ach.condition(AchievementContext(completedLessons = 0, totalLessons = 0)))
+    }
+
+    @Test
+    fun allLessonsRequiresAll() {
+        val ach = AchievementChecker.ALL.first { it.id == "all_lessons" }
+        assertFalse(ach.condition(AchievementContext(completedLessons = 9, totalLessons = 10)))
+        assertTrue(ach.condition(AchievementContext(completedLessons = 10, totalLessons = 10)))
+    }
+
+    // ── Quiz achievements ────────────────────────────────────────────
+
+    @Test
+    fun quizMilestonesRequireCorrectCount() {
+        val q10 = AchievementChecker.ALL.first { it.id == "quiz_10" }
+        val q50 = AchievementChecker.ALL.first { it.id == "quiz_50" }
+        val q100 = AchievementChecker.ALL.first { it.id == "quiz_100" }
+        assertFalse(q10.condition(AchievementContext(quizCorrect = 9)))
+        assertTrue(q10.condition(AchievementContext(quizCorrect = 10)))
+        assertFalse(q50.condition(AchievementContext(quizCorrect = 49)))
+        assertTrue(q50.condition(AchievementContext(quizCorrect = 50)))
+        assertFalse(q100.condition(AchievementContext(quizCorrect = 99)))
+        assertTrue(q100.condition(AchievementContext(quizCorrect = 100)))
+    }
+
+    @Test
+    fun quizStreakAchievements() {
+        val s5 = AchievementChecker.ALL.first { it.id == "perfect_streak_5" }
+        val s10 = AchievementChecker.ALL.first { it.id == "perfect_streak_10" }
+        assertFalse(s5.condition(AchievementContext(quizBestStreak = 4)))
+        assertTrue(s5.condition(AchievementContext(quizBestStreak = 5)))
+        assertFalse(s10.condition(AchievementContext(quizBestStreak = 9)))
+        assertTrue(s10.condition(AchievementContext(quizBestStreak = 10)))
+    }
+
+    // ── Ear training achievements ────────────────────────────────────
+
+    @Test
+    fun earFirstUnlocksWithEitherType() {
+        val ach = AchievementChecker.ALL.first { it.id == "ear_first" }
+        assertFalse(ach.condition(AchievementContext(intervalTotal = 0, chordEarTotal = 0)))
+        assertTrue(ach.condition(AchievementContext(intervalTotal = 1, chordEarTotal = 0)))
+        assertTrue(ach.condition(AchievementContext(intervalTotal = 0, chordEarTotal = 1)))
+    }
+
+    @Test
+    fun ear50CombinesBothTypes() {
+        val ach = AchievementChecker.ALL.first { it.id == "ear_50" }
+        assertFalse(ach.condition(AchievementContext(intervalTotal = 25, chordEarTotal = 24)))
+        assertTrue(ach.condition(AchievementContext(intervalTotal = 25, chordEarTotal = 25)))
+    }
+
+    @Test
+    fun earAccuracy80RequiresMinimumAndThreshold() {
+        val ach = AchievementChecker.ALL.first { it.id == "ear_accuracy_80" }
+        assertFalse("Needs 50+ total", ach.condition(
+            AchievementContext(intervalTotal = 10, intervalCorrect = 10, chordEarTotal = 0, chordEarCorrect = 0),
+        ))
+        assertFalse("79% not enough", ach.condition(
+            AchievementContext(intervalTotal = 50, intervalCorrect = 39, chordEarTotal = 0, chordEarCorrect = 0),
+        ))
+        assertTrue("80% with 50 total", ach.condition(
+            AchievementContext(intervalTotal = 30, intervalCorrect = 24, chordEarTotal = 20, chordEarCorrect = 16),
+        ))
+    }
+
+    // ── Songbook & favorites ─────────────────────────────────────────
+
+    @Test
+    fun songbookMilestones() {
+        val s1 = AchievementChecker.ALL.first { it.id == "first_song" }
+        val s5 = AchievementChecker.ALL.first { it.id == "songs_5" }
+        val s10 = AchievementChecker.ALL.first { it.id == "songs_10" }
+        assertFalse(s1.condition(AchievementContext(songsCount = 0)))
+        assertTrue(s1.condition(AchievementContext(songsCount = 1)))
+        assertTrue(s5.condition(AchievementContext(songsCount = 5)))
+        assertTrue(s10.condition(AchievementContext(songsCount = 10)))
+    }
+
+    @Test
+    fun favoriteMilestones() {
+        val f5 = AchievementChecker.ALL.first { it.id == "fav_5" }
+        val f25 = AchievementChecker.ALL.first { it.id == "fav_25" }
+        assertFalse(f5.condition(AchievementContext(favoritesCount = 4)))
+        assertTrue(f5.condition(AchievementContext(favoritesCount = 5)))
+        assertTrue(f25.condition(AchievementContext(favoritesCount = 25)))
+    }
+
+    // ── Scale practice ───────────────────────────────────────────────
+
+    @Test
+    fun scalePracticeMilestones() {
+        val s1 = AchievementChecker.ALL.first { it.id == "scale_first" }
+        val s25 = AchievementChecker.ALL.first { it.id == "scale_25" }
+        assertFalse(s1.condition(AchievementContext(scalePracticeTotal = 0)))
+        assertTrue(s1.condition(AchievementContext(scalePracticeTotal = 1)))
+        assertTrue(s25.condition(AchievementContext(scalePracticeTotal = 25)))
+    }
+
+    // ── checkNewlyEarned ─────────────────────────────────────────────
+
+    @Test
+    fun checkNewlyEarnedExcludesAlreadyUnlocked() {
+        val ctx = AchievementContext(currentStreak = 7, completedLessons = 1, totalLessons = 10)
+        val alreadyUnlocked = setOf("streak_3", "first_lesson")
+        val newly = AchievementChecker.checkNewlyEarned(ctx, alreadyUnlocked)
+        assertTrue("streak_7 should be newly earned", newly.any { it.id == "streak_7" })
+        assertFalse("streak_3 already unlocked", newly.any { it.id == "streak_3" })
+        assertFalse("first_lesson already unlocked", newly.any { it.id == "first_lesson" })
+    }
+
+    @Test
+    fun checkNewlyEarnedReturnsEmptyWhenNothingNew() {
+        val ctx = AchievementContext()
+        val newly = AchievementChecker.checkNewlyEarned(ctx, emptySet())
+        assertTrue("No conditions met, nothing newly earned", newly.isEmpty())
+    }
+
+    @Test
+    fun checkNewlyEarnedReturnsMultipleSimultaneously() {
+        val ctx = AchievementContext(
+            currentStreak = 30,
+            completedLessons = 10,
+            totalLessons = 10,
+            quizCorrect = 100,
+            quizBestStreak = 10,
+            intervalTotal = 30,
+            intervalCorrect = 25,
+            chordEarTotal = 20,
+            chordEarCorrect = 16,
+            scalePracticeTotal = 25,
+            songsCount = 10,
+            favoritesCount = 25,
+        )
+        val newly = AchievementChecker.checkNewlyEarned(ctx, emptySet())
+        assertEquals("All achievements should be newly earned", AchievementChecker.totalCount(), newly.size)
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/TunerArbitrationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/TunerArbitrationTest.kt
@@ -1,0 +1,101 @@
+package com.baijum.ukufretboard.viewmodel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the pitch arbitration helper functions in [TunerViewModel].
+ *
+ * These verify semitone distance calculations and octave detection logic
+ * used to arbitrate between YIN and neural pitch estimates.
+ */
+class TunerArbitrationTest {
+
+    // ── semitoneDistance ──────────────────────────────────────────────
+
+    @Test
+    fun semitoneDistanceUnisonIsZero() {
+        assertEquals(0.0, TunerViewModel.semitoneDistance(440.0, 440.0), 0.001)
+    }
+
+    @Test
+    fun semitoneDistanceOctaveIsTwelve() {
+        assertEquals(12.0, TunerViewModel.semitoneDistance(440.0, 880.0), 0.01)
+        assertEquals(12.0, TunerViewModel.semitoneDistance(880.0, 440.0), 0.01)
+    }
+
+    @Test
+    fun semitoneDistanceTwoOctavesIsTwentyFour() {
+        assertEquals(24.0, TunerViewModel.semitoneDistance(220.0, 880.0), 0.01)
+    }
+
+    @Test
+    fun semitoneDistancePerfectFifthIsSeven() {
+        val a4 = 440.0
+        val e5 = a4 * Math.pow(2.0, 7.0 / 12.0)
+        assertEquals(7.0, TunerViewModel.semitoneDistance(a4, e5), 0.01)
+    }
+
+    @Test
+    fun semitoneDistanceZeroOrNegativeReturnsMaxValue() {
+        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(0.0, 440.0), 0.0)
+        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(440.0, 0.0), 0.0)
+        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(-1.0, 440.0), 0.0)
+        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(440.0, -1.0), 0.0)
+    }
+
+    @Test
+    fun semitoneDistanceIsSymmetric() {
+        val d1 = TunerViewModel.semitoneDistance(440.0, 523.25)
+        val d2 = TunerViewModel.semitoneDistance(523.25, 440.0)
+        assertEquals(d1, d2, 0.001)
+    }
+
+    // ── isOctaveRelation ─────────────────────────────────────────────
+
+    @Test
+    fun isOctaveRelationTrueForExactOctave() {
+        assertTrue(TunerViewModel.isOctaveRelation(440.0, 880.0))
+        assertTrue(TunerViewModel.isOctaveRelation(880.0, 440.0))
+    }
+
+    @Test
+    fun isOctaveRelationTrueForDoubleOctave() {
+        assertTrue(TunerViewModel.isOctaveRelation(220.0, 880.0))
+        assertTrue(TunerViewModel.isOctaveRelation(880.0, 220.0))
+    }
+
+    @Test
+    fun isOctaveRelationTrueWithSlightDetuning() {
+        val slightlySharp = 880.0 * Math.pow(2.0, 0.8 / 12.0)
+        assertTrue(TunerViewModel.isOctaveRelation(440.0, slightlySharp))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForUnison() {
+        assertFalse(TunerViewModel.isOctaveRelation(440.0, 440.0))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForFifth() {
+        val e5 = 440.0 * Math.pow(2.0, 7.0 / 12.0)
+        assertFalse(TunerViewModel.isOctaveRelation(440.0, e5))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForZeroOrNegative() {
+        assertFalse(TunerViewModel.isOctaveRelation(0.0, 440.0))
+        assertFalse(TunerViewModel.isOctaveRelation(440.0, -1.0))
+    }
+
+    // ── Tuning status thresholds ─────────────────────────────────────
+
+    @Test
+    fun inTuneCentsThresholdValues() {
+        assertEquals(6.0, TunerViewModel.IN_TUNE_CENTS, 0.0)
+        assertEquals(2.0, TunerViewModel.PRECISION_IN_TUNE_CENTS, 0.0)
+        assertEquals(15.0, TunerViewModel.CLOSE_CENTS, 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

- Add 20 unit tests for `AchievementChecker`: boundary-value checks for all 21 achievement conditions across practice streaks, theory lessons, quiz milestones, ear training, songbook, favorites, and scale practice; plus `checkNewlyEarned` filtering and simultaneous multi-unlock
- Add 13 unit tests for `TunerViewModel` arbitration helpers: `semitoneDistance` calculations (unison, octave, double octave, perfect fifth, symmetry, invalid inputs) and `isOctaveRelation` detection (exact/detuned octaves, non-octave intervals, edge cases)
- Extract `semitoneDistance` and `isOctaveRelation` as `internal` companion functions with `@VisibleForTesting` on `TunerViewModel`, keeping private instance delegates for backward compatibility

Phase 2 PR 2.1 of issue #136 (Android app module test coverage).

## Test plan

- [x] All 33 new tests pass locally (`./gradlew :app:testDebugUnitTest`)
- [ ] CI passes (unit tests + lint)


Made with [Cursor](https://cursor.com)