### PR TITLE
Test: Add NeuralPitchSupervisor tensor parsing tests (#136)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisor.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisor.kt
@@ -18,9 +18,62 @@ import kotlin.math.max
 class NeuralPitchSupervisor(context: Context) : AutoCloseable {
     companion object {
         private const val MODEL_ASSET = "swift_f0_model.onnx"
-        private const val MIN_FREQ_HZ = 46.875
-        private const val MAX_FREQ_HZ = 2093.75
-        private const val MIN_CONFIDENCE = 0.50
+        internal const val MIN_FREQ_HZ = 46.875
+        internal const val MAX_FREQ_HZ = 2093.75
+        internal const val MIN_CONFIDENCE = 0.50
+
+        @androidx.annotation.VisibleForTesting
+        internal fun extractFloatSeries(value: Any?): FloatArray? {
+            return when (value) {
+                is FloatArray -> value
+                is Array<*> -> flattenArrayValue(value)
+                else -> null
+            }
+        }
+
+        @androidx.annotation.VisibleForTesting
+        internal fun flattenArrayValue(array: Array<*>): FloatArray? {
+            if (array.isEmpty()) return FloatArray(0)
+            val first = array[0]
+            return when (first) {
+                is FloatArray -> {
+                    val total = array.filterIsInstance<FloatArray>().sumOf { it.size }
+                    val out = FloatArray(total)
+                    var pos = 0
+                    array.filterIsInstance<FloatArray>().forEach { row ->
+                        row.copyInto(out, pos)
+                        pos += row.size
+                    }
+                    out
+                }
+                is Array<*> -> {
+                    val list = mutableListOf<Float>()
+                    array.filterIsInstance<Array<*>>().forEach { nested ->
+                        nested.filterIsInstance<Float>().forEach { list.add(it) }
+                        nested.filterIsInstance<Double>().forEach { list.add(it.toFloat()) }
+                    }
+                    list.toFloatArray()
+                }
+                is Number -> array.mapNotNull { (it as? Number)?.toFloat() }.toFloatArray()
+                else -> null
+            }
+        }
+
+        @androidx.annotation.VisibleForTesting
+        internal fun parseMiddleEstimate(
+            pitchArray: FloatArray,
+            confidenceArray: FloatArray?,
+        ): NeuralPitchResult? {
+            if (pitchArray.isEmpty()) return null
+            val idx = pitchArray.size / 2
+            val freq = pitchArray[idx].toDouble()
+            val conf = confidenceArray?.getOrNull(
+                max(0, idx.coerceAtMost(confidenceArray.lastIndex)),
+            )?.toDouble() ?: 0.0
+            if (freq !in MIN_FREQ_HZ..MAX_FREQ_HZ) return null
+            if (conf < MIN_CONFIDENCE) return null
+            return NeuralPitchResult(frequencyHz = freq, confidence = conf)
+        }
     }
 
     private val env: OrtEnvironment = OrtEnvironment.getEnvironment()
@@ -68,59 +121,13 @@ class NeuralPitchSupervisor(context: Context) : AutoCloseable {
 
     private fun extractMiddleEstimate(outputs: OrtSession.Result): NeuralPitchResult? {
         if (outputs.size() == 0) return null
-
-        val pitchArray = extractFloatSeries(outputs[0].value) ?: return null
-        if (pitchArray.isEmpty()) return null
-
+        val pitchArray = Companion.extractFloatSeries(outputs[0].value) ?: return null
         val confidenceArray = if (outputs.size() >= 2) {
-            extractFloatSeries(outputs[1].value)
+            Companion.extractFloatSeries(outputs[1].value)
         } else {
             null
         }
-
-        val idx = pitchArray.size / 2
-        val freq = pitchArray[idx].toDouble()
-        val conf = confidenceArray?.getOrNull(max(0, idx.coerceAtMost(confidenceArray.lastIndex)))?.toDouble() ?: 0.0
-
-        if (freq !in MIN_FREQ_HZ..MAX_FREQ_HZ) return null
-        if (conf < MIN_CONFIDENCE) return null
-
-        return NeuralPitchResult(frequencyHz = freq, confidence = conf)
-    }
-
-    private fun extractFloatSeries(value: Any?): FloatArray? {
-        return when (value) {
-            is FloatArray -> value
-            is Array<*> -> flattenArrayValue(value)
-            else -> null
-        }
-    }
-
-    private fun flattenArrayValue(array: Array<*>): FloatArray? {
-        if (array.isEmpty()) return FloatArray(0)
-        val first = array[0]
-        return when (first) {
-            is FloatArray -> {
-                val total = array.filterIsInstance<FloatArray>().sumOf { it.size }
-                val out = FloatArray(total)
-                var pos = 0
-                array.filterIsInstance<FloatArray>().forEach { row ->
-                    row.copyInto(out, pos)
-                    pos += row.size
-                }
-                out
-            }
-            is Array<*> -> {
-                val list = mutableListOf<Float>()
-                array.filterIsInstance<Array<*>>().forEach { nested ->
-                    nested.filterIsInstance<Float>().forEach { list.add(it) }
-                    nested.filterIsInstance<Double>().forEach { list.add(it.toFloat()) }
-                }
-                list.toFloatArray()
-            }
-            is Number -> array.mapNotNull { (it as? Number)?.toFloat() }.toFloatArray()
-            else -> null
-        }
+        return Companion.parseMiddleEstimate(pitchArray, confidenceArray)
     }
 
     override fun close() {

--- a/app/src/test/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisorTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisorTest.kt
@@ -1,0 +1,150 @@
+package com.baijum.ukufretboard.domain
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for the tensor parsing and middle-estimate extraction logic in
+ * [NeuralPitchSupervisor]. These exercise the companion functions that
+ * convert raw ONNX output values into [NeuralPitchResult].
+ */
+class NeuralPitchSupervisorTest {
+
+    // ── extractFloatSeries ───────────────────────────────────────────
+
+    @Test
+    fun extractFloatSeriesFromDirectFloatArray() {
+        val input = floatArrayOf(440f, 441f, 442f)
+        val result = NeuralPitchSupervisor.extractFloatSeries(input)
+        assertArrayEquals(input, result, 0.001f)
+    }
+
+    @Test
+    fun extractFloatSeriesFromNestedFloatArrays() {
+        val input: Array<Any> = arrayOf(
+            floatArrayOf(100f, 200f),
+            floatArrayOf(300f),
+        )
+        val result = NeuralPitchSupervisor.extractFloatSeries(input)
+        assertNotNull(result)
+        assertArrayEquals(floatArrayOf(100f, 200f, 300f), result!!, 0.001f)
+    }
+
+    @Test
+    fun extractFloatSeriesFromNumberArray() {
+        @Suppress("USELESS_CAST")
+        val input: Array<Any> = arrayOf(440f as Number, 441f as Number, 442f as Number)
+        val result = NeuralPitchSupervisor.extractFloatSeries(input)
+        assertNotNull(result)
+        assertArrayEquals(floatArrayOf(440f, 441f, 442f), result!!, 0.001f)
+    }
+
+    @Test
+    fun extractFloatSeriesReturnsNullForUnsupportedType() {
+        assertNull(NeuralPitchSupervisor.extractFloatSeries("not a tensor"))
+        assertNull(NeuralPitchSupervisor.extractFloatSeries(42))
+        assertNull(NeuralPitchSupervisor.extractFloatSeries(null))
+    }
+
+    @Test
+    fun extractFloatSeriesEmptyArrayReturnsEmpty() {
+        val input: Array<Any> = emptyArray()
+        val result = NeuralPitchSupervisor.extractFloatSeries(input)
+        assertNotNull(result)
+        assertEquals(0, result!!.size)
+    }
+
+    // ── flattenArrayValue ────────────────────────────────────────────
+
+    @Test
+    fun flattenArrayValueDoublyNestedWithDoubles() {
+        val inner1: Array<Any> = arrayOf(440.0, 441.0)
+        val inner2: Array<Any> = arrayOf(442.0)
+        val input: Array<Any> = arrayOf(inner1, inner2)
+        val result = NeuralPitchSupervisor.flattenArrayValue(input)
+        assertNotNull(result)
+        assertEquals(3, result!!.size)
+        assertEquals(440f, result[0], 0.01f)
+        assertEquals(441f, result[1], 0.01f)
+        assertEquals(442f, result[2], 0.01f)
+    }
+
+    @Test
+    fun flattenArrayValueReturnsNullForUnknownElementType() {
+        val input: Array<Any> = arrayOf("string1", "string2")
+        assertNull(NeuralPitchSupervisor.flattenArrayValue(input))
+    }
+
+    // ── parseMiddleEstimate ──────────────────────────────────────────
+
+    @Test
+    fun parseMiddleEstimatePicksMiddleElement() {
+        val pitches = floatArrayOf(200f, 440f, 600f)
+        val confidences = floatArrayOf(0.7f, 0.95f, 0.8f)
+        val result = NeuralPitchSupervisor.parseMiddleEstimate(pitches, confidences)
+        assertNotNull(result)
+        assertEquals(440.0, result!!.frequencyHz, 0.01)
+        assertEquals(0.95, result.confidence, 0.01)
+    }
+
+    @Test
+    fun parseMiddleEstimateReturnsNullForEmptyPitch() {
+        assertNull(NeuralPitchSupervisor.parseMiddleEstimate(FloatArray(0), null))
+    }
+
+    @Test
+    fun parseMiddleEstimateRejectsFrequencyBelowRange() {
+        val pitches = floatArrayOf(10f)
+        val confidences = floatArrayOf(0.9f)
+        assertNull(NeuralPitchSupervisor.parseMiddleEstimate(pitches, confidences))
+    }
+
+    @Test
+    fun parseMiddleEstimateRejectsFrequencyAboveRange() {
+        val pitches = floatArrayOf(3000f)
+        val confidences = floatArrayOf(0.9f)
+        assertNull(NeuralPitchSupervisor.parseMiddleEstimate(pitches, confidences))
+    }
+
+    @Test
+    fun parseMiddleEstimateRejectsLowConfidence() {
+        val pitches = floatArrayOf(440f)
+        val confidences = floatArrayOf(0.3f)
+        assertNull(NeuralPitchSupervisor.parseMiddleEstimate(pitches, confidences))
+    }
+
+    @Test
+    fun parseMiddleEstimateReturnsNullWhenConfidenceArrayMissing() {
+        val pitches = floatArrayOf(440f)
+        val result = NeuralPitchSupervisor.parseMiddleEstimate(pitches, null)
+        assertNull("0.0 default confidence is below MIN_CONFIDENCE", result)
+    }
+
+    @Test
+    fun parseMiddleEstimateAcceptsBoundaryFrequencies() {
+        val lowBound = NeuralPitchSupervisor.MIN_FREQ_HZ.toFloat()
+        val highBound = NeuralPitchSupervisor.MAX_FREQ_HZ.toFloat()
+        val conf = floatArrayOf(0.9f)
+
+        val lowResult = NeuralPitchSupervisor.parseMiddleEstimate(floatArrayOf(lowBound), conf)
+        assertNotNull("MIN_FREQ_HZ should be accepted", lowResult)
+        assertEquals(lowBound.toDouble(), lowResult!!.frequencyHz, 0.01)
+
+        val highResult = NeuralPitchSupervisor.parseMiddleEstimate(floatArrayOf(highBound), conf)
+        assertNotNull("MAX_FREQ_HZ should be accepted", highResult)
+        assertEquals(highBound.toDouble(), highResult!!.frequencyHz, 0.01)
+    }
+
+    @Test
+    fun parseMiddleEstimateHandlesMismatchedArrayLengths() {
+        val pitches = floatArrayOf(200f, 440f, 600f, 800f, 1000f)
+        val confidences = floatArrayOf(0.9f, 0.95f)
+        val result = NeuralPitchSupervisor.parseMiddleEstimate(pitches, confidences)
+        assertNotNull(result)
+        assertEquals(600.0, result!!.frequencyHz, 0.01)
+        assertEquals(0.95, result.confidence, 0.01)
+    }
+}


### PR DESCRIPTION
## Summary

- Add 15 unit tests for `NeuralPitchSupervisor` tensor parsing logic: `extractFloatSeries` (5 tests), `flattenArrayValue` (2 tests), and `parseMiddleEstimate` (8 tests)
- Tests cover direct FloatArray input, nested batch arrays, Number arrays, unsupported types, empty inputs, middle-element selection, frequency range validation at boundaries, confidence thresholds, null confidence fallback, and mismatched array lengths
- Extract `extractFloatSeries`, `flattenArrayValue`, and `parseMiddleEstimate` as `internal` companion functions with `@VisibleForTesting` so tensor parsing can be tested without loading an ONNX model

Phase 2 PR 2.2 of issue #136 (Android app module test coverage).

## Test plan

- [x] All 15 new tests pass locally (`./gradlew :app:testDebugUnitTest`)
- [ ] CI passes (unit tests + lint)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for pitch detection processing.

* **Tests**
  * Added comprehensive test coverage for pitch detection validation and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->