### PR TITLE
Test: Add FretboardViewModel unit tests (#136)

### DIFF
--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/FretboardViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/FretboardViewModelTest.kt
@@ -1,0 +1,230 @@
+package com.baijum.ukufretboard.viewmodel
+
+import com.baijum.ukufretboard.data.Notes
+import com.baijum.ukufretboard.data.Scale
+import com.baijum.ukufretboard.data.Scales
+import com.baijum.ukufretboard.data.TuningSettings
+import com.baijum.ukufretboard.data.UkuleleTuning
+import com.baijum.ukufretboard.domain.ChordDetector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FretboardViewModelTest {
+
+    private lateinit var vm: FretboardViewModel
+
+    @Before
+    fun setUp() {
+        vm = FretboardViewModel()
+    }
+
+    // ── Initial state ────────────────────────────────────────────────
+
+    @Test
+    fun initialStateHasNoSelectionsAndShowsNoteNames() {
+        val state = vm.uiState.value
+        state.selections.values.forEach { assertNull(it) }
+        assertTrue(state.showNoteNames)
+        assertEquals(0, state.capoFret)
+        assertEquals(FretboardViewModel.LAST_FRET, state.lastFret)
+        assertTrue(state.detectionResult is ChordDetector.DetectionResult.NoSelection)
+    }
+
+    @Test
+    fun initialTuningIsStandardHighG() {
+        assertEquals(4, vm.tuning.size)
+        assertEquals("G", vm.tuning[0].name)
+        assertEquals(7, vm.tuning[0].openPitchClass)
+        assertEquals("C", vm.tuning[1].name)
+        assertEquals(0, vm.tuning[1].openPitchClass)
+        assertEquals("E", vm.tuning[2].name)
+        assertEquals(4, vm.tuning[2].openPitchClass)
+        assertEquals("A", vm.tuning[3].name)
+        assertEquals(9, vm.tuning[3].openPitchClass)
+    }
+
+    // ── toggleFret ───────────────────────────────────────────────────
+
+    @Test
+    fun toggleFretSelectsAndDeselects() {
+        vm.toggleFret(0, 3)
+        assertEquals(3, vm.uiState.value.selections[0])
+
+        vm.toggleFret(0, 3)
+        assertNull(vm.uiState.value.selections[0])
+    }
+
+    @Test
+    fun toggleFretReplacesExistingSelection() {
+        vm.toggleFret(1, 2)
+        assertEquals(2, vm.uiState.value.selections[1])
+
+        vm.toggleFret(1, 5)
+        assertEquals(5, vm.uiState.value.selections[1])
+    }
+
+    @Test
+    fun toggleFretBlockedByCapo() {
+        vm.setCapoFret(3)
+        vm.toggleFret(0, 2)
+        assertNull("Fret behind capo should be blocked", vm.uiState.value.selections[0])
+
+        vm.toggleFret(0, 3)
+        assertNull("Fret at capo should be blocked", vm.uiState.value.selections[0])
+
+        vm.toggleFret(0, 0)
+        assertEquals("Open string allowed with capo", 0, vm.uiState.value.selections[0])
+
+        vm.toggleFret(0, 0)
+        vm.toggleFret(0, 4)
+        assertEquals("Fret beyond capo allowed", 4, vm.uiState.value.selections[0])
+    }
+
+    @Test
+    fun toggleFretTriggersChordDetection() {
+        vm.toggleFret(0, 0)
+        vm.toggleFret(1, 0)
+        vm.toggleFret(2, 0)
+        vm.toggleFret(3, 0)
+        val result = vm.uiState.value.detectionResult
+        assertTrue("All open strings should detect a chord", result is ChordDetector.DetectionResult.ChordFound)
+    }
+
+    // ── clearAll ─────────────────────────────────────────────────────
+
+    @Test
+    fun clearAllResetsSelectionsPreservesNoteNames() {
+        vm.setShowNoteNames(false)
+        vm.toggleFret(0, 3)
+        vm.toggleFret(2, 5)
+        vm.clearAll()
+        val state = vm.uiState.value
+        state.selections.values.forEach { assertNull(it) }
+        assertFalse("showNoteNames should be preserved", state.showNoteNames)
+    }
+
+    // ── setCapoFret ──────────────────────────────────────────────────
+
+    @Test
+    fun setCapoFretClearsSelectionsBehindCapo() {
+        vm.toggleFret(0, 2)
+        vm.toggleFret(1, 5)
+        vm.setCapoFret(3)
+        assertNull("Fret 2 behind capo 3 should be cleared", vm.uiState.value.selections[0])
+        assertEquals("Fret 5 beyond capo 3 should remain", 5, vm.uiState.value.selections[1])
+        assertEquals(3, vm.uiState.value.capoFret)
+    }
+
+    @Test
+    fun setCapoFretCoercesToLastFret() {
+        vm.setCapoFret(99)
+        assertEquals(vm.uiState.value.lastFret, vm.uiState.value.capoFret)
+    }
+
+    // ── setLastFret ──────────────────────────────────────────────────
+
+    @Test
+    fun setLastFretCoercesRange() {
+        vm.setLastFret(5)
+        assertEquals(FretboardViewModel.LAST_FRET, vm.uiState.value.lastFret)
+
+        vm.setLastFret(30)
+        assertEquals(FretboardViewModel.MAX_LAST_FRET, vm.uiState.value.lastFret)
+    }
+
+    @Test
+    fun setLastFretClearsSelectionsAndCoercesCapo() {
+        vm.setCapoFret(5)
+        vm.setLastFret(22)
+        vm.toggleFret(0, 20)
+        assertEquals(20, vm.uiState.value.selections[0])
+
+        vm.setLastFret(15)
+        assertNull("Fret 20 beyond new last fret 15 should be cleared", vm.uiState.value.selections[0])
+        assertEquals(5, vm.uiState.value.capoFret)
+    }
+
+    // ── getNoteAt ────────────────────────────────────────────────────
+
+    @Test
+    fun getNoteAtComputesPitchClassCorrectly() {
+        val noteG0 = vm.getNoteAt(0, 0)
+        assertEquals(7, noteG0.pitchClass)
+
+        val noteA1 = vm.getNoteAt(0, 2)
+        assertEquals(9, noteA1.pitchClass)
+
+        val noteC0 = vm.getNoteAt(1, 0)
+        assertEquals(0, noteC0.pitchClass)
+    }
+
+    @Test
+    fun getNoteAtAccountsForCapo() {
+        vm.setCapoFret(2)
+        val note = vm.getNoteAt(1, 0)
+        assertEquals("C string open + capo 2 = D (pitch class 2)", 2, note.pitchClass)
+    }
+
+    // ── fingerPositions ──────────────────────────────────────────────
+
+    @Test
+    fun fingerPositionsFormatsCorrectly() {
+        assertEquals("x - x - x - x", vm.uiState.value.fingerPositions)
+
+        vm.toggleFret(0, 0)
+        vm.toggleFret(1, 0)
+        vm.toggleFret(2, 0)
+        vm.toggleFret(3, 3)
+        assertEquals("0 - 0 - 0 - 3", vm.uiState.value.fingerPositions)
+    }
+
+    // ── Scale overlay ────────────────────────────────────────────────
+
+    @Test
+    fun toggleScaleOverlayTogglesEnabled() {
+        assertFalse(vm.uiState.value.scaleOverlay.enabled)
+        vm.toggleScaleOverlay()
+        assertTrue(vm.uiState.value.scaleOverlay.enabled)
+        vm.toggleScaleOverlay()
+        assertFalse(vm.uiState.value.scaleOverlay.enabled)
+    }
+
+    @Test
+    fun setScaleComputesScaleNotesAndEnables() {
+        val major = Scales.ALL.first { it.name == "Major" }
+        vm.setScaleRoot(0)
+        vm.setScale(major)
+        val overlay = vm.uiState.value.scaleOverlay
+        assertTrue("Setting a scale should enable the overlay", overlay.enabled)
+        assertEquals(major.intervals.size, overlay.scaleNotes.size)
+        assertTrue("C major should contain pitch class 0 (C)", 0 in overlay.scaleNotes)
+    }
+
+    // ── buildTuning ──────────────────────────────────────────────────
+
+    @Test
+    fun buildTuningHighGAndLowGDiffer() {
+        val highG = FretboardViewModel.buildTuning(UkuleleTuning.HIGH_G)
+        val lowG = FretboardViewModel.buildTuning(UkuleleTuning.LOW_G)
+        assertEquals(4, highG.size)
+        assertEquals(4, lowG.size)
+        assertEquals(highG[0].openPitchClass, lowG[0].openPitchClass)
+        assertTrue(
+            "Low-G should have a lower octave on the G string",
+            lowG[0].octave < highG[0].octave,
+        )
+    }
+
+    @Test
+    fun setTuningSettingsUpdatesTuningAndState() {
+        vm.setTuningSettings(TuningSettings(tuning = UkuleleTuning.LOW_G))
+        val state = vm.uiState.value
+        assertEquals(4, state.tuning.size)
+        assertEquals(UkuleleTuning.LOW_G.octaves[0], state.tuning[0].octave)
+    }
+}


### PR DESCRIPTION
## Summary

- Add 18 unit tests for `FretboardViewModel` covering all public state management APIs
- Tests exercise fret toggling (select/deselect/replace/capo blocking), `clearAll` preserving settings, capo management (clearing behind capo, coercion), last fret range adjustment, note-at-position calculation with and without capo, `fingerPositions` derived formatting, scale overlay toggle and note computation, `buildTuning` High-G vs Low-G, and tuning settings propagation
- No production code changes needed -- the ViewModel's state logic is directly testable through `StateFlow`

Phase 3 PR 3.1 of issue #136 (Android app module test coverage).

## Test plan

- [x] All 18 new tests pass locally (`./gradlew :app:testDebugUnitTest`)
- [ ] CI passes (unit tests + lint)


Made with [Cursor](https://cursor.com)