### PR TITLE
Test: Add ChordLibraryViewModel and ScalePracticeViewModel tests (#136)

### DIFF
--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModelTest.kt
@@ -1,0 +1,115 @@
+package com.baijum.ukufretboard.viewmodel
+
+import com.baijum.ukufretboard.data.ChordCategory
+import com.baijum.ukufretboard.data.ChordFormulas
+import com.baijum.ukufretboard.data.UkuleleTuning
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ChordLibraryViewModelTest {
+
+    private lateinit var vm: ChordLibraryViewModel
+
+    @Before
+    fun setUp() {
+        vm = ChordLibraryViewModel()
+    }
+
+    @Test
+    fun initialStateAutoSelectsFirstTriadFormula() {
+        val state = vm.uiState.value
+        assertEquals(0, state.selectedRoot)
+        assertEquals(ChordCategory.TRIAD, state.selectedCategory)
+        assertNotNull(state.selectedFormula)
+        assertEquals(
+            ChordFormulas.BY_CATEGORY[ChordCategory.TRIAD]?.first(),
+            state.selectedFormula,
+        )
+        assertTrue("Should generate voicings for default selection", state.voicings.isNotEmpty())
+    }
+
+    @Test
+    fun selectRootChangesRootAndRegeneratesVoicings() {
+        vm.selectRoot(7)
+        val state = vm.uiState.value
+        assertEquals(7, state.selectedRoot)
+        assertTrue(state.voicings.isNotEmpty())
+    }
+
+    @Test
+    fun selectCategoryAutoSelectsFirstFormula() {
+        vm.selectCategory(ChordCategory.SEVENTH)
+        val state = vm.uiState.value
+        assertEquals(ChordCategory.SEVENTH, state.selectedCategory)
+        assertEquals(
+            ChordFormulas.BY_CATEGORY[ChordCategory.SEVENTH]?.first(),
+            state.selectedFormula,
+        )
+    }
+
+    @Test
+    fun selectFormulaRegeneratesVoicings() {
+        val formulas = ChordFormulas.BY_CATEGORY[ChordCategory.TRIAD]!!
+        val minorFormula = formulas.first { it.symbol == "m" }
+        vm.selectFormula(minorFormula)
+        assertEquals(minorFormula, vm.uiState.value.selectedFormula)
+        assertTrue(vm.uiState.value.voicings.isNotEmpty())
+    }
+
+    @Test
+    fun transposeUpWrapsAroundCorrectly() {
+        vm.selectRoot(0)
+        vm.transpose(1)
+        assertEquals(1, vm.uiState.value.selectedRoot)
+
+        vm.selectRoot(11)
+        vm.transpose(1)
+        assertEquals(0, vm.uiState.value.selectedRoot)
+    }
+
+    @Test
+    fun transposeDownWrapsAroundCorrectly() {
+        vm.selectRoot(0)
+        vm.transpose(-1)
+        assertEquals(11, vm.uiState.value.selectedRoot)
+    }
+
+    @Test
+    fun currentChordNameCombinesRootAndSymbol() {
+        vm.selectRoot(0)
+        assertEquals("C", vm.currentChordName().substringBefore("m").takeIf { it == "C" } ?: vm.currentChordName())
+
+        val minorFormula = ChordFormulas.BY_CATEGORY[ChordCategory.TRIAD]!!.first { it.symbol == "m" }
+        vm.selectRoot(9)
+        vm.selectFormula(minorFormula)
+        assertEquals("Am", vm.currentChordName())
+    }
+
+    @Test
+    fun searchQueryReturnsResults() {
+        vm.updateSearchQuery("Am")
+        assertTrue(vm.searchResults.value.isNotEmpty())
+        assertEquals("Am", vm.searchQuery.value)
+    }
+
+    @Test
+    fun selectSearchResultUpdatesState() {
+        vm.updateSearchQuery("Dm7")
+        val results = vm.searchResults.value
+        if (results.isNotEmpty()) {
+            vm.selectSearchResult(results[0])
+            assertEquals("", vm.searchQuery.value)
+            assertTrue(vm.searchResults.value.isEmpty())
+        }
+    }
+
+    @Test
+    fun setTuningRegeneratesVoicings() {
+        val lowG = FretboardViewModel.buildTuning(UkuleleTuning.LOW_G)
+        vm.setTuning(lowG)
+        assertTrue(vm.uiState.value.voicings.isNotEmpty())
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModelTest.kt
@@ -79,8 +79,9 @@ class ChordLibraryViewModelTest {
 
     @Test
     fun currentChordNameCombinesRootAndSymbol() {
+        val defaultFormula = ChordFormulas.BY_CATEGORY[ChordCategory.TRIAD]!!.first()
         vm.selectRoot(0)
-        assertEquals("C", vm.currentChordName().substringBefore("m").takeIf { it == "C" } ?: vm.currentChordName())
+        assertEquals("C${defaultFormula.symbol}", vm.currentChordName())
 
         val minorFormula = ChordFormulas.BY_CATEGORY[ChordCategory.TRIAD]!!.first { it.symbol == "m" }
         vm.selectRoot(9)
@@ -99,11 +100,10 @@ class ChordLibraryViewModelTest {
     fun selectSearchResultUpdatesState() {
         vm.updateSearchQuery("Dm7")
         val results = vm.searchResults.value
-        if (results.isNotEmpty()) {
-            vm.selectSearchResult(results[0])
-            assertEquals("", vm.searchQuery.value)
-            assertTrue(vm.searchResults.value.isEmpty())
-        }
+        assertTrue("Search for 'Dm7' should return results", results.isNotEmpty())
+        vm.selectSearchResult(results[0])
+        assertEquals("", vm.searchQuery.value)
+        assertTrue(vm.searchResults.value.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
@@ -1,0 +1,160 @@
+package com.baijum.ukufretboard.viewmodel
+
+import com.baijum.ukufretboard.data.ScaleCategory
+import com.baijum.ukufretboard.data.ScalePracticeSettings
+import com.baijum.ukufretboard.data.Scales
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ScalePracticeViewModelTest {
+
+    private lateinit var vm: ScalePracticeViewModel
+
+    @Before
+    fun setUp() {
+        vm = ScalePracticeViewModel()
+    }
+
+    @Test
+    fun initialStateDefaults() {
+        val state = vm.uiState.value
+        assertEquals(PracticeMode.PLAY_ALONG, state.mode)
+        assertEquals(0, state.selectedRoot)
+        assertEquals(ScalePracticeSettings.DEFAULT_BPM, state.bpm)
+        assertEquals(PlayDirection.ASCENDING, state.direction)
+        assertEquals(PlaybackState.STOPPED, state.playbackState)
+        assertFalse(state.showFretboard)
+    }
+
+    @Test
+    fun setModeUpdatesMode() {
+        vm.setMode(PracticeMode.QUIZ)
+        assertEquals(PracticeMode.QUIZ, vm.uiState.value.mode)
+        vm.setMode(PracticeMode.EAR_TRAINING)
+        assertEquals(PracticeMode.EAR_TRAINING, vm.uiState.value.mode)
+    }
+
+    @Test
+    fun setRootCoercesToValidRange() {
+        vm.setRoot(7)
+        assertEquals(7, vm.uiState.value.selectedRoot)
+
+        vm.setRoot(-1)
+        assertEquals(0, vm.uiState.value.selectedRoot)
+
+        vm.setRoot(15)
+        assertEquals(11, vm.uiState.value.selectedRoot)
+    }
+
+    @Test
+    fun setCategoryFiltersAvailableScales() {
+        vm.setCategory(ScaleCategory.BLUES)
+        val scales = vm.uiState.value.availableScales
+        assertTrue(scales.isNotEmpty())
+        assertTrue(scales.all { ScaleCategory.BLUES in it.categories })
+    }
+
+    @Test
+    fun setCategoryNullShowsAllScales() {
+        vm.setCategory(ScaleCategory.BLUES)
+        vm.setCategory(null)
+        assertEquals(Scales.ALL, vm.uiState.value.availableScales)
+    }
+
+    @Test
+    fun setBpmCoercesToRange() {
+        vm.setBpm(10)
+        assertEquals(ScalePracticeSettings.MIN_BPM, vm.uiState.value.bpm)
+
+        vm.setBpm(500)
+        assertEquals(ScalePracticeSettings.MAX_BPM, vm.uiState.value.bpm)
+
+        vm.setBpm(120)
+        assertEquals(120, vm.uiState.value.bpm)
+    }
+
+    @Test
+    fun toggleFretboardFlips() {
+        assertFalse(vm.uiState.value.showFretboard)
+        vm.toggleFretboard()
+        assertTrue(vm.uiState.value.showFretboard)
+        vm.toggleFretboard()
+        assertFalse(vm.uiState.value.showFretboard)
+    }
+
+    @Test
+    fun toggleLoopFlips() {
+        assertFalse(vm.uiState.value.loopPlayback)
+        vm.toggleLoop()
+        assertTrue(vm.uiState.value.loopPlayback)
+    }
+
+    @Test
+    fun quizScoringTracksCorrectAndStreak() {
+        vm.generateQuizQuestion()
+        val question = vm.uiState.value.quizQuestion
+        assertNotNull(question)
+
+        val correctIdx = question!!.correctIndex
+        assertTrue(vm.submitQuizAnswer(correctIdx))
+        assertEquals(1, vm.uiState.value.quizCorrect)
+        assertEquals(1, vm.uiState.value.quizTotal)
+        assertEquals(1, vm.uiState.value.quizStreak)
+
+        vm.generateQuizQuestion()
+        val wrongIdx = (vm.uiState.value.quizQuestion!!.correctIndex + 1) % 4
+        assertFalse(vm.submitQuizAnswer(wrongIdx))
+        assertEquals(1, vm.uiState.value.quizCorrect)
+        assertEquals(2, vm.uiState.value.quizTotal)
+        assertEquals(0, vm.uiState.value.quizStreak)
+        assertEquals(1, vm.uiState.value.quizBestStreak)
+    }
+
+    @Test
+    fun earTrainingScoringTracksCorrectAndStreak() {
+        vm.generateEarQuestion()
+        val question = vm.uiState.value.earQuestion
+        assertNotNull(question)
+
+        val correctIdx = question!!.correctIndex
+        assertTrue(vm.submitEarAnswer(correctIdx))
+        assertEquals(1, vm.uiState.value.earCorrect)
+        assertEquals(1, vm.uiState.value.earTotal)
+        assertEquals(1, vm.uiState.value.earStreak)
+    }
+
+    @Test
+    fun restoreAndCurrentSettingsRoundTrip() {
+        vm.setRoot(5)
+        vm.setBpm(140)
+        vm.setMode(PracticeMode.QUIZ)
+        vm.toggleFretboard()
+
+        val settings = vm.currentSettings()
+        assertEquals(5, settings.lastRoot)
+        assertEquals(140, settings.lastBpm)
+        assertEquals(PracticeMode.QUIZ.ordinal, settings.lastMode)
+        assertTrue(settings.showFretboard)
+
+        val vm2 = ScalePracticeViewModel()
+        vm2.restoreSettings(settings)
+        val state2 = vm2.uiState.value
+        assertEquals(5, state2.selectedRoot)
+        assertEquals(140, state2.bpm)
+        assertEquals(PracticeMode.QUIZ, state2.mode)
+        assertTrue(state2.showFretboard)
+    }
+
+    @Test
+    fun fretPositionRanges() {
+        assertEquals(null, FretPosition.ALL.range())
+        assertEquals(0..4, FretPosition.OPEN.range())
+        assertEquals(4..8, FretPosition.MID.range())
+        assertEquals(7..12, FretPosition.HIGH.range())
+        assertEquals(7..18, FretPosition.HIGH.range(lastFret = 18))
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
@@ -91,6 +91,8 @@ class ScalePracticeViewModelTest {
         assertFalse(vm.uiState.value.loopPlayback)
         vm.toggleLoop()
         assertTrue(vm.uiState.value.loopPlayback)
+        vm.toggleLoop()
+        assertFalse(vm.uiState.value.loopPlayback)
     }
 
     @Test
@@ -125,6 +127,14 @@ class ScalePracticeViewModelTest {
         assertEquals(1, vm.uiState.value.earCorrect)
         assertEquals(1, vm.uiState.value.earTotal)
         assertEquals(1, vm.uiState.value.earStreak)
+
+        vm.generateEarQuestion()
+        val wrongIdx = (vm.uiState.value.earQuestion!!.correctIndex + 1) % 4
+        assertFalse(vm.submitEarAnswer(wrongIdx))
+        assertEquals(1, vm.uiState.value.earCorrect)
+        assertEquals(2, vm.uiState.value.earTotal)
+        assertEquals(0, vm.uiState.value.earStreak)
+        assertEquals(1, vm.uiState.value.earBestStreak)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add 10 unit tests for `ChordLibraryViewModel`: initial state with auto-selected triad formula, root selection, category switching with auto-formula, formula selection, transpose up/down with wraparound, chord name display, search query with results, search result selection clearing, and tuning change voicing regeneration
- Add 13 unit tests for `ScalePracticeViewModel`: initial defaults, mode switching, root coercion (0-11), category filtering (Blues-only and null=all), BPM coercion (40-200), fretboard and loop toggles, quiz scoring with streak and best-streak tracking, ear training scoring, settings round-trip persistence, and `FretPosition` fret range validation including configurable HIGH range
- No production code changes -- both ViewModels are plain `ViewModel` subclasses testable without Robolectric

Phase 3 PR 3.3 of issue #136 (Android app module test coverage). This completes the full 3-phase plan.

## Test plan

- [x] All 23 new tests pass locally (`./gradlew :app:testDebugUnitTest`)
- [ ] CI passes (unit tests + lint)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for chord library functionality including root selection, category changes, chord transposition, and search operations.
  * Added test coverage for scale practice functionality including mode selection, BPM adjustments, quiz scoring, and settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->