### PR TITLE
Test: add MetronomeViewModel unit tests (12 tests)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		A10078 /* ChordLibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10078 /* ChordLibraryViewModelTests.swift */; };
 		A10079 /* ChordVoicing+Frets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10079 /* ChordVoicing+Frets.swift */; };
 		A10080 /* SongwriterModeFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10080 /* SongwriterModeFlow.swift */; };
+		A10095 /* MetronomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* MetronomeViewModelTests.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
 		A20002 /* click_low.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20002 /* click_low.wav */; };
 		A20003 /* uke_a.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20003 /* uke_a.wav */; };
@@ -233,6 +234,7 @@
 		B10078 /* ChordLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordLibraryViewModelTests.swift; sourceTree = "<group>"; };
 		B10079 /* ChordVoicing+Frets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChordVoicing+Frets.swift"; sourceTree = "<group>"; };
 		B10080 /* SongwriterModeFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongwriterModeFlow.swift; sourceTree = "<group>"; };
+		B10095 /* MetronomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetronomeViewModelTests.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
 		B20002 /* click_low.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_low.wav; sourceTree = "<group>"; };
 		B20003 /* uke_a.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = uke_a.wav; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				B10065 /* SettingsViewModelTests.swift */,
 				B10076 /* SongbookViewModelTests.swift */,
 				B10093 /* SetlistViewModelTests.swift */,
+				B10095 /* MetronomeViewModelTests.swift */,
 			);
 			path = UkuleleCompanionTests;
 			sourceTree = "<group>";
@@ -750,6 +753,7 @@
 				A10065 /* SettingsViewModelTests.swift in Sources */,
 				A10076 /* SongbookViewModelTests.swift in Sources */,
 				A10093 /* SetlistViewModelTests.swift in Sources */,
+				A10095 /* MetronomeViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanionTests/MetronomeViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/MetronomeViewModelTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import UkuleleCompanion
+
+final class MetronomeViewModelTests: XCTestCase {
+
+    @MainActor
+    func testInitialStateDefaults() {
+        let vm = MetronomeViewModel()
+        XCTAssertEqual(vm.bpm, 100)
+        XCTAssertEqual(vm.beatsPerMeasure, 4)
+        XCTAssertEqual(vm.subdivision, 1)
+        XCTAssertFalse(vm.isPlaying)
+        XCTAssertFalse(vm.isCompound)
+        XCTAssertEqual(vm.timeSignatureLabel, "4/4")
+    }
+
+    @MainActor
+    func testInitialAccentPatternFirstBeatAccented() {
+        let vm = MetronomeViewModel()
+        XCTAssertEqual(vm.accentPattern.count, 4)
+        XCTAssertEqual(vm.accentPattern[0], .accent)
+        for i in 1..<vm.accentPattern.count {
+            XCTAssertEqual(vm.accentPattern[i], .normal)
+        }
+    }
+
+    @MainActor
+    func testSetBpmCoercesRange() {
+        let vm = MetronomeViewModel()
+        vm.setBpm(10)
+        XCTAssertEqual(vm.bpm, 30)
+
+        vm.setBpm(500)
+        XCTAssertEqual(vm.bpm, 300)
+
+        vm.setBpm(120)
+        XCTAssertEqual(vm.bpm, 120)
+    }
+
+    @MainActor
+    func testSetTimeSignature68SetsCompoundMode() {
+        let vm = MetronomeViewModel()
+        vm.setTimeSignature("6/8")
+        XCTAssertTrue(vm.isCompound)
+        XCTAssertEqual(vm.beatsPerMeasure, 2)
+        XCTAssertEqual(vm.subdivision, 3)
+        XCTAssertEqual(vm.timeSignatureLabel, "6/8")
+    }
+
+    @MainActor
+    func testSetTimeSignature128SetsCompoundMode() {
+        let vm = MetronomeViewModel()
+        vm.setTimeSignature("12/8")
+        XCTAssertTrue(vm.isCompound)
+        XCTAssertEqual(vm.beatsPerMeasure, 4)
+        XCTAssertEqual(vm.subdivision, 3)
+    }
+
+    @MainActor
+    func testSetTimeSignatureSimpleParsesBeats() {
+        let vm = MetronomeViewModel()
+        vm.setTimeSignature("3/4")
+        XCTAssertFalse(vm.isCompound)
+        XCTAssertEqual(vm.beatsPerMeasure, 3)
+        XCTAssertEqual(vm.subdivision, 1)
+        XCTAssertEqual(vm.timeSignatureLabel, "3/4")
+    }
+
+    @MainActor
+    func testSetSubdivisionBlockedInCompoundMode() {
+        let vm = MetronomeViewModel()
+        vm.setTimeSignature("6/8")
+        XCTAssertEqual(vm.subdivision, 3)
+        vm.setSubdivision(2)
+        XCTAssertEqual(vm.subdivision, 3, "Subdivision change should be blocked in compound mode")
+    }
+
+    @MainActor
+    func testSetSubdivisionCoercesInSimpleMode() {
+        let vm = MetronomeViewModel()
+        vm.setSubdivision(0)
+        XCTAssertEqual(vm.subdivision, 1)
+
+        vm.setSubdivision(6)
+        XCTAssertEqual(vm.subdivision, 4)
+
+        vm.setSubdivision(2)
+        XCTAssertEqual(vm.subdivision, 2)
+    }
+
+    @MainActor
+    func testToggleBeatTypeCyclesAccentNormalMute() {
+        let vm = MetronomeViewModel()
+        XCTAssertEqual(vm.accentPattern[0], .accent)
+
+        vm.toggleBeatType(0)
+        XCTAssertEqual(vm.accentPattern[0], .normal)
+
+        vm.toggleBeatType(0)
+        XCTAssertEqual(vm.accentPattern[0], .mute)
+
+        vm.toggleBeatType(0)
+        XCTAssertEqual(vm.accentPattern[0], .accent)
+    }
+
+    @MainActor
+    func testToggleBeatTypeIgnoresOutOfBounds() {
+        let vm = MetronomeViewModel()
+        let before = vm.accentPattern
+        vm.toggleBeatType(-1)
+        vm.toggleBeatType(99)
+        XCTAssertEqual(vm.accentPattern, before)
+    }
+
+    @MainActor
+    func testSetTimeSignatureResetsCompoundWhenSimple() {
+        let vm = MetronomeViewModel()
+        vm.setTimeSignature("6/8")
+        XCTAssertTrue(vm.isCompound)
+
+        vm.setTimeSignature("5/4")
+        XCTAssertFalse(vm.isCompound)
+        XCTAssertEqual(vm.beatsPerMeasure, 5)
+        XCTAssertEqual(vm.subdivision, 1)
+    }
+
+    @MainActor
+    func testStopResetsPlaybackState() {
+        let vm = MetronomeViewModel()
+        vm.start()
+        XCTAssertTrue(vm.isPlaying)
+        vm.stop()
+        XCTAssertFalse(vm.isPlaying)
+        XCTAssertEqual(vm.currentBeat, -1)
+        XCTAssertEqual(vm.currentSubBeat, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 12 XCTest unit tests for `MetronomeViewModel` covering all pure state-management logic
- Tests: initial state defaults, BPM clamping (30–300), simple time signature parsing (`3/4`, `5/4`), compound time signatures (`6/8`, `12/8`), subdivision blocking in compound mode, subdivision clamping in simple mode, accent pattern cycling (accent → normal → mute → accent), out-of-bounds toggle guard, compound→simple reset, and start/stop playback state
- New file: `MetronomeViewModelTests.swift` added to the Xcode project test target

## Test plan
- [x] All 12 tests pass locally on iPhone 16 Pro simulator (iOS 18.2)
- [ ] CI passes

Part of #137

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the metronome functionality, including validation of tempo settings, time signature parsing, beat pattern cycling, and playback state management to improve reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->