### PR TITLE
Test: add ChordTransitionsViewModel unit tests (10 tests)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		A10080 /* SongwriterModeFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10080 /* SongwriterModeFlow.swift */; };
 		A10095 /* MetronomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10095 /* MetronomeViewModelTests.swift */; };
 		A10096 /* ScalePracticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10096 /* ScalePracticeViewModelTests.swift */; };
+		A10097 /* ChordTransitionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* ChordTransitionsViewModelTests.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
 		A20002 /* click_low.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20002 /* click_low.wav */; };
 		A20003 /* uke_a.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20003 /* uke_a.wav */; };
@@ -235,9 +236,9 @@
 		B10078 /* ChordLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordLibraryViewModelTests.swift; sourceTree = "<group>"; };
 		B10079 /* ChordVoicing+Frets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChordVoicing+Frets.swift"; sourceTree = "<group>"; };
 		B10080 /* SongwriterModeFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongwriterModeFlow.swift; sourceTree = "<group>"; };
-<<<<<<< HEAD
 		B10095 /* MetronomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetronomeViewModelTests.swift; sourceTree = "<group>"; };
 		B10096 /* ScalePracticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalePracticeViewModelTests.swift; sourceTree = "<group>"; };
+		B10097 /* ChordTransitionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordTransitionsViewModelTests.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
 		B20002 /* click_low.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_low.wav; sourceTree = "<group>"; };
 		B20003 /* uke_a.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = uke_a.wav; sourceTree = "<group>"; };
@@ -494,6 +495,7 @@
 				B10093 /* SetlistViewModelTests.swift */,
 				B10095 /* MetronomeViewModelTests.swift */,
 				B10096 /* ScalePracticeViewModelTests.swift */,
+				B10097 /* ChordTransitionsViewModelTests.swift */,
 			);
 			path = UkuleleCompanionTests;
 			sourceTree = "<group>";
@@ -759,6 +761,7 @@
 				A10093 /* SetlistViewModelTests.swift in Sources */,
 				A10095 /* MetronomeViewModelTests.swift in Sources */,
 				A10096 /* ScalePracticeViewModelTests.swift in Sources */,
+				A10097 /* ChordTransitionsViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanionTests/ChordTransitionsViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/ChordTransitionsViewModelTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import UkuleleCompanion
+
+final class ChordTransitionsViewModelTests: XCTestCase {
+
+    @MainActor
+    func testInitialState() {
+        let vm = ChordTransitionsViewModel()
+        XCTAssertEqual(vm.chord1, "C")
+        XCTAssertEqual(vm.chord2, "G")
+        XCTAssertEqual(vm.bpm, 80)
+        XCTAssertEqual(vm.beatsPerChord, 4)
+        XCTAssertFalse(vm.isRunning)
+        XCTAssertEqual(vm.transitionCount, 0)
+        XCTAssertEqual(vm.currentBeat, 0)
+        XCTAssertTrue(vm.currentChordIsFirst)
+        XCTAssertTrue(vm.playChordOnTransition)
+    }
+
+    @MainActor
+    func testCurrentChordReflectsToggle() {
+        let vm = ChordTransitionsViewModel()
+        XCTAssertEqual(vm.currentChord, "C")
+
+        vm.currentChordIsFirst = false
+        XCTAssertEqual(vm.currentChord, "G")
+
+        vm.currentChordIsFirst = true
+        XCTAssertEqual(vm.currentChord, "C")
+    }
+
+    @MainActor
+    func testChordPairSelection() {
+        let vm = ChordTransitionsViewModel()
+        vm.chord1 = "Am"
+        vm.chord2 = "Dm"
+        XCTAssertEqual(vm.chord1, "Am")
+        XCTAssertEqual(vm.chord2, "Dm")
+        XCTAssertEqual(vm.currentChord, "Am")
+    }
+
+    @MainActor
+    func testSwitchesPerMinuteCalculation() {
+        let vm = ChordTransitionsViewModel()
+        vm.transitionCount = 10
+        vm.elapsedSeconds = 30
+        XCTAssertEqual(vm.switchesPerMinute, 20.0, accuracy: 0.01)
+    }
+
+    @MainActor
+    func testSwitchesPerMinuteZeroWhenNoElapsed() {
+        let vm = ChordTransitionsViewModel()
+        vm.transitionCount = 5
+        vm.elapsedSeconds = 0
+        XCTAssertEqual(vm.switchesPerMinute, 0)
+    }
+
+    @MainActor
+    func testSwitchesPerMinuteZeroWhenNoTransitions() {
+        let vm = ChordTransitionsViewModel()
+        vm.transitionCount = 0
+        vm.elapsedSeconds = 30
+        XCTAssertEqual(vm.switchesPerMinute, 0)
+    }
+
+    @MainActor
+    func testResetClearsState() {
+        let vm = ChordTransitionsViewModel()
+        vm.transitionCount = 5
+        vm.currentBeat = 3
+        vm.currentChordIsFirst = false
+        vm.elapsedSeconds = 60
+        vm.startTime = Date()
+
+        vm.reset()
+        XCTAssertFalse(vm.isRunning)
+        XCTAssertEqual(vm.transitionCount, 0)
+        XCTAssertEqual(vm.currentBeat, 0)
+        XCTAssertTrue(vm.currentChordIsFirst)
+        XCTAssertEqual(vm.elapsedSeconds, 0)
+        XCTAssertNil(vm.startTime)
+    }
+
+    @MainActor
+    func testStopSetsNotRunning() {
+        let vm = ChordTransitionsViewModel()
+        vm.start()
+        XCTAssertTrue(vm.isRunning)
+        vm.stop()
+        XCTAssertFalse(vm.isRunning)
+    }
+
+    @MainActor
+    func testVoicingForChordReturnsVoicing() {
+        let vm = ChordTransitionsViewModel()
+        let voicing = vm.voicingForChord(name: "C")
+        XCTAssertNotNil(voicing, "Should find a voicing for C major")
+    }
+
+    @MainActor
+    func testVoicingForMinorChord() {
+        let vm = ChordTransitionsViewModel()
+        let voicing = vm.voicingForChord(name: "Am")
+        XCTAssertNotNil(voicing, "Should find a voicing for Am")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 10 XCTest unit tests for `ChordTransitionsViewModel` covering state management and KMP voicing interop
- Tests: initial state defaults, current chord toggle, chord pair selection, `switchesPerMinute` calculation (positive, zero elapsed, zero transitions), reset state clearing, start/stop lifecycle, and voicing lookup for major and minor chords via KMP `VoicingGenerator`
- New file: `ChordTransitionsViewModelTests.swift` added to the Xcode project test target

## Test plan
- [x] All 10 tests pass locally on iPhone 16 Pro simulator (iOS 18.2)
- [ ] CI passes

Part of #137

Made with [Cursor](https://cursor.com)