### PR TITLE
Test: add MelodyViewModel unit tests (11 tests)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		A10096 /* ScalePracticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10096 /* ScalePracticeViewModelTests.swift */; };
 		A10097 /* ChordTransitionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10097 /* ChordTransitionsViewModelTests.swift */; };
 		A10098 /* FretboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10098 /* FretboardViewModelTests.swift */; };
+		A10099 /* MelodyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10099 /* MelodyViewModelTests.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
 		A20002 /* click_low.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20002 /* click_low.wav */; };
 		A20003 /* uke_a.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20003 /* uke_a.wav */; };
@@ -241,6 +242,7 @@
 		B10096 /* ScalePracticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalePracticeViewModelTests.swift; sourceTree = "<group>"; };
 		B10097 /* ChordTransitionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordTransitionsViewModelTests.swift; sourceTree = "<group>"; };
 		B10098 /* FretboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FretboardViewModelTests.swift; sourceTree = "<group>"; };
+		B10099 /* MelodyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelodyViewModelTests.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
 		B20002 /* click_low.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_low.wav; sourceTree = "<group>"; };
 		B20003 /* uke_a.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = uke_a.wav; sourceTree = "<group>"; };
@@ -499,6 +501,7 @@
 				B10096 /* ScalePracticeViewModelTests.swift */,
 				B10097 /* ChordTransitionsViewModelTests.swift */,
 				B10098 /* FretboardViewModelTests.swift */,
+				B10099 /* MelodyViewModelTests.swift */,
 			);
 			path = UkuleleCompanionTests;
 			sourceTree = "<group>";
@@ -766,6 +769,7 @@
 				A10096 /* ScalePracticeViewModelTests.swift in Sources */,
 				A10097 /* ChordTransitionsViewModelTests.swift in Sources */,
 				A10098 /* FretboardViewModelTests.swift in Sources */,
+				A10099 /* MelodyViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanionTests/MelodyViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/MelodyViewModelTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+@testable import UkuleleCompanion
+
+final class MelodyViewModelTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "melodies")
+    }
+
+    @MainActor
+    func testInitialEmptyState() {
+        let vm = MelodyViewModel()
+        XCTAssertTrue(vm.notes.isEmpty)
+        XCTAssertEqual(vm.selectedDuration, .quarter)
+        XCTAssertEqual(vm.bpm, 120)
+        XCTAssertEqual(vm.currentOctave, 4)
+        XCTAssertFalse(vm.isPlaying)
+        XCTAssertNil(vm.playingIndex)
+        XCTAssertFalse(vm.isRecording)
+        XCTAssertFalse(vm.hasUnsavedChanges)
+    }
+
+    @MainActor
+    func testAddNoteAppendsAndMarksUnsaved() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 0, octave: 4)
+        XCTAssertEqual(vm.notes.count, 1)
+        XCTAssertEqual(vm.notes[0].pitchClass, 0)
+        XCTAssertEqual(vm.notes[0].octave, 4)
+        XCTAssertFalse(vm.notes[0].isRest)
+        XCTAssertTrue(vm.hasUnsavedChanges)
+    }
+
+    @MainActor
+    func testAddRestAppendsRestNote() {
+        let vm = MelodyViewModel()
+        vm.addRest()
+        XCTAssertEqual(vm.notes.count, 1)
+        XCTAssertTrue(vm.notes[0].isRest)
+        XCTAssertNil(vm.notes[0].pitchClass)
+        XCTAssertEqual(vm.notes[0].displayName, "Rest")
+    }
+
+    @MainActor
+    func testDeleteNoteRemovesAtIndex() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 0, octave: 4)
+        vm.addNote(pitchClass: 4, octave: 4)
+        vm.addNote(pitchClass: 7, octave: 4)
+        XCTAssertEqual(vm.notes.count, 3)
+
+        vm.deleteNoteAt(index: 1)
+        XCTAssertEqual(vm.notes.count, 2)
+        XCTAssertEqual(vm.notes[0].pitchClass, 0)
+        XCTAssertEqual(vm.notes[1].pitchClass, 7)
+    }
+
+    @MainActor
+    func testClearAllResetsState() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 5, octave: 3)
+        vm.save(name: "Test")
+        vm.addNote(pitchClass: 7, octave: 3)
+
+        vm.clearAll()
+        XCTAssertTrue(vm.notes.isEmpty)
+        XCTAssertNil(vm.loadedMelodyName)
+        XCTAssertFalse(vm.hasUnsavedChanges)
+    }
+
+    @MainActor
+    func testNoteDurationBeats() {
+        XCTAssertEqual(NoteDuration.whole.beats, 4.0)
+        XCTAssertEqual(NoteDuration.half.beats, 2.0)
+        XCTAssertEqual(NoteDuration.quarter.beats, 1.0)
+        XCTAssertEqual(NoteDuration.eighth.beats, 0.5)
+        XCTAssertEqual(NoteDuration.sixteenth.beats, 0.25)
+    }
+
+    @MainActor
+    func testSaveLoadRoundTrip() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 0, octave: 4)
+        vm.addNote(pitchClass: 4, octave: 4)
+        vm.bpm = 100
+        vm.save(name: "My Melody")
+
+        XCTAssertEqual(vm.savedMelodies.count, 1)
+        XCTAssertEqual(vm.savedMelodies[0].name, "My Melody")
+        XCTAssertEqual(vm.loadedMelodyName, "My Melody")
+        XCTAssertFalse(vm.hasUnsavedChanges)
+
+        let vm2 = MelodyViewModel()
+        XCTAssertEqual(vm2.savedMelodies.count, 1)
+        XCTAssertEqual(vm2.savedMelodies[0].notes.count, 2)
+        XCTAssertEqual(vm2.savedMelodies[0].bpm, 100)
+    }
+
+    @MainActor
+    func testExportImportRoundTrip() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 7, octave: 5)
+        vm.save(name: "Export Test")
+        let exported = vm.exportData()
+        XCTAssertEqual(exported.count, 1)
+
+        UserDefaults.standard.removeObject(forKey: "melodies")
+        let vm2 = MelodyViewModel()
+        XCTAssertTrue(vm2.savedMelodies.isEmpty)
+
+        vm2.importData(exported)
+        XCTAssertEqual(vm2.savedMelodies.count, 1)
+        XCTAssertEqual(vm2.savedMelodies[0].name, "Export Test")
+        XCTAssertEqual(vm2.savedMelodies[0].notes[0].pitchClass, 7)
+    }
+
+    @MainActor
+    func testSelectNoteToggle() {
+        let vm = MelodyViewModel()
+        XCTAssertNil(vm.selectedNoteIndex)
+
+        vm.selectNote(index: 2)
+        XCTAssertEqual(vm.selectedNoteIndex, 2)
+
+        vm.selectNote(index: 2)
+        XCTAssertNil(vm.selectedNoteIndex, "Selecting the same index should deselect")
+
+        vm.selectNote(index: 3)
+        XCTAssertEqual(vm.selectedNoteIndex, 3)
+    }
+
+    @MainActor
+    func testStepSequencerExpandAndShrink() {
+        let vm = MelodyViewModel()
+        XCTAssertEqual(vm.steps.count, MelodyViewModel.stepCount8)
+
+        vm.expandSteps()
+        XCTAssertEqual(vm.steps.count, MelodyViewModel.stepCount16)
+
+        vm.expandSteps()
+        XCTAssertEqual(vm.steps.count, MelodyViewModel.stepCount8, "Should shrink back to 8")
+    }
+
+    @MainActor
+    func testDeleteMelody() {
+        let vm = MelodyViewModel()
+        vm.addNote(pitchClass: 0, octave: 4)
+        vm.save(name: "To Delete")
+        let id = vm.savedMelodies[0].id
+        XCTAssertEqual(vm.savedMelodies.count, 1)
+
+        vm.deleteMelody(id: id)
+        XCTAssertTrue(vm.savedMelodies.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 11 XCTest unit tests for `MelodyViewModel` covering note management, persistence, and step sequencer
- Tests: initial empty state, add note/rest, delete note at index, clearAll reset, `NoteDuration.beats` values (whole/half/quarter/eighth/sixteenth), save/load round-trip via `UserDefaults`, export/import round-trip, selectNote toggle, step sequencer expand/shrink (8↔16), and delete melody by ID
- Audio recording/playback paths are skipped (hardware-dependent)
- New file: `MelodyViewModelTests.swift` added to the Xcode project test target

## Test plan
- [x] All 11 tests pass locally on iPhone 16 Pro simulator (iOS 18.2)
- [ ] CI passes

Part of #137

Made with [Cursor](https://cursor.com)