### PR TITLE
Test: add PlayAlongViewModel + NeuralPitchSupervisor pure logic tests (12 tests)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		A10098 /* FretboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10098 /* FretboardViewModelTests.swift */; };
 		A10099 /* MelodyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10099 /* MelodyViewModelTests.swift */; };
 		A10100 /* PitchMonitorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10100 /* PitchMonitorViewModelTests.swift */; };
+		A10101 /* PlayAlongAndNeuralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10101 /* PlayAlongAndNeuralTests.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
 		A20002 /* click_low.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20002 /* click_low.wav */; };
 		A20003 /* uke_a.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20003 /* uke_a.wav */; };
@@ -245,6 +246,7 @@
 		B10098 /* FretboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FretboardViewModelTests.swift; sourceTree = "<group>"; };
 		B10099 /* MelodyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelodyViewModelTests.swift; sourceTree = "<group>"; };
 		B10100 /* PitchMonitorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchMonitorViewModelTests.swift; sourceTree = "<group>"; };
+		B10101 /* PlayAlongAndNeuralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAlongAndNeuralTests.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
 		B20002 /* click_low.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_low.wav; sourceTree = "<group>"; };
 		B20003 /* uke_a.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = uke_a.wav; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				B10098 /* FretboardViewModelTests.swift */,
 				B10099 /* MelodyViewModelTests.swift */,
 				B10100 /* PitchMonitorViewModelTests.swift */,
+				B10101 /* PlayAlongAndNeuralTests.swift */,
 			);
 			path = UkuleleCompanionTests;
 			sourceTree = "<group>";
@@ -774,6 +777,7 @@
 				A10098 /* FretboardViewModelTests.swift in Sources */,
 				A10099 /* MelodyViewModelTests.swift in Sources */,
 				A10100 /* PitchMonitorViewModelTests.swift in Sources */,
+				A10101 /* PlayAlongAndNeuralTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanion/Audio/NeuralPitchSupervisor.swift
+++ b/iosApp/UkuleleCompanion/Audio/NeuralPitchSupervisor.swift
@@ -3,9 +3,13 @@ import onnxruntime
 import shared
 
 final class NeuralPitchSupervisor {
-    private static let minFreqHz: Double = 46.875
-    private static let maxFreqHz: Double = 2093.75
-    private static let minConfidence: Double = 0.50
+    static let minFreqHz: Double = 46.875
+    static let maxFreqHz: Double = 2093.75
+    static let minConfidence: Double = 0.50
+
+    static func isValidEstimate(frequencyHz: Double, confidence: Double) -> Bool {
+        frequencyHz >= minFreqHz && frequencyHz <= maxFreqHz && confidence >= minConfidence
+    }
 
     private let api: UnsafePointer<OrtApi>
     private let session: OpaquePointer

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -137,8 +137,8 @@ final class PlayAlongViewModel: ObservableObject {
             confidence: displayedChord != nil ? 0.8 : 0.0
         )
 
-        let normalized = displayedChord.map { normalizeForComparison($0) }
-        let expectedNorm = normalizeForComparison(expectedChord)
+        let normalized = displayedChord.map { Self.normalizeForComparison($0) }
+        let expectedNorm = Self.normalizeForComparison(expectedChord)
         isChordCorrect = normalized == expectedNorm
 
         if currentBeat >= beatsPerChord {
@@ -225,7 +225,7 @@ final class PlayAlongViewModel: ObservableObject {
         return name + degree.quality
     }
 
-    private func normalizeForComparison(_ name: String) -> String {
+    nonisolated static func normalizeForComparison(_ name: String) -> String {
         name.replacingOccurrences(of: "7", with: "")
             .replacingOccurrences(of: "9", with: "")
             .replacingOccurrences(of: "maj", with: "")

--- a/iosApp/UkuleleCompanionTests/PlayAlongAndNeuralTests.swift
+++ b/iosApp/UkuleleCompanionTests/PlayAlongAndNeuralTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import UkuleleCompanion
+
+final class PlayAlongAndNeuralTests: XCTestCase {
+
+    // MARK: - PlayAlongViewModel.normalizeForComparison
+
+    func testNormalizeRemoves7() {
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("C7"), "C")
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("Am7"), "Am")
+    }
+
+    func testNormalizeRemoves9() {
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("G9"), "G")
+    }
+
+    func testNormalizeRemovesMaj() {
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("Cmaj"), "C")
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("Fmaj7"), "F")
+    }
+
+    func testNormalizeTrimsWhitespace() {
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("  Am  "), "Am")
+    }
+
+    func testNormalizePreservesSimpleChord() {
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("C"), "C")
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("Am"), "Am")
+        XCTAssertEqual(PlayAlongViewModel.normalizeForComparison("F#m"), "F#m")
+    }
+
+    // MARK: - NeuralPitchSupervisor bounds
+
+    func testValidEstimateInRange() {
+        XCTAssertTrue(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 440.0, confidence: 0.85))
+    }
+
+    func testEstimateBelowMinFreqInvalid() {
+        XCTAssertFalse(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 30.0, confidence: 0.90))
+    }
+
+    func testEstimateAboveMaxFreqInvalid() {
+        XCTAssertFalse(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 3000.0, confidence: 0.90))
+    }
+
+    func testEstimateBelowMinConfidenceInvalid() {
+        XCTAssertFalse(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 440.0, confidence: 0.40))
+    }
+
+    func testEstimateAtBoundaryMinFreq() {
+        XCTAssertTrue(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 46.875, confidence: 0.50))
+    }
+
+    func testEstimateAtBoundaryMaxFreq() {
+        XCTAssertTrue(NeuralPitchSupervisor.isValidEstimate(frequencyHz: 2093.75, confidence: 0.50))
+    }
+
+    func testBoundsConstants() {
+        XCTAssertEqual(NeuralPitchSupervisor.minFreqHz, 46.875, accuracy: 0.001)
+        XCTAssertEqual(NeuralPitchSupervisor.maxFreqHz, 2093.75, accuracy: 0.001)
+        XCTAssertEqual(NeuralPitchSupervisor.minConfidence, 0.50, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts testable pure functions from `PlayAlongViewModel` and `NeuralPitchSupervisor`, adds 12 XCTest unit tests
- **PlayAlongViewModel** (5 tests): `normalizeForComparison` made `nonisolated static` -- tests strip `7`/`9`/`maj`, trim whitespace, preserve simple chord names like `C`, `Am`, `F#m`
- **NeuralPitchSupervisor** (7 tests): new `isValidEstimate(frequencyHz:confidence:)` static method with exposed bounds constants -- tests in-range, below/above frequency bounds (46.875–2093.75 Hz), below confidence threshold (0.50), exact boundary values, and constants verification
- Production code changes are minimal: one private method becomes static, three private constants become internal, one new static validation method added
- New file: `PlayAlongAndNeuralTests.swift` added to the Xcode project test target

## Test plan
- [x] All 12 tests pass locally on iPhone 16 Pro simulator (iOS 18.2)
- [ ] CI passes

Part of #137

Made with [Cursor](https://cursor.com)