### PR TITLE
Add: haptic feedback when entering in-tune zone (Android + iOS)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
@@ -164,6 +164,17 @@ private fun TunerContent(
         previousTunedCount = currentTunedCount
     }
 
+    // --- Haptic feedback on entering the in-tune zone --------------------
+    var previousTuningStatus by remember { mutableStateOf(state.tuningStatus) }
+    LaunchedEffect(state.tuningStatus) {
+        if (state.tuningStatus == TuningStatus.IN_TUNE &&
+            previousTuningStatus != TuningStatus.IN_TUNE
+        ) {
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+        previousTuningStatus = state.tuningStatus
+    }
+
     // --- All strings tuned detection --------------------------------------
     val allTuned by remember {
         derivedStateOf { state.stringProgress.all { it } && state.isListening }

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -111,6 +111,11 @@ struct TunerView: View {
         .onChange(of: settings.selectedTuning) { _ in
             viewModel.currentTuning = tuning
         }
+        .onChange(of: viewModel.isInTune) { inTune in
+            if inTune {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+        }
         .onDisappear {
             viewModel.stopCapture()
         }
@@ -346,6 +351,7 @@ final class TunerViewModel: ObservableObject {
     @Published var tuningStatus: String = ""
     @Published var isCapturing: Bool = false
     @Published var neuralStatus: NeuralRuntimeStatus = .active
+    @Published var isInTune: Bool = false
 
     // String progress tracking
     @Published var stringProgress: [Bool] = [false, false, false, false]
@@ -530,6 +536,7 @@ final class TunerViewModel: ObservableObject {
 
                     let cents = stringResult.centsFromTarget
                     let justTuned: Bool
+                    self.isInTune = abs(cents) <= 6
                     if abs(cents) <= 6 {
                         self.tuningStatus = "In tune!"
                         self.settledFrames += 1


### PR DESCRIPTION
## Summary
- Adds haptic pulse when the tuner needle first enters the ±6-cent in-tune zone
- Android: `LaunchedEffect` tracks `TuningStatus` transitions, fires `HapticFeedbackType.LongPress` on edge into `IN_TUNE`
- iOS: new `@Published isInTune` on `TunerViewModel` + `.onChange` in `TunerView` triggers `UINotificationFeedbackGenerator.success`
- Significantly helps blind/VoiceOver/TalkBack users confirm in-tune without visual feedback

## Test plan
- [ ] Android: start tuner, tune a string close → verify haptic fires exactly once when entering in-tune zone (not continuously)
- [ ] iOS: same test on simulator or device (device required for actual haptic)
- [ ] Verify existing string-tuned haptic (Android) still fires independently

Part of #140

Made with [Cursor](https://cursor.com)