### PR TITLE
Add: reduce motion support for Android animations

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/MainActivity.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/MainActivity.kt
@@ -7,13 +7,16 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.baijum.ukufretboard.ui.FretboardScreen
+import com.baijum.ukufretboard.ui.LocalReduceMotion
 import com.baijum.ukufretboard.ui.OnboardingScreen
+import com.baijum.ukufretboard.ui.rememberReduceMotion
 import com.baijum.ukufretboard.ui.theme.UkuleleCompanionTheme
 import com.baijum.ukufretboard.viewmodel.SettingsViewModel
 
@@ -41,9 +44,11 @@ class MainActivity : AppCompatActivity() {
         setContent {
             val appSettings by settingsViewModel.settings.collectAsState()
             val windowSizeClass = calculateWindowSizeClass(this)
+            val reduceMotion = rememberReduceMotion()
             var onboardingDone by rememberSaveable {
                 mutableStateOf(appSettings.onboardingCompleted)
             }
+            CompositionLocalProvider(LocalReduceMotion provides reduceMotion) {
             UkuleleCompanionTheme(themeMode = appSettings.display.themeMode) {
                 if (onboardingDone) {
                     FretboardScreen(
@@ -57,6 +62,7 @@ class MainActivity : AppCompatActivity() {
                         onFinished = { onboardingDone = true },
                     )
                 }
+            }
             }
         }
     }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionAnimation.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionAnimation.kt
@@ -94,20 +94,25 @@ fun ChordTransitionAnimation(
     val fromFingering = remember(fromVoicing) { ChordInfo.suggestFingering(fromVoicing.frets) }
     val toFingering = remember(toVoicing) { ChordInfo.suggestFingering(toVoicing.frets) }
 
+    val reduceMotion = LocalReduceMotion.current
+
     // Animation controller
     LaunchedEffect(isAnimating, animationSpeed) {
         if (isAnimating) {
-            // Animate from 0 to 1
             progress.snapTo(0f)
-            delay((500 / animationSpeed).toLong()) // Hold on from chord
-            progress.animateTo(
-                targetValue = 1f,
-                animationSpec = tween(
-                    durationMillis = (1000 / animationSpeed).toInt(),
-                    easing = EaseInOutCubic,
-                ),
-            )
-            delay((500 / animationSpeed).toLong()) // Hold on to chord
+            if (reduceMotion) {
+                progress.snapTo(1f)
+            } else {
+                delay((500 / animationSpeed).toLong())
+                progress.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(
+                        durationMillis = (1000 / animationSpeed).toInt(),
+                        easing = EaseInOutCubic,
+                    ),
+                )
+                delay((500 / animationSpeed).toLong())
+            }
             isAnimating = false
         }
     }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/FavoritesTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/FavoritesTab.kt
@@ -1,6 +1,8 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -355,8 +357,10 @@ private fun ReorderableFavoritesGrid(
     ) {
         itemsIndexed(localList, key = { _, fav -> fav.key }) { _, favorite ->
             ReorderableItem(reorderableState, key = favorite.key) { isDragging ->
+                val reduceMotion = LocalReduceMotion.current
                 val elevation by animateDpAsState(
                     if (isDragging) 8.dp else 0.dp,
+                    animationSpec = if (reduceMotion) snap() else tween(),
                     label = "dragElevation",
                 )
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/MetronomeTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/MetronomeTab.kt
@@ -2,6 +2,7 @@ package com.baijum.ukufretboard.ui
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -267,9 +268,10 @@ private fun BeatIndicator(
     isActive: Boolean,
     onClick: () -> Unit,
 ) {
+    val reduceMotion = LocalReduceMotion.current
     val targetScale by animateFloatAsState(
         targetValue = if (isActive) 1.3f else 1.0f,
-        animationSpec = tween(durationMillis = 100),
+        animationSpec = if (reduceMotion) snap() else tween(durationMillis = 100),
         label = "beatScale",
     )
     val backgroundColor by animateColorAsState(
@@ -281,7 +283,7 @@ private fun BeatIndicator(
             type == BeatType.NORMAL -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f)
             else -> Color.Transparent
         },
-        animationSpec = tween(durationMillis = 100),
+        animationSpec = if (reduceMotion) snap() else tween(durationMillis = 100),
         label = "beatColor",
     )
     val borderColor = when (type) {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/OnboardingScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/OnboardingScreen.kt
@@ -1,6 +1,8 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -199,12 +201,14 @@ private fun PageIndicator(pageCount: Int, currentPage: Int) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val reduceMotion = LocalReduceMotion.current
         repeat(pageCount) { index ->
             val color by animateColorAsState(
                 targetValue = if (index == currentPage)
                     MaterialTheme.colorScheme.primary
                 else
                     MaterialTheme.colorScheme.outlineVariant,
+                animationSpec = if (reduceMotion) snap() else tween(),
                 label = "dot",
             )
             Box(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ReduceMotion.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ReduceMotion.kt
@@ -1,0 +1,49 @@
+package com.baijum.ukufretboard.ui
+
+import android.provider.Settings
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.snap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * `true` when the user has set "Remove animations" / animator duration scale = 0
+ * in system accessibility settings.
+ */
+val LocalReduceMotion = compositionLocalOf { false }
+
+@Composable
+fun rememberReduceMotion(): Boolean {
+    val context = LocalContext.current
+    return remember {
+        val scale = Settings.Global.getFloat(
+            context.contentResolver,
+            Settings.Global.ANIMATOR_DURATION_SCALE,
+            1f,
+        )
+        scale == 0f
+    }
+}
+
+/**
+ * Returns [fallback] when animations are enabled, or [snap] when reduced.
+ */
+@Composable
+fun <T> reduceMotionSpec(fallback: AnimationSpec<T>): AnimationSpec<T> {
+    return if (LocalReduceMotion.current) snap() else fallback
+}
+
+/** No-op enter/exit when reduce motion is on. */
+object ReduceMotionTransitions {
+    @Composable
+    fun enter(fallback: EnterTransition): EnterTransition =
+        if (LocalReduceMotion.current) EnterTransition.None else fallback
+
+    @Composable
+    fun exit(fallback: ExitTransition): ExitTransition =
+        if (LocalReduceMotion.current) ExitTransition.None else fallback
+}

--- a/app/src/main/java/com/baijum/ukufretboard/ui/StrumPatternsTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/StrumPatternsTab.kt
@@ -1,6 +1,8 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -634,9 +636,11 @@ private fun BeatArrow(beat: StrumBeat, isActive: Boolean = false) {
     val fontWeight = if (beat.emphasis) FontWeight.ExtraBold else FontWeight.Normal
     val fontSize = if (beat.emphasis) 20.sp else 18.sp
 
+    val reduceMotion = LocalReduceMotion.current
     val bgColor by animateColorAsState(
         targetValue = if (isActive) MaterialTheme.colorScheme.primaryContainer
         else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0f),
+        animationSpec = if (reduceMotion) snap() else tween(),
         label = "beatHighlight",
     )
 
@@ -879,9 +883,11 @@ private fun FingerpickStepIndicator(step: FingerpickStep, isActive: Boolean = fa
     }
     val fontWeight = if (step.emphasis) FontWeight.ExtraBold else FontWeight.Normal
 
+    val reduceMotion = LocalReduceMotion.current
     val bgColor by animateColorAsState(
         targetValue = if (isActive) MaterialTheme.colorScheme.primaryContainer
         else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0f),
+        animationSpec = if (reduceMotion) snap() else tween(),
         label = "stepHighlight",
     )
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
@@ -1,9 +1,11 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -145,6 +147,7 @@ private fun TunerContent(
     val state by viewModel.uiState.collectAsState()
     val scope = rememberCoroutineScope()
     val haptic = LocalHapticFeedback.current
+    val reduceMotion = LocalReduceMotion.current
 
     // --- Auto-start: begin listening when entering the tab ----------------
     if (tunerSettings.autoStart && !state.isListening) {
@@ -221,7 +224,7 @@ private fun TunerContent(
                 state.tuningStatus == TuningStatus.SILENT -> MaterialTheme.colorScheme.onSurfaceVariant
                 else -> MaterialTheme.colorScheme.error
             },
-            animationSpec = tween(durationMillis = 200),
+            animationSpec = if (reduceMotion) snap() else tween(durationMillis = 200),
             label = "noteColor",
         )
 
@@ -229,7 +232,7 @@ private fun TunerContent(
         val confidenceAlpha by animateFloatAsState(
             targetValue = if (state.tuningStatus == TuningStatus.SILENT) 1f
             else (1.0f - state.confidence.toFloat() * 2f).coerceIn(0.4f, 1.0f),
-            animationSpec = tween(durationMillis = 150),
+            animationSpec = if (reduceMotion) snap() else tween(durationMillis = 150),
             label = "confidenceAlpha",
         )
 
@@ -273,7 +276,7 @@ private fun TunerContent(
         }
         val animatedCents by animateFloatAsState(
             targetValue = needleTarget,
-            animationSpec = tween(durationMillis = 120),
+            animationSpec = if (reduceMotion) snap() else tween(durationMillis = 120),
             label = "needleCents",
         )
 
@@ -378,7 +381,8 @@ private fun TunerContent(
         // --- All strings tuned celebration ----------------------------------
         AnimatedVisibility(
             visible = allTuned,
-            enter = scaleIn(
+            enter = if (reduceMotion) EnterTransition.None
+            else scaleIn(
                 animationSpec = spring(
                     dampingRatio = Spring.DampingRatioMediumBouncy,
                     stiffness = Spring.StiffnessLow,
@@ -697,10 +701,11 @@ private fun StringButton(
 @Composable
 private fun StringButtonContent(label: String, isTuned: Boolean) {
     if (isTuned) {
-        // Animate the checkmark appearing with a bouncy scale-in.
+        val reduceMotion = LocalReduceMotion.current
         val checkScale by animateFloatAsState(
             targetValue = 1f,
-            animationSpec = spring(
+            animationSpec = if (reduceMotion) snap()
+            else spring(
                 dampingRatio = Spring.DampingRatioMediumBouncy,
                 stiffness = Spring.StiffnessMedium,
             ),


### PR DESCRIPTION
## Summary
- Reads `Settings.Global.ANIMATOR_DURATION_SCALE` to detect the system "Remove animations" accessibility preference
- When enabled, all decorative animations use `snap()` instead of `tween`/`spring` specs
- New `ReduceMotion.kt` with `LocalReduceMotion` CompositionLocal provided at the `MainActivity` level
- Updated 7 UI files covering 12 animation instances across tuner, metronome, chord transitions, strum patterns, favorites, and onboarding

## Test plan
- [ ] Enable Settings > Accessibility > Remove animations on device/emulator
- [ ] Verify tuner needle jumps instantly, no color transition, no bounce on checkmark/celebration
- [ ] Verify metronome beat indicators change instantly without scale pulse
- [ ] Verify chord transition animation skips smoothly
- [ ] Disable the setting and confirm all animations work normally

Part of #140

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added accessibility support for reduced motion settings. When the system "Remove animations" setting is enabled, animations throughout the app—including chord transitions, metronome beats, strumming patterns, tuner adjustments, and onboarding indicators—now snap instantly instead of smoothly animating, providing a better experience for users with motion sensitivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->