### PR TITLE
Add: reduce motion support for iOS animations

### DIFF
--- a/iosApp/UkuleleCompanion/Views/ChordLibraryView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordLibraryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import shared
 
 struct ChordLibraryView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var viewModel = ChordLibraryViewModel()
     @EnvironmentObject private var favoritesVM: FavoritesViewModel
     var onApplyVoicing: ((ChordVoicing, Int32, ChordFormula) -> Void)?
@@ -175,7 +176,7 @@ struct ChordLibraryView: View {
     // MARK: - Filter Toggle
 
     private var filterToggleRow: some View {
-        Button(action: { withAnimation { filtersExpanded.toggle() } }) {
+        Button(action: { withAnimation(reduceMotion ? nil : .default) { filtersExpanded.toggle() } }) {
             HStack {
                 Image(systemName: "line.3.horizontal.decrease.circle")
                 if filtersExpanded {

--- a/iosApp/UkuleleCompanion/Views/GlossaryView.swift
+++ b/iosApp/UkuleleCompanion/Views/GlossaryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import shared
 
 struct GlossaryView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var searchText = ""
     @State private var expandedTerm: String?
 
@@ -41,7 +42,7 @@ struct GlossaryView: View {
     private func glossaryRow(_ entry: GlossaryEntry) -> some View {
         let isExpanded = expandedTerm == entry.term
         Button {
-            withAnimation {
+            withAnimation(reduceMotion ? nil : .default) {
                 expandedTerm = isExpanded ? nil : entry.term
             }
         } label: {

--- a/iosApp/UkuleleCompanion/Views/HelpView.swift
+++ b/iosApp/UkuleleCompanion/Views/HelpView.swift
@@ -88,6 +88,7 @@ private let helpSections: [HelpSection] = [
 ]
 
 struct HelpView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var expandedEntry: String?
 
     var body: some View {
@@ -110,7 +111,7 @@ struct HelpView: View {
                         ForEach(Array(section.entries.enumerated()), id: \.element.id) { index, entry in
                             VStack(alignment: .leading, spacing: 4) {
                                 Button {
-                                    withAnimation {
+                                    withAnimation(reduceMotion ? nil : .default) {
                                         expandedEntry = expandedEntry == entry.id ? nil : entry.id
                                     }
                                 } label: {

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import shared
 
 struct MelodyNotepadView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var viewModel = MelodyViewModel()
     @State private var showingSaveDialog = false
     @State private var saveName = ""
@@ -239,8 +240,8 @@ struct MelodyNotepadView: View {
                     .background(Color.accentColor.opacity(0.9))
                     .foregroundStyle(.white)
                     .clipShape(Capsule())
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.lastAddedFeedback)
+                    .transition(reduceMotion ? .identity : .move(edge: .top).combined(with: .opacity))
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.3), value: viewModel.lastAddedFeedback)
             }
         }
     }

--- a/iosApp/UkuleleCompanion/Views/MetronomeView.swift
+++ b/iosApp/UkuleleCompanion/Views/MetronomeView.swift
@@ -149,6 +149,7 @@ struct MetronomeView: View {
 }
 
 struct BeatIndicatorView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let index: Int
     let type: BeatType
     let isActive: Bool
@@ -161,7 +162,7 @@ struct BeatIndicatorView: View {
                 .background(Circle().fill(fillColor))
                 .frame(width: 44, height: 44)
                 .scaleEffect(isActive ? 1.3 : 1.0)
-                .animation(.easeInOut(duration: 0.1), value: isActive)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.1), value: isActive)
                 .onTapGesture { onTap() }
             Text("\(index + 1)")
                 .font(.caption2)

--- a/iosApp/UkuleleCompanion/Views/OnboardingView.swift
+++ b/iosApp/UkuleleCompanion/Views/OnboardingView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var settingsVM = SettingsViewModel()
     let onFinished: () -> Void
 
@@ -42,7 +43,7 @@ struct OnboardingView: View {
             HStack {
                 if currentPage > 0 {
                     Button("Back") {
-                        withAnimation { currentPage -= 1 }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage -= 1 }
                     }
                 } else {
                     Spacer().frame(width: 1)
@@ -57,7 +58,7 @@ struct OnboardingView: View {
                     .buttonStyle(.borderedProminent)
                 } else {
                     Button("Next") {
-                        withAnimation { currentPage += 1 }
+                        withAnimation(reduceMotion ? nil : .default) { currentPage += 1 }
                     }
                     .buttonStyle(.borderedProminent)
                 }

--- a/iosApp/UkuleleCompanion/Views/OpenSourceLicensesView.swift
+++ b/iosApp/UkuleleCompanion/Views/OpenSourceLicensesView.swift
@@ -73,13 +73,14 @@ private let licenseEntries: [LicenseEntry] = [
 ]
 
 struct OpenSourceLicensesView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var expandedEntry: String?
 
     var body: some View {
         List(licenseEntries) { entry in
             VStack(alignment: .leading, spacing: 8) {
                 Button {
-                    withAnimation {
+                    withAnimation(reduceMotion ? nil : .default) {
                         expandedEntry = expandedEntry == entry.id ? nil : entry.id
                     }
                 } label: {
@@ -119,7 +120,7 @@ struct OpenSourceLicensesView: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
-                    .transition(.opacity)
+                    .transition(reduceMotion ? .identity : .opacity)
                 }
             }
         }

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -3,6 +3,7 @@ import UniformTypeIdentifiers
 import shared
 
 struct SongbookView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @EnvironmentObject var viewModel: SongbookViewModel
     @State private var showingImportSheet = false
     @State private var showingFileImporter = false
@@ -1026,7 +1027,7 @@ struct SongViewerView: View {
                 HStack(spacing: 8) {
                     ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
                         Button {
-                            withAnimation {
+                            withAnimation(reduceMotion ? nil : .default) {
                                 proxy.scrollTo("line_\(section.lineIndex)", anchor: .top)
                             }
                         } label: {

--- a/iosApp/UkuleleCompanion/Views/StrumPatternsView.swift
+++ b/iosApp/UkuleleCompanion/Views/StrumPatternsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import shared
 
 struct StrumPatternsView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var customPatternsVM = CustomPatternsViewModel()
     @StateObject private var patternPlayer = PatternPlayer()
     @State private var selectedTab = 0
@@ -344,7 +345,7 @@ struct StrumPatternsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: .black.opacity(0.08), radius: 2, y: 1)
         .onTapGesture {
-            withAnimation {
+            withAnimation(reduceMotion ? nil : .default) {
                 expandedIndex = expandedIndex == index ? nil : index
             }
         }
@@ -518,7 +519,7 @@ struct StrumPatternsView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: .black.opacity(0.08), radius: 2, y: 1)
         .onTapGesture {
-            withAnimation {
+            withAnimation(reduceMotion ? nil : .default) {
                 expandedIndex = expandedIndex == index ? nil : index
             }
         }


### PR DESCRIPTION
## Summary
- Reads `@Environment(\.accessibilityReduceMotion)` to respect the iOS "Reduce Motion" accessibility preference
- When enabled, all `withAnimation` calls use `nil` (instant) and `.animation` modifiers use `nil`
- Updated 9 SwiftUI views covering all animation instances in the iOS app

## Test plan
- [ ] Enable Settings > Accessibility > Motion > Reduce Motion on device/simulator
- [ ] Verify metronome beat indicators change instantly without scale pulse
- [ ] Verify onboarding page transitions are instant
- [ ] Verify expand/collapse in Help, Glossary, Chord Library, Strum Patterns is instant
- [ ] Disable the setting and confirm all animations work normally

Part of #140

Made with [Cursor](https://cursor.com)