### PR TITLE
Add: per-string chord diagram exploration for TalkBack/VoiceOver

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/VerticalChordDiagram.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/VerticalChordDiagram.kt
@@ -33,8 +33,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -129,24 +132,30 @@ fun VerticalChordDiagram(
     }
     val isAtNut = startFret == 0
 
-    // Build accessibility description in composable scope for stringResource access
+    // Build per-string descriptions for accessibility exploration
+    val stringNames = listOf("G", "C", "E", "A")
+    val indices = if (leftHanded) voicing.frets.indices.reversed() else voicing.frets.indices.toList()
+    val perStringDescs = indices.map { i ->
+        val name = stringNames.getOrElse(i) { "String $i" }
+        val fret = voicing.frets[i]
+        val role = when {
+            bassStringIndex == i -> ", bass note"
+            commonToneIndices?.contains(i) == true -> ", common tone"
+            else -> ""
+        }
+        when (fret) {
+            ChordVoicing.MUTED -> "$name ${stringResource(R.string.diagram_string_muted)}$role"
+            0 -> "$name ${stringResource(R.string.diagram_string_open)}$role"
+            else -> "$name ${stringResource(R.string.diagram_string_fret, fret)}$role"
+        }
+    }
+
     val chordDescription = run {
-        val stringNames = listOf("G", "C", "E", "A")
         val parts = mutableListOf<String>()
         val notesSummary = soundingNotes
             ?: voicing.notes.joinToString(" ") { it?.name ?: "x" }
         parts.add(stringResource(R.string.diagram_chord_cd, notesSummary))
-        val indices = if (leftHanded) voicing.frets.indices.reversed() else voicing.frets.indices.toList()
-        for (i in indices) {
-            val name = stringNames.getOrElse(i) { "String $i" }
-            val fret = voicing.frets[i]
-            val desc = when (fret) {
-                ChordVoicing.MUTED -> "$name ${stringResource(R.string.diagram_string_muted)}"
-                0 -> "$name ${stringResource(R.string.diagram_string_open)}"
-                else -> "$name ${stringResource(R.string.diagram_string_fret, fret)}"
-            }
-            parts.add(desc)
-        }
+        parts.addAll(perStringDescs)
         if (capoFret != null) {
             parts.add(stringResource(R.string.diagram_capo_fret, capoFret))
         }
@@ -156,13 +165,33 @@ fun VerticalChordDiagram(
         parts.joinToString(", ")
     }
 
+    val context = LocalContext.current
+    val customStringActions = perStringDescs.map { desc ->
+        CustomAccessibilityAction(desc) {
+            context.getSystemService(android.view.accessibility.AccessibilityManager::class.java)
+                ?.let { am ->
+                    if (am.isEnabled) {
+                        val event = android.view.accessibility.AccessibilityEvent.obtain(
+                            android.view.accessibility.AccessibilityEvent.TYPE_ANNOUNCEMENT,
+                        )
+                        event.text.add(desc)
+                        am.sendAccessibilityEvent(event)
+                    }
+                }
+            true
+        }
+    }
+
     Card(
         modifier = modifier
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick,
             )
-            .semantics { contentDescription = chordDescription },
+            .semantics {
+                contentDescription = chordDescription
+                customActions = customStringActions
+            },
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/iosApp/UkuleleCompanion/Views/ChordDiagramView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordDiagramView.swift
@@ -47,13 +47,30 @@ struct ChordDiagramView: View {
 
     private var showNut: Bool { startFret == 0 }
 
-    private var fretDescription: String {
-        let descriptions = frets.map { fret -> String in
-            if fret == 0 { return "open" }
-            if fret < 0 { return "muted" }
-            return "\(fret)"
+    private var stringNames: [String] {
+        leftHanded ? ["A", "E", "C", "G"] : ["G", "C", "E", "A"]
+    }
+
+    private var perStringDescriptions: [String] {
+        frets.enumerated().map { (index, fret) in
+            let name = stringNames[index]
+            let role: String
+            let originalIndex = leftHanded ? (stringCount - 1 - index) : index
+            if originalIndex == bassStringIndex {
+                role = ", bass note"
+            } else if let common = commonToneIndices, common.contains(originalIndex) {
+                role = ", common tone"
+            } else {
+                role = ""
+            }
+            if fret == 0 { return "\(name) string open\(role)" }
+            if fret < 0 { return "\(name) string muted\(role)" }
+            return "\(name) string fret \(fret)\(role)"
         }
-        return "Strings: " + descriptions.joined(separator: ", ")
+    }
+
+    private var fretDescription: String {
+        perStringDescriptions.joined(separator: ", ")
     }
 
     var body: some View {
@@ -139,6 +156,22 @@ struct ChordDiagramView: View {
         }
         .padding(8)
         .accessibilityCombined(label: chordName ?? "Chord diagram", value: fretDescription)
+        .accessibilityCustomContent(
+            AccessibilityCustomContentKey("String 1", id: "s1"),
+            perStringDescriptions.count > 0 ? perStringDescriptions[0] : ""
+        )
+        .accessibilityCustomContent(
+            AccessibilityCustomContentKey("String 2", id: "s2"),
+            perStringDescriptions.count > 1 ? perStringDescriptions[1] : ""
+        )
+        .accessibilityCustomContent(
+            AccessibilityCustomContentKey("String 3", id: "s3"),
+            perStringDescriptions.count > 2 ? perStringDescriptions[2] : ""
+        )
+        .accessibilityCustomContent(
+            AccessibilityCustomContentKey("String 4", id: "s4"),
+            perStringDescriptions.count > 3 ? perStringDescriptions[3] : ""
+        )
     }
 
     private func dotColor(for stringIndex: Int) -> Color {


### PR DESCRIPTION
## Summary
- Chord diagrams previously had a single combined accessibility description
- Now each string can be explored individually with its fret position and role (bass note / common tone)
- Android: custom accessibility actions per string on the Card semantics
- iOS: per-string `AccessibilityCustomContent` entries for VoiceOver "More Content" rotor

## Test plan
- [ ] Android: enable TalkBack, focus a chord diagram, use custom actions menu to hear individual strings
- [ ] iOS: enable VoiceOver, focus a chord diagram, use rotor "More Content" to navigate per-string info
- [ ] Verify bass note and common tone roles are announced when applicable
- [ ] Verify left-handed mode reverses string order correctly

Part of #140

Made with [Cursor](https://cursor.com)