### PR TITLE
Fix: color-only state differentiation in tuner badges and meter

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
@@ -491,7 +491,10 @@ private fun SwiftF0StatusBadge(
     Box(
         modifier = modifier
             .background(color = bgColor, shape = RoundedCornerShape(999.dp))
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .semantics {
+                contentDescription = label
+            },
     ) {
         Text(
             text = label,
@@ -627,16 +630,18 @@ private fun NeedleMeter(
  */
 @Composable
 private fun PrecisionModeBadge(modifier: Modifier = Modifier) {
+    val label = stringResource(R.string.tuner_precision_mode)
     Box(
         modifier = modifier
             .background(
                 color = MaterialTheme.colorScheme.tertiaryContainer,
                 shape = RoundedCornerShape(999.dp),
             )
-            .padding(horizontal = 12.dp, vertical = 6.dp),
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .semantics { contentDescription = label },
     ) {
         Text(
-            text = stringResource(R.string.tuner_precision_mode),
+            text = label,
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onTertiaryContainer,
             fontWeight = FontWeight.SemiBold,

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -42,6 +42,7 @@ struct TunerView: View {
                 NeedleMeterView(cents: viewModel.centsDeviation)
                     .frame(height: 100)
                     .padding(.horizontal, 24)
+                    .accessibilityValue(viewModel.centsAccessibilityValue)
 
                 // Frequency display
                 if let freq = viewModel.frequency {
@@ -145,6 +146,7 @@ struct TunerView: View {
                     .background(Color.green.opacity(0.15))
                     .foregroundStyle(.green)
                     .clipShape(Capsule())
+                    .accessibilityLabel("Neural pitch detection active")
             case .fallback:
                 Text("SwiftF0 Fallback")
                     .font(.caption2.bold())
@@ -153,6 +155,7 @@ struct TunerView: View {
                     .background(Color.red.opacity(0.15))
                     .foregroundStyle(.red)
                     .clipShape(Capsule())
+                    .accessibilityLabel("Neural pitch detection fallback mode")
             }
         }
     }
@@ -316,6 +319,7 @@ struct NeedleMeterView: View {
         }
         .accessibilityElement()
         .accessibilityLabel(meterAccessibilityLabel)
+        .accessibilityAddTraits(.updatesFrequently)
     }
 
     private var needleColor: Color {


### PR DESCRIPTION
## Summary
- Android: adds `contentDescription` to SwiftF0StatusBadge and PrecisionModeBadge so TalkBack announces status text
- iOS: adds `accessibilityLabel` to neural badge, wires the previously dead `centsAccessibilityValue` to the meter view, and adds `.updatesFrequently` trait to NeedleMeterView

## Test plan
- [ ] Android: enable TalkBack, navigate to tuner, verify SwiftF0 badge is announced
- [ ] Android: enable precision mode, verify badge is announced
- [ ] iOS: enable VoiceOver, navigate to tuner, verify neural badge is announced
- [ ] iOS: verify meter gauge is announced as "updates frequently" element
- [ ] iOS: verify cents value (e.g. "5 cents flat") is spoken for the meter

Part of #140

Made with [Cursor](https://cursor.com)