### PR TITLE
Perf: pre-allocate iOS audio analysis buffer

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -21,6 +21,9 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
 
     /// Ring buffer holding the most recent `frameSize` samples.
     private var ringBuffer: [Float]
+    /// Reusable linear buffer passed to `onBuffer`. Callers must not hold a
+    /// reference beyond the callback invocation.
+    private var analysisBuf: [Float]
     private var writePos = 0
     private var filled = 0
 
@@ -29,6 +32,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
 
     init() {
         ringBuffer = [Float](repeating: 0, count: Self.frameSize)
+        analysisBuf = [Float](repeating: 0, count: Self.frameSize)
     }
 
     func start() {
@@ -108,6 +112,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             filled = 0
             resampleAccumulator = 0.0
             ringBuffer = [Float](repeating: 0, count: Self.frameSize)
+            analysisBuf = [Float](repeating: 0, count: Self.frameSize)
             bufferLock.unlock()
             return true
         }
@@ -152,7 +157,6 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
         }
 
         if filled >= Self.frameSize {
-            var analysisBuf = [Float](repeating: 0, count: Self.frameSize)
             for i in 0..<Self.frameSize {
                 analysisBuf[i] = ringBuffer[(writePos + i) % Self.frameSize]
             }


### PR DESCRIPTION
## Summary
- Eliminates 690 KB/s GC pressure by reusing the analysis buffer instead of allocating 16 KB per frame
- `analysisBuf` is now an instance property initialized in `init()` and reused across ~43 frames/sec
- Matches the existing Android `AudioCaptureEngine` pre-allocation pattern

## Test plan
- [ ] iOS: start tuner, verify pitch detection works correctly
- [ ] Verify no regression in tuning accuracy

Part of #141

Made with [Cursor](https://cursor.com)