### PR TITLE
Perf: add frame-dropping when processing falls behind

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -13,6 +13,7 @@ import com.baijum.ukufretboard.domain.NeuralPitchSupervisor
 import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.PitchResult
 import com.baijum.ukufretboard.domain.TunerNoteMapper
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -239,6 +240,9 @@ class PitchMonitorViewModel : ViewModel() {
      */
     private var previousFrequency: Double? = null
 
+    // --- Frame-dropping (backpressure) ----------------------------------------
+    private val isProcessing = AtomicBoolean(false)
+
     // --- Neural supervisor state ----------------------------------------------
 
     private var neuralSupervisor: NeuralPitchSupervisor? = null
@@ -347,7 +351,15 @@ class PitchMonitorViewModel : ViewModel() {
      */
     private fun processBuffer(samples: FloatArray) {
         if (!_uiState.value.isListening) return
+        if (!isProcessing.compareAndSet(false, true)) return
+        try {
+            processBufferInner(samples)
+        } finally {
+            isProcessing.set(false)
+        }
+    }
 
+    private fun processBufferInner(samples: FloatArray) {
         // Guard: the FFT requires a power-of-2 buffer.  When the recorder is
         // stopped, a partial (non-power-of-2) buffer may slip through; drop it.
         val n = samples.size

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
 import kotlin.math.log2
 
@@ -282,6 +283,9 @@ class TunerViewModel : ViewModel() {
         LOST_SIGNAL_HOLD_MS / FRAME_INTERVAL_MS
     ).toInt().coerceAtLeast(1)
 
+    // --- Frame-dropping (backpressure) ----------------------------------------
+    private val isProcessing = AtomicBoolean(false)
+
     // --- Neural supervisor state --------------------------------------------
 
     private var neuralSupervisor: NeuralPitchSupervisor? = null
@@ -447,6 +451,15 @@ class TunerViewModel : ViewModel() {
      */
     private fun processBuffer(samples: FloatArray) {
         if (!_uiState.value.isListening) return
+        if (!isProcessing.compareAndSet(false, true)) return
+        try {
+            processBufferInner(samples)
+        } finally {
+            isProcessing.set(false)
+        }
+    }
+
+    private fun processBufferInner(samples: FloatArray) {
         // --- Onset detection (adaptive) -------------------------------------
         // Detect sudden energy spikes (pluck attacks) using an adaptive
         // threshold based on a running EMA of recent RMS values. This makes

--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -28,6 +28,9 @@ final class PitchMonitorViewModel: ObservableObject {
     private static let smoothingWindow = 5
     private static let historyDurationMs: Int64 = 10_000
 
+    // Frame-dropping (backpressure)
+    private var isProcessing = false
+
     // Neural state
     private var neuralFrameCounter: Int = 0
     private var lastNeuralResult: NeuralPitchResult?
@@ -138,6 +141,10 @@ final class PitchMonitorViewModel: ObservableObject {
     }
 
     private func processBuffer(_ samples: [Float]) {
+        guard !isProcessing else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
         let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
         for i in 0..<samples.count {
             kotlinArray.set(index: Int32(i), value: samples[i])

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -389,6 +389,9 @@ final class TunerViewModel: ObservableObject {
     private static let ttsInTuneInterval: TimeInterval = 3.0
     private static let ttsCentsBucketSize = 5
 
+    // Frame-dropping (backpressure)
+    private var isProcessing = false
+
     // Neural pitch supervision
     private let neuralSupervisor: NeuralPitchSupervisor?
     private var neuralFrameCounter: Int = 0
@@ -479,6 +482,10 @@ final class TunerViewModel: ObservableObject {
     }
 
     private func processAudioBuffer(_ samples: [Float]) {
+        guard !isProcessing else { return }
+        isProcessing = true
+        defer { isProcessing = false }
+
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
         if rms < noiseGateRms {
             return


### PR DESCRIPTION
## Summary
- Adds backpressure to the audio pipeline on both platforms to prevent tuner needle lag under thermal throttling
- Android: `AtomicBoolean` guard in `TunerViewModel.processBuffer` and `PitchMonitorViewModel.processBuffer` — if the previous frame is still processing, the new frame is dropped
- iOS: Boolean guard in `TunerViewModel.processAudioBuffer` and `PitchMonitorViewModel.processBuffer` — actor-confined, no atomics needed

## Test plan
- [ ] Android: start tuner, verify pitch detection works correctly
- [ ] iOS: start tuner, verify pitch detection works correctly
- [ ] Both: no regression in tuning accuracy or responsiveness

Part of #141

Made with [Cursor](https://cursor.com)