### PR TITLE
Fix: prevent ONNX session close race in onCleared()

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -248,6 +248,7 @@ class PitchMonitorViewModel : ViewModel() {
 
     // --- Neural supervisor state ----------------------------------------------
 
+    @Volatile
     private var neuralSupervisor: NeuralPitchSupervisor? = null
     private var neuralFrameCounter = 0
     private var lastNeuralResult: NeuralPitchResult? = null
@@ -337,9 +338,10 @@ class PitchMonitorViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        AudioCaptureEngine.stop()
-        neuralSupervisor?.close()
+        val supervisor = neuralSupervisor
         neuralSupervisor = null
+        AudioCaptureEngine.stop()
+        supervisor?.close()
     }
 
     // --- Internal pipeline ---------------------------------------------------

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -292,6 +292,7 @@ class TunerViewModel : ViewModel() {
 
     // --- Neural supervisor state --------------------------------------------
 
+    @Volatile
     private var neuralSupervisor: NeuralPitchSupervisor? = null
     private var neuralFrameCounter = 0
     private var lastNeuralResult: NeuralPitchResult? = null
@@ -436,9 +437,10 @@ class TunerViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        AudioCaptureEngine.stop()
-        neuralSupervisor?.close()
+        val supervisor = neuralSupervisor
         neuralSupervisor = null
+        AudioCaptureEngine.stop()
+        supervisor?.close()
         shutdownTts()
     }
 


### PR DESCRIPTION
## Summary

- Make `neuralSupervisor` field `@Volatile` so the audio thread (running on `Dispatchers.Default`) sees the null write promptly
- Reorder `onCleared()` to null the reference **before** stopping the engine and closing the session, eliminating the race where `session.run()` could be in-flight when `session.close()` fires

## Context

`AudioCaptureEngine.stop()` is non-blocking — it cancels the capture coroutine without joining. The audio thread could still be inside `NeuralPitchSupervisor.estimate()` → `OrtSession.run()` when `close()` is called. Since `OrtSession` is not thread-safe, this is undefined behavior at the native JNI layer and can cause SIGSEGV/SIGBUS crashes.

## Test plan

- [x] `./gradlew assembleDebug` builds cleanly
- [ ] Existing unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Manual: rapidly toggle tuner on/off while playing audio, verify no native crashes in logcat
- [ ] Stress test: navigate away from Tuner/Pitch Monitor screens rapidly under CPU load

Fixes #180

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety and resource cleanup reliability in audio processing components to enhance stability during operation and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->