### PR TITLE
Fix: move iOS frame-dropping guard to audio thread

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import os
 import shared
 
 struct PitchPoint {
@@ -28,8 +29,8 @@ final class PitchMonitorViewModel: ObservableObject {
     private static let smoothingWindow = 5
     private static let historyDurationMs: Int64 = 10_000
 
-    // Frame-dropping (backpressure)
-    private var isProcessing = false
+    // Frame-dropping (backpressure) — checked on audio thread, not MainActor
+    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
 
     // Neural state
     private var neuralFrameCounter: Int = 0
@@ -74,8 +75,16 @@ final class PitchMonitorViewModel: ObservableObject {
     init() {
         neuralSupervisor = nil
         audioEngine.onBuffer = { [weak self] samples in
+            guard let self else { return }
+            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
+                if isProcessing { return false }
+                isProcessing = true
+                return true
+            }
+            guard shouldProcess else { return }
             Task { @MainActor in
-                self?.processBuffer(samples)
+                self.processBuffer(samples)
+                self.processingLock.withLock { $0 = false }
             }
         }
         Task {
@@ -149,10 +158,6 @@ final class PitchMonitorViewModel: ObservableObject {
     }
 
     private func processBuffer(_ samples: [Float]) {
-        guard !isProcessing else { return }
-        isProcessing = true
-        defer { isProcessing = false }
-
         let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
         for i in 0..<samples.count {
             kotlinArray.set(index: Int32(i), value: samples[i])

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AVFoundation
 import Foundation
+import os
 import shared
 
 struct TunerView: View {
@@ -398,8 +399,8 @@ final class TunerViewModel: ObservableObject {
     private static let ttsInTuneInterval: TimeInterval = 3.0
     private static let ttsCentsBucketSize = 5
 
-    // Frame-dropping (backpressure)
-    private var isProcessing = false
+    // Frame-dropping (backpressure) — checked on audio thread, not MainActor
+    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
 
     // Neural pitch supervision
     private var neuralSupervisor: NeuralPitchSupervisor?
@@ -446,8 +447,16 @@ final class TunerViewModel: ObservableObject {
     init() {
         neuralSupervisor = nil
         audioEngine.onBuffer = { [weak self] samples in
+            guard let self else { return }
+            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
+                if isProcessing { return false }
+                isProcessing = true
+                return true
+            }
+            guard shouldProcess else { return }
             Task { @MainActor in
-                self?.processAudioBuffer(samples)
+                self.processAudioBuffer(samples)
+                self.processingLock.withLock { $0 = false }
             }
         }
         Task {
@@ -500,10 +509,6 @@ final class TunerViewModel: ObservableObject {
     }
 
     private func processAudioBuffer(_ samples: [Float]) {
-        guard !isProcessing else { return }
-        isProcessing = true
-        defer { isProcessing = false }
-
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
         if rms < noiseGateRms {
             return


### PR DESCRIPTION
## Summary

- Replace the ineffective `isProcessing` Bool (checked on `@MainActor`) with an `OSAllocatedUnfairLock` that is checked atomically on the audio callback thread
- Frames are now actually dropped when processing falls behind, preventing Task queue buildup under thermal throttling

## Context

Both `TunerViewModel` and `PitchMonitorViewModel` are `@MainActor`. The audio callback dispatches to MainActor via `Task { @MainActor in ... }`. Since MainActor is a serial executor, `isProcessing` was always `false` by the time a queued Task executed — no frames were ever dropped. Under thermal throttling this caused increasing latency and potential memory growth.

The fix moves the check to the audio thread using `OSAllocatedUnfairLock` (iOS 16+, our deployment target), matching the Android pattern where `AtomicBoolean.compareAndSet` is checked on `Dispatchers.Default`.

## Test plan

- [x] iOS build succeeds (`xcodebuild ... build` — **BUILD SUCCEEDED**)
- [ ] Manual: open tuner, play audio — verify needle responds without increasing latency
- [ ] Stress test: simulate heavy CPU load and verify tuner remains responsive

Fixes #181

Made with [Cursor](https://cursor.com)