### PR TITLE
Fix: skip chord matching when fewer than 3 pitch classes are active

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioChordDetector.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioChordDetector.kt
@@ -121,7 +121,7 @@ object AudioChordDetector {
         val detection = if (activePitchClasses.size >= MIN_PITCH_CLASSES) {
             ChordDetector.detect(activePitchClasses.toList())
         } else {
-            ChordDetector.detect(activePitchClasses.toList())
+            ChordDetector.DetectionResult.NoSelection
         }
 
         // Confidence: fraction of total energy captured by the active bins


### PR DESCRIPTION
## Summary

- Fix copy-paste error where both branches of the `MIN_PITCH_CLASSES` check called `ChordDetector.detect()` identically
- The else branch now returns `DetectionResult.NoSelection`, preventing false-positive chord detection from noisy audio chromagram data with only 1-2 bins above threshold

## Context

A chord by definition requires at least 3 distinct pitch classes. When fewer than 3 are detected from audio, the active bins are unreliable (likely noise or a single sustained note). Passing them to `ChordDetector.detect()` could produce spurious `SingleNote` or `Interval` results that confuse the audio chord detection display.

## Test plan

- [x] `./gradlew :shared:build` compiles successfully
- [ ] Existing unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Manual: play a single note on ukulele — verify no chord name appears in Pitch Monitor

Fixes #182

Made with [Cursor](https://cursor.com)