### PR TITLE
Fix: check and release OrtStatusPtr from ONNX output name queries

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/NeuralPitchSupervisor.swift
+++ b/iosApp/UkuleleCompanion/Audio/NeuralPitchSupervisor.swift
@@ -126,7 +126,8 @@ final class NeuralPitchSupervisor: @unchecked Sendable {
 
         // Get output count
         var outputCount: Int = 0
-        api.pointee.SessionGetOutputCount(session, &outputCount)
+        let countStatus = api.pointee.SessionGetOutputCount(session, &outputCount)
+        if let s = countStatus { api.pointee.ReleaseStatus(s); return nil }
         let actualOutputCount = min(outputCount, 2)
 
         // Get allocator for output names
@@ -139,7 +140,14 @@ final class NeuralPitchSupervisor: @unchecked Sendable {
         var outputNameCPtrs: [UnsafePointer<CChar>?] = []
         for i in 0..<actualOutputCount {
             var namePtr: UnsafeMutablePointer<CChar>?
-            api.pointee.SessionGetOutputName(session, i, allocator, &namePtr)
+            let nameStatus = api.pointee.SessionGetOutputName(session, i, allocator, &namePtr)
+            if let s = nameStatus {
+                api.pointee.ReleaseStatus(s)
+                for ptr in outputNamePtrs {
+                    if let ptr = ptr { api.pointee.AllocatorFree(allocator, ptr) }
+                }
+                return nil
+            }
             outputNamePtrs.append(namePtr)
             outputNameCPtrs.append(namePtr.map { UnsafePointer($0) })
         }


### PR DESCRIPTION
## Summary

- Check the `OrtStatusPtr` returned by `SessionGetOutputCount` and `SessionGetOutputName` in `NeuralPitchSupervisor.estimate()`
- Release the status on error and return `nil` gracefully, matching the pattern used in `init()` for `SessionGetInputName`
- Clean up any already-allocated output name pointers if a mid-loop failure occurs

## Context

The ONNX C API returns an `OrtStatusPtr` from every function call. A non-nil status indicates an error and must be released with `ReleaseStatus`. Previously these return values were discarded, meaning:
1. The status object's memory leaked
2. An uninitialized `namePtr` could be used, causing undefined behavior

## Test plan

- [x] iOS build succeeds (**BUILD SUCCEEDED**)
- [ ] Manual: open tuner, verify neural pitch estimation still works

Fixes #183

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and resource cleanup in audio processing to improve application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->