### PR TITLE
Fix: correct descending interval octave calculation in ear training

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/IntervalTrainer.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/IntervalTrainer.kt
@@ -122,11 +122,8 @@ object IntervalTrainer {
                 note2Octave = if (note1 + interval >= 12) baseOctave + 1 else baseOctave
             }
             IntervalDirection.DESCENDING -> {
-                note1Octave = baseOctave + 1
-                // Descending: second note is lower
+                note1Octave = baseOctave
                 note2Octave = if (note1 + interval >= 12) baseOctave + 1 else baseOctave
-                // Actually for descending we want note1 high, note2 low
-                // note2 = note1 - interval
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix the DESCENDING branch in `IntervalTrainer.generateQuestion()` to use the same octave logic as ASCENDING
- Previously, a "descending P5" sounded like an ascending P4 (wrong interval and wrong direction)

## Root Cause

The playback code plays `note2` first (high) then `note1` second (low) for descending. The ASCENDING octave logic correctly makes note2 >= note1. But the DESCENDING branch incorrectly set `note1Octave = baseOctave + 1`, flipping which note was higher and producing the wrong audible interval.

## Verification

| Interval | Notes | Before (bug) | After (fix) |
|----------|-------|------|------|
| P5 from C | C(0), G(7) | G4->C5 = asc P4 | G4->C4 = desc P5 |
| P5 from G | G(7), D(2) | D5->G5 = asc P4 | D5->G4 = desc P5 |

## Test plan

- [x] Shared module compiles (`compileCommonMainKotlinMetadata` -- BUILD SUCCESSFUL)
- [ ] Manual: open Interval Trainer in descending mode, verify intervals sound correct

Fixes #184

Made with [Cursor](https://cursor.com)