### PR TITLE
Fix: move ONNX inference off @MainActor to prevent UI jank

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -372,14 +372,19 @@ final class PitchMonitorViewModel: ObservableObject {
         neuralFrameCounter += 1
 
         if neuralFrameCounter % Self.neuralSupervisorInterval == 0 {
-            let estimate = supervisor.estimate(samples)
-            lastNeuralResult = estimate
-            neuralResultAgeFrames = 0
-            if let estimate = estimate {
-                updateNeuralConsistency(estimate.frequencyHz)
-            } else {
-                neuralConsistencyFrames = 0
-                lastNeuralFrequencyForConsistency = nil
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let estimate = supervisor.estimate(samples)
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.lastNeuralResult = estimate
+                    self.neuralResultAgeFrames = 0
+                    if let estimate = estimate {
+                        self.updateNeuralConsistency(estimate.frequencyHz)
+                    } else {
+                        self.neuralConsistencyFrames = 0
+                        self.lastNeuralFrequencyForConsistency = nil
+                    }
+                }
             }
         } else if neuralResultAgeFrames < Int.max {
             neuralResultAgeFrames += 1

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -619,22 +619,23 @@ final class TunerViewModel: ObservableObject {
         neuralFrameCounter += 1
 
         if neuralFrameCounter % Self.neuralSupervisorInterval == 0 {
-            let estimate = supervisor.estimate(samples)
-            lastNeuralResult = estimate
-            neuralResultAgeFrames = 0
-            if let estimate = estimate {
-                consecutiveNeuralFailures = 0
-                updateNeuralConsistency(estimate.frequencyHz)
-                DispatchQueue.main.async { [weak self] in
-                    self?.neuralStatus = .active
-                }
-            } else {
-                consecutiveNeuralFailures += 1
-                neuralConsistencyFrames = 0
-                lastNeuralFrequencyForConsistency = nil
-                if consecutiveNeuralFailures >= Self.neuralFailureThreshold {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.neuralStatus = .fallback
+            Task.detached(priority: .userInitiated) { [weak self] in
+                let estimate = supervisor.estimate(samples)
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.lastNeuralResult = estimate
+                    self.neuralResultAgeFrames = 0
+                    if let estimate = estimate {
+                        self.consecutiveNeuralFailures = 0
+                        self.updateNeuralConsistency(estimate.frequencyHz)
+                        self.neuralStatus = .active
+                    } else {
+                        self.consecutiveNeuralFailures += 1
+                        self.neuralConsistencyFrames = 0
+                        self.lastNeuralFrequencyForConsistency = nil
+                        if self.consecutiveNeuralFailures >= Self.neuralFailureThreshold {
+                            self.neuralStatus = .fallback
+                        }
                     }
                 }
             }
@@ -642,10 +643,7 @@ final class TunerViewModel: ObservableObject {
             neuralResultAgeFrames += 1
         }
 
-        if neuralResultAgeFrames <= Self.neuralResultTTLFrames {
-            return lastNeuralResult
-        }
-        return nil
+        return neuralResultAgeFrames <= Self.neuralResultTTLFrames ? lastNeuralResult : nil
     }
 
     private func arbitrate(yinFreq: Double, yinConf: Double, neuralResult: NeuralPitchResult) -> Double {


### PR DESCRIPTION
## Summary

- Dispatch `supervisor.estimate()` to a `Task.detached(priority: .userInitiated)` instead of running it synchronously on `@MainActor`
- Neural results are updated asynchronously via `await MainActor.run` when inference completes
- The function still returns the cached `lastNeuralResult` synchronously for current-frame arbitration

## Context

Under thermal throttling, ONNX inference can take 20-50ms per frame, blocking all UI updates (needle movement, note display, haptic feedback). Since neural inference already runs only every 5th frame and results are cached with a 10-frame TTL, moving inference to a background task adds imperceptible latency while keeping the main thread free for UI.

`NeuralPitchSupervisor` is `@unchecked Sendable`, making it safe to call from a detached Task.

## Test plan

- [x] iOS build succeeds (**BUILD SUCCEEDED**)
- [ ] Manual: open tuner, play audio -- verify needle animation is smooth
- [ ] Stress test: simulate thermal throttling, verify no jank

Fixes #185

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized neural pitch estimation in the tuner to execute asynchronously, improving app responsiveness during pitch detection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->