### PR TITLE
Fix: close OrtSession.SessionOptions after session creation

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisor.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/domain/NeuralPitchSupervisor.kt
@@ -83,11 +83,14 @@ class NeuralPitchSupervisor(context: Context) : AutoCloseable {
 
     init {
         val bytes = context.assets.open(MODEL_ASSET).use { it.readBytes() }
-        val options = OrtSession.SessionOptions().apply {
-            setInterOpNumThreads(1)
-            setIntraOpNumThreads(1)
+        val options = OrtSession.SessionOptions()
+        try {
+            options.setInterOpNumThreads(1)
+            options.setIntraOpNumThreads(1)
+            session = env.createSession(bytes, options)
+        } finally {
+            options.close()
         }
-        session = env.createSession(bytes, options)
         inputName = session.inputNames.first()
     }
 


### PR DESCRIPTION
## Summary

- Close `OrtSession.SessionOptions` in a `finally` block after `env.createSession()` to release the native pointer

## Context

`SessionOptions` extends ONNX Runtime's `NativeObject` and implements `AutoCloseable`. It was created, used to configure the session, but never closed. The native memory was only reclaimed by the GC finalizer (unreliable on Android). A new instance leaked each time the user navigated to a screen using the neural pitch supervisor.

## Test plan

- [x] `./gradlew assembleDebug` builds cleanly (BUILD SUCCESSFUL)

Fixes #186

Made with [Cursor](https://cursor.com)