### PR TITLE
Fix: release ToneGenerator SoundPool on activity destroy

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/MainActivity.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.baijum.ukufretboard.audio.ToneGenerator
 import com.baijum.ukufretboard.ui.FretboardScreen
 import com.baijum.ukufretboard.ui.LocalReduceMotion
 import com.baijum.ukufretboard.ui.OnboardingScreen
@@ -65,5 +66,10 @@ class MainActivity : AppCompatActivity() {
             }
             }
         }
+    }
+
+    override fun onDestroy() {
+        ToneGenerator.release()
+        super.onDestroy()
     }
 }


### PR DESCRIPTION
## Summary

- Release `ToneGenerator`'s `SoundPool` in `MainActivity.onDestroy()`, fixing a native audio resource leak that persisted for the entire app lifetime
- Follows the same cleanup pattern already used by `MetronomeViewModel.onCleared()` for `ClickSoundPlayer`

Closes #194

## Test plan

- [ ] Build succeeds (`./gradlew assembleDebug`)
- [ ] Launch app, navigate screens that use ToneGenerator (fretboard, chord ear training, interval trainer), then destroy activity -- no SoundPool leak warnings in logcat
- [ ] Verify ToneGenerator re-initializes correctly after activity recreation (e.g. configuration change)

Made with [Cursor](https://cursor.com)