### PR TITLE
Fix: guard neuralSupervisor with lock to prevent race conditions

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -248,7 +248,8 @@ class PitchMonitorViewModel : ViewModel() {
 
     // --- Neural supervisor state ----------------------------------------------
 
-    @Volatile
+    private val supervisorLock = Any()
+    private var isCleared = false
     private var neuralSupervisor: NeuralPitchSupervisor? = null
     private var neuralFrameCounter = 0
     private var lastNeuralResult: NeuralPitchResult? = null
@@ -338,8 +339,12 @@ class PitchMonitorViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        val supervisor = neuralSupervisor
-        neuralSupervisor = null
+        val supervisor = synchronized(supervisorLock) {
+            isCleared = true
+            val s = neuralSupervisor
+            neuralSupervisor = null
+            s
+        }
         AudioCaptureEngine.stop()
         supervisor?.close()
     }
@@ -610,7 +615,9 @@ class PitchMonitorViewModel : ViewModel() {
     }
 
     private fun initializeNeuralSupervisor() {
-        if (neuralSupervisor != null) return
+        synchronized(supervisorLock) {
+            if (neuralSupervisor != null) return
+        }
         val ctx = appContext ?: return
         viewModelScope.launch {
             val supervisor = withContext(Dispatchers.IO) {
@@ -621,12 +628,18 @@ class PitchMonitorViewModel : ViewModel() {
                     null
                 }
             }
-            neuralSupervisor = supervisor
+            synchronized(supervisorLock) {
+                if (isCleared) {
+                    supervisor?.close()
+                    return@launch
+                }
+                neuralSupervisor = supervisor
+            }
         }
     }
 
     private fun runNeuralSupervisor(samples: FloatArray): NeuralPitchResult? {
-        val supervisor = neuralSupervisor ?: return null
+        val supervisor = synchronized(supervisorLock) { neuralSupervisor } ?: return null
         neuralFrameCounter++
 
         if (neuralFrameCounter % NEURAL_SUPERVISOR_INTERVAL == 0) {
@@ -734,7 +747,8 @@ class PitchMonitorViewModel : ViewModel() {
         val neuralConf = neuralResult?.confidence?.let { "%.2f".format(it) } ?: "null"
         val finalHz = finalResult?.frequencyHz?.let { "%.2f".format(it) } ?: "null"
         val finalConf = finalResult?.confidence?.let { "%.2f".format(it) } ?: "null"
-        val neuralMs = neuralSupervisor?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
+        val neuralMs = synchronized(supervisorLock) { neuralSupervisor }
+            ?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
 
         Log.d(
             TAG,

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -292,7 +292,8 @@ class TunerViewModel : ViewModel() {
 
     // --- Neural supervisor state --------------------------------------------
 
-    @Volatile
+    private val supervisorLock = Any()
+    private var isCleared = false
     private var neuralSupervisor: NeuralPitchSupervisor? = null
     private var neuralFrameCounter = 0
     private var lastNeuralResult: NeuralPitchResult? = null
@@ -437,8 +438,12 @@ class TunerViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        val supervisor = neuralSupervisor
-        neuralSupervisor = null
+        val supervisor = synchronized(supervisorLock) {
+            isCleared = true
+            val s = neuralSupervisor
+            neuralSupervisor = null
+            s
+        }
         AudioCaptureEngine.stop()
         supervisor?.close()
         shutdownTts()
@@ -707,7 +712,9 @@ class TunerViewModel : ViewModel() {
     }
 
     private fun initializeNeuralSupervisor() {
-        if (neuralSupervisor != null) return
+        synchronized(supervisorLock) {
+            if (neuralSupervisor != null) return
+        }
         val ctx = appContext ?: return
         updateNeuralStatus(
             available = false,
@@ -723,7 +730,13 @@ class TunerViewModel : ViewModel() {
                     null
                 }
             }
-            neuralSupervisor = supervisor
+            synchronized(supervisorLock) {
+                if (isCleared) {
+                    supervisor?.close()
+                    return@launch
+                }
+                neuralSupervisor = supervisor
+            }
             if (supervisor != null) {
                 updateNeuralStatus(
                     available = true,
@@ -741,7 +754,7 @@ class TunerViewModel : ViewModel() {
     }
 
     private fun runNeuralSupervisor(samples: FloatArray): NeuralPitchResult? {
-        val supervisor = neuralSupervisor ?: return null
+        val supervisor = synchronized(supervisorLock) { neuralSupervisor } ?: return null
         neuralFrameCounter++
 
         if (neuralFrameCounter % NEURAL_SUPERVISOR_INTERVAL == 0) {
@@ -997,7 +1010,8 @@ class TunerViewModel : ViewModel() {
 
         val neuralFreq = neuralResult?.frequencyHz?.let { "%.2f".format(it) } ?: "null"
         val neuralConf = neuralResult?.confidence?.let { "%.2f".format(it) } ?: "null"
-        val inferenceMs = neuralSupervisor?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
+        val inferenceMs = synchronized(supervisorLock) { neuralSupervisor }
+            ?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
 
         Log.d(
             TAG,


### PR DESCRIPTION
## Summary

- Guard `neuralSupervisor` in `TunerViewModel` and `PitchMonitorViewModel` with a `supervisorLock` and `isCleared` flag, replacing the insufficient `@Volatile` annotation
- Fixes use-after-close race where `onCleared()` could close the OrtSession while `runNeuralSupervisor()` was mid-inference on a background thread
- Fixes init-after-destroy leak where a newly loaded `NeuralPitchSupervisor` could be orphaned if `onCleared()` ran during model loading

Closes #195

## Test plan

- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] Open tuner, wait for "Neural: Active" status, rapidly navigate away -- no OrtException in logcat
- [ ] Open pitch monitor, repeat the same rapid navigation test

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential race conditions in real-time audio processing and neural inference that could cause application instability during lifecycle transitions and shutdown.
  * Enhanced thread safety and resource management for background processing tasks to reliably prevent crashes and ensure proper cleanup when the application transitions between operational states or closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->