### PR TITLE
Fix: handle audio session interruptions on iOS and Android

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/audio/AudioCaptureEngine.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/audio/AudioCaptureEngine.kt
@@ -1,8 +1,13 @@
 package com.baijum.ukufretboard.audio
 
+import android.content.Context
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.os.Handler
+import android.os.Looper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +56,9 @@ object AudioCaptureEngine {
 
     private var audioRecord: AudioRecord? = null
     private var captureJob: Job? = null
+    private var focusRequest: AudioFocusRequest? = null
+    private var audioManager: AudioManager? = null
+    private var onInterrupted: (() -> Unit)? = null
 
     /** Whether capture is currently active. */
     val isCapturing: Boolean get() = captureJob?.isActive == true
@@ -63,12 +71,19 @@ object AudioCaptureEngine {
      * overlapping analysis frame is linearised and passed to [onBuffer] on a
      * background thread every [HOP_SIZE] new samples.
      *
-     * @param scope    Coroutine scope that owns the capture lifetime.
-     * @param onBuffer Callback receiving a [FloatArray] of [FRAME_SIZE]
+     * @param scope          Coroutine scope that owns the capture lifetime.
+     * @param context        Application context for audio focus requests.
+     * @param onInterrupted  Optional callback when another app takes audio focus.
+     * @param onBuffer       Callback receiving a [FloatArray] of [FRAME_SIZE]
      *   normalised samples. The array is reused across calls; consumers must
      *   not hold a reference beyond the callback invocation.
      */
-    fun start(scope: CoroutineScope, onBuffer: (FloatArray) -> Unit) {
+    fun start(
+        scope: CoroutineScope,
+        context: Context,
+        onInterrupted: (() -> Unit)? = null,
+        onBuffer: (FloatArray) -> Unit,
+    ) {
         if (isCapturing) return
 
         val minBuf = AudioRecord.getMinBufferSize(
@@ -98,6 +113,25 @@ object AudioCaptureEngine {
 
         audioRecord = recorder
         recorder.startRecording()
+
+        val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+            .setOnAudioFocusChangeListener({ focusChange ->
+                if (focusChange == AudioManager.AUDIOFOCUS_LOSS ||
+                    focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT
+                ) {
+                    val callback = onInterrupted
+                    stop()
+                    Handler(Looper.getMainLooper()).post {
+                        callback?.invoke()
+                    }
+                }
+            }, Handler(Looper.getMainLooper()))
+            .build()
+        am.requestAudioFocus(request)
+        audioManager = am
+        focusRequest = request
+        this.onInterrupted = onInterrupted
 
         captureJob = scope.launch {
             try {
@@ -184,5 +218,10 @@ object AudioCaptureEngine {
         captureJob?.cancel()
         captureJob = null
         audioRecord = null
+
+        focusRequest?.let { audioManager?.abandonAudioFocusRequest(it) }
+        focusRequest = null
+        audioManager = null
+        onInterrupted = null
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -149,7 +149,11 @@ fun PlayAlongView(
     // Audio detection callback
     LaunchedEffect(isListening) {
         if (isListening && hasMicPermission) {
-            AudioCaptureEngine.start(scope) { samples ->
+            AudioCaptureEngine.start(
+                scope,
+                context.applicationContext,
+                onInterrupted = { isListening = false },
+            ) { samples ->
                 val result = AudioChordDetector.detect(samples)
                 val chordFound = result.detection as? ChordDetector.DetectionResult.ChordFound
                 scope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -96,6 +96,7 @@ class MelodyViewModel : ViewModel() {
     val uiState: StateFlow<MelodyUiState> = _uiState.asStateFlow()
 
     private var repository: MelodyRepository? = null
+    private var appContext: Context? = null
     private var soundSettings: SoundSettings = SoundSettings()
 
     // --- Recording state ---
@@ -111,6 +112,9 @@ class MelodyViewModel : ViewModel() {
     private var awaitingSilence = false
 
     fun setApplicationContext(context: Context) {
+        if (appContext == null) {
+            appContext = context.applicationContext
+        }
         if (repository == null) {
             repository = MelodyRepository(context.applicationContext)
             refreshSavedMelodies()
@@ -441,7 +445,12 @@ class MelodyViewModel : ViewModel() {
             )
         }
 
-        AudioCaptureEngine.start(viewModelScope) { buffer ->
+        val ctx = appContext ?: return
+        AudioCaptureEngine.start(
+            viewModelScope,
+            ctx,
+            onInterrupted = { stopRecording() },
+        ) { buffer ->
             processRecordingBuffer(buffer)
         }
     }

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -295,7 +295,11 @@ class PitchMonitorViewModel : ViewModel() {
         neuralConsistencyFrames = 0
         telemetryFrameCounter = 0
 
-        AudioCaptureEngine.start(viewModelScope) { buffer ->
+        AudioCaptureEngine.start(
+            viewModelScope,
+            appContext!!,
+            onInterrupted = { stopListening() },
+        ) { buffer ->
             processBuffer(buffer)
         }
     }

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -389,7 +389,11 @@ class TunerViewModel : ViewModel() {
         telemetryOverrideCount = 0
         lastLoggedStatus = TuningStatus.SILENT
 
-        AudioCaptureEngine.start(viewModelScope) { buffer ->
+        AudioCaptureEngine.start(
+            viewModelScope,
+            appContext!!,
+            onInterrupted = { stopTuning() },
+        ) { buffer ->
             processBuffer(buffer)
         }
     }

--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -30,6 +30,10 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
     /// Called on a background queue with each analysis frame.
     var onBuffer: (([Float]) -> Void)?
 
+    /// Called on the main actor when the system interrupts capture (phone call, Siri, etc.).
+    var onInterrupted: (() -> Void)?
+    private var interruptionObserver: NSObjectProtocol?
+
     init() {
         ringBuffer = [Float](repeating: 0, count: Self.frameSize)
         analysisBuf = [Float](repeating: 0, count: Self.frameSize)
@@ -82,6 +86,15 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             do {
                 try engine.start()
                 _isRunning = true
+                #if !targetEnvironment(simulator)
+                interruptionObserver = NotificationCenter.default.addObserver(
+                    forName: AVAudioSession.interruptionNotification,
+                    object: AVAudioSession.sharedInstance(),
+                    queue: nil
+                ) { [weak self] notification in
+                    self?.handleInterruption(notification)
+                }
+                #endif
                 return true
             } catch {
                 print("AudioCaptureEngine failed to start: \(error)")
@@ -100,6 +113,11 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
     func stop() {
         let didStop: Bool = sessionQueue.sync {
             guard _isRunning else { return false }
+
+            if let observer = interruptionObserver {
+                NotificationCenter.default.removeObserver(observer)
+                interruptionObserver = nil
+            }
 
             engine.inputNode.removeTap(onBus: 0)
             engine.stop()
@@ -162,6 +180,20 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             }
             onBuffer?(analysisBuf)
             filled -= Self.hopSize
+        }
+    }
+
+    private func handleInterruption(_ notification: Notification) {
+        guard let info = notification.userInfo,
+              let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+
+        if type == .began {
+            let callback = onInterrupted
+            stop()
+            Task { @MainActor in
+                callback?()
+            }
         }
     }
 

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -346,6 +346,7 @@ final class MelodyViewModel: ObservableObject {
             }
         }
 
+        audioEngine.onInterrupted = { [weak self] in self?.stopRecording() }
         audioEngine.start()
         isRecording = true
     }

--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -153,6 +153,7 @@ final class PitchMonitorViewModel: ObservableObject {
         lastSimultaneousChordMs = 0
         lastArpeggioChordMs = 0
 
+        audioEngine.onInterrupted = { [weak self] in self?.stopCapture() }
         audioEngine.start()
         isListening = true
     }

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -107,6 +107,7 @@ final class PlayAlongViewModel: ObservableObject {
     }
 
     private func beginSession() {
+        audioEngine.onInterrupted = { [weak self] in self?.stop() }
         audioEngine.start()
         isPlaying = true
 

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -503,6 +503,7 @@ final class TunerViewModel: ObservableObject {
     }
 
     private func startCapture() {
+        audioEngine.onInterrupted = { [weak self] in self?.stopCapture() }
         audioEngine.start()
         isCapturing = true
         previousFrequency = nil


### PR DESCRIPTION
## Summary

- Add `onInterrupted` callback to both `AudioCaptureEngine` implementations so mic consumers can update UI when the system stops capture
- **iOS:** register for `AVAudioSession.interruptionNotification` and stop capture on `.began`
- **Android:** request/abandon audio focus via `AudioFocusRequest`, stopping on `AUDIOFOCUS_LOSS` / `AUDIOFOCUS_LOSS_TRANSIENT`
- Wire all four mic consumers on each platform (tuner, pitch monitor, melody recorder, play-along) to call their stop methods on interruption

Closes #197

## Test plan

- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] iOS Xcode build succeeds
- [ ] Start tuner, trigger a phone call or Siri — UI updates to "not listening" and user can tap to restart
- [ ] Repeat on pitch monitor, melody recorder, and play-along screens

Made with [Cursor](https://cursor.com)