### PR TITLE
Fix: guard TonePlayer asyncAfter against invalidated audio nodes

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
+++ b/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
@@ -106,9 +106,12 @@ final class TonePlayer {
             let delaySeconds = Double(index) * Double(strumDelayMs) / 1000.0
 
             if delaySeconds > 0 {
-                nonisolated(unsafe) let p = player
+                nonisolated(unsafe) let weakSelf = self
                 nonisolated(unsafe) let b = buffer
+                let nodeIndex = (nextNodeIndex - 1) % nodePoolSize
                 DispatchQueue.main.asyncAfter(deadline: .now() + delaySeconds) {
+                    guard let engine = weakSelf.audioEngine, engine.isRunning else { return }
+                    let p = weakSelf.playerNodes[nodeIndex]
                     p.stop()
                     p.scheduleBuffer(b, at: nil, options: .interrupts)
                     p.play()


### PR DESCRIPTION
## Summary

- Add `engine.isRunning` guard to `TonePlayer.playChord()` delayed closures so they are no-ops if the engine is stopped during the 50-150ms strum delay window
- Look up the player node through `self` via index instead of capturing the `AVAudioPlayerNode` reference directly, preventing operations on disconnected nodes

Closes #198

## Test plan

- [ ] Xcode build succeeds
- [ ] Play chords, rapidly navigate away mid-strum -- no crash or console error
- [ ] Strum playback sounds correct under normal use

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal audio playback handling for chord strumming with delayed timing to enhance stability and code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->