### PR TITLE
Fix: replace appContext!! with safe early-return in ViewModels

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -434,6 +434,7 @@ class MelodyViewModel : ViewModel() {
 
     fun startRecording() {
         if (_uiState.value.isRecording) return
+        val ctx = appContext ?: return
         if (_uiState.value.isPlaying) stopPlayback()
 
         resetRecordingState()
@@ -445,7 +446,6 @@ class MelodyViewModel : ViewModel() {
             )
         }
 
-        val ctx = appContext ?: return
         AudioCaptureEngine.start(
             viewModelScope,
             ctx,

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -265,6 +265,7 @@ class PitchMonitorViewModel : ViewModel() {
      */
     fun startListening() {
         if (_uiState.value.isListening) return
+        val ctx = appContext ?: return
 
         initializeNeuralSupervisor()
 
@@ -297,7 +298,7 @@ class PitchMonitorViewModel : ViewModel() {
 
         AudioCaptureEngine.start(
             viewModelScope,
-            appContext!!,
+            ctx,
             onInterrupted = { stopListening() },
         ) { buffer ->
             processBuffer(buffer)

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -358,6 +358,7 @@ class TunerViewModel : ViewModel() {
      */
     fun startTuning() {
         if (_uiState.value.isListening) return
+        val ctx = appContext ?: return
 
         _uiState.update {
             it.copy(
@@ -391,7 +392,7 @@ class TunerViewModel : ViewModel() {
 
         AudioCaptureEngine.start(
             viewModelScope,
-            appContext!!,
+            ctx,
             onInterrupted = { stopTuning() },
         ) { buffer ->
             processBuffer(buffer)


### PR DESCRIPTION
## Summary
- Replace `appContext!!` force-unwrap with `val ctx = appContext ?: return` in `PitchMonitorViewModel.startListening()` and `TunerViewModel.startTuning()`, preventing a potential NPE crash if `setApplicationContext()` hasn't been called.
- Matches the safe pattern already used in `MelodyViewModel`.

Closes #206

## Test plan
- [ ] Verify tuner starts and detects pitch normally
- [ ] Verify pitch monitor starts and detects chords normally
- [ ] Confirm no regression in audio capture flow

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash prevention in audio monitoring and tuning components by safely handling cases where the application context may not be available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->