### PR TITLE
Fix: snapshot steps array in playSteps() to prevent index out of bounds

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -192,14 +192,15 @@ final class MelodyViewModel: ObservableObject {
         playbackTask = Task { @MainActor [weak self] in
             guard let self else { return }
             repeat {
-                for i in 0..<self.steps.count {
+                let snapshot = self.steps
+                for i in 0..<snapshot.count {
                     if Task.isCancelled { break }
                     guard self.isPlaying else { break }
                     self.playingIndex = i
-                    if let note = self.steps[i], let pc = note.pitchClass {
+                    if let note = snapshot[i], let pc = note.pitchClass {
                         self.tonePlayer.playNote(pitchClass: Int32(pc))
                     }
-                    let duration = (self.steps[i]?.duration ?? self.selectedDuration).beats
+                    let duration = (snapshot[i]?.duration ?? self.selectedDuration).beats
                     let ms = duration * 60_000.0 / Double(self.bpm)
                     try? await Task.sleep(nanoseconds: UInt64(ms * 1_000_000))
                 }


### PR DESCRIPTION
## Summary
- Snapshot `self.steps` into a local `let` at the start of each `repeat` cycle in `playSteps()` and iterate over the snapshot instead of the live array.
- Prevents an "Index out of range" crash when `expandSteps()` shrinks the array from 16 to 8 elements during an `await Task.sleep` suspension point mid-playback.
- Matches the safe value-type copy pattern already used by `playMelody()`.

Closes #207

## Test plan
- [ ] Start step playback with 16 steps filled, tap expand/shrink during playback -- verify no crash
- [ ] Verify step playback sounds correct in both 8-step and 16-step modes
- [ ] Verify looping playback picks up the latest steps on each cycle

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the overall stability and responsiveness of melody step playback during musical performance. The internal playback mechanism now more reliably handles step-based note sequencing and duration calculations, ensuring consistent timing and smoother execution across all playback scenarios. This improvement provides users with more reliable, stable, and predictable melody playback experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->