### PR TITLE
Fix: use normalized comparison for Play Along chord matching

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -293,10 +293,12 @@ fun PlayAlongView(
                 if (isPlaying && detectedChord != null) {
                     Spacer(modifier = Modifier.height(8.dp))
                     val expectedChord = chordNames.getOrElse(currentChordIndex) { "" }
-                    val isCorrect = detectedChord?.contains(
-                        expectedChord.take(2),
-                        ignoreCase = true,
-                    ) == true
+                    val isCorrect = detectedChord?.let {
+                        normalizeChordForComparison(it).equals(
+                            normalizeChordForComparison(expectedChord),
+                            ignoreCase = true,
+                        )
+                    } == true
 
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
@@ -668,3 +670,8 @@ fun PlayAlongSetup(
         }
     }
 }
+
+private fun normalizeChordForComparison(name: String): String =
+    name.replace(Regex("[79]$"), "")
+        .replace("maj", "")
+        .trim()


### PR DESCRIPTION
## Summary
- Replace `take(2).contains()` chord matching with a normalization-based equality check that preserves root + quality distinction.
- Add `normalizeChordForComparison` helper that strips extensions (7, 9, maj) but keeps the core chord name (e.g., "Am7" -> "Am", "C" stays "C").
- Achieves platform parity with the iOS `PlayAlongViewModel.normalizeForComparison` logic.

Closes #208

## Test plan
- [ ] Play Along: play C major when C is expected -- verify correct
- [ ] Play Along: play Cm when C is expected -- verify incorrect (was previously accepted)
- [ ] Play Along: play Am7 when Am is expected -- verify correct (extension stripped)
- [ ] Play Along: play G when Gm is expected -- verify incorrect

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chord recognition in play-along practice mode: chord names are now normalized (case and whitespace-insensitive, treating implicit majors the same and ignoring trailing 7/9) and compared exactly, yielding more accurate validation and clearer feedback during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->