### PR TITLE
Fix: guard against empty degrees array in PlayAlongViewModel.start()

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -57,6 +57,7 @@ final class PlayAlongViewModel: ObservableObject {
         rootPitchClass: Int32,
         isMinorScale: Bool
     ) {
+        guard !degrees.isEmpty else { return }
         self.degrees = degrees
         self.bpm = bpm
         self.beatsPerChord = beatsPerChord


### PR DESCRIPTION
## Summary
- Add `guard !degrees.isEmpty else { return }` at the top of `PlayAlongViewModel.start()` to prevent an "Index out of range" crash when `onBeatTick()` accesses `degrees[currentChordIndex]` on an empty array.

Closes #209

## Test plan
- [ ] Start Play Along with a valid chord progression -- verify normal behavior
- [ ] Verify no crash if start() is invoked with an empty degrees array

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in the play-along feature when starting playback with invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->