### PR TITLE
Fix: add frame-dropping backpressure to PlayAlongView audio callback

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -76,6 +76,7 @@ import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.PlayAlongScorer
 import com.baijum.ukufretboard.viewmodel.UkuleleString
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Real-Time Play-Along with feedback view.
@@ -127,6 +128,7 @@ fun PlayAlongView(
     var score by remember { mutableStateOf(PlayAlongScorer.PlayAlongScore()) }
     var sessionComplete by remember { mutableStateOf(false) }
     var isListening by remember { mutableStateOf(false) }
+    val isProcessing = remember { AtomicBoolean(false) }
 
     // Build chord names for the progression
     val chordNames = remember(progression, keyRoot) {
@@ -154,16 +156,21 @@ fun PlayAlongView(
                 context.applicationContext,
                 onInterrupted = { isListening = false },
             ) { samples ->
-                val result = AudioChordDetector.detect(samples)
-                val chordFound = result.detection as? ChordDetector.DetectionResult.ChordFound
-                scope.launch(Dispatchers.Main) {
-                    if (chordFound != null && result.confidence > 0.3f) {
-                        detectedChord = chordFound.result.name
-                        detectionConfidence = result.confidence
-                    } else {
-                        detectedChord = null
-                        detectionConfidence = 0f
+                if (!isProcessing.compareAndSet(false, true)) return@start
+                try {
+                    val result = AudioChordDetector.detect(samples)
+                    val chordFound = result.detection as? ChordDetector.DetectionResult.ChordFound
+                    scope.launch(Dispatchers.Main) {
+                        if (chordFound != null && result.confidence > 0.3f) {
+                            detectedChord = chordFound.result.name
+                            detectionConfidence = result.confidence
+                        } else {
+                            detectedChord = null
+                            detectionConfidence = 0f
+                        }
                     }
+                } finally {
+                    isProcessing.set(false)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add an `AtomicBoolean` `isProcessing` guard around the `AudioChordDetector.detect()` call in the `PlayAlongView` audio callback.
- Drops incoming audio frames while chord detection is still running, preventing AudioRecord buffer overflow under thermal throttling.
- Matches the established backpressure pattern from `TunerViewModel` and `PitchMonitorViewModel`.

Closes #210

## Test plan
- [ ] Play Along chord detection works normally on a standard device
- [ ] No audio discontinuities or detection lag under sustained use

Made with [Cursor](https://cursor.com)