### PR TITLE
Fix: reset isInTune on signal loss to restore haptic feedback

### DIFF
--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -512,6 +512,7 @@ final class TunerViewModel: ObservableObject {
     private func processAudioBuffer(_ samples: [Float]) {
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
         if rms < noiseGateRms {
+            self.isInTune = false
             return
         }
 
@@ -609,6 +610,7 @@ final class TunerViewModel: ObservableObject {
                 }
             } else {
                 self.settledFrames = 0
+                self.isInTune = false
             }
         }
     }
@@ -757,6 +759,7 @@ final class TunerViewModel: ObservableObject {
         previousFrequency = nil
         activeStringIndex = nil
         settledFrames = 0
+        isInTune = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Reset `isInTune = false` in three paths where tuning state is lost: the noise gate early return, the no-pitch-result else branch, and `resetDisplay()`.
- Without this fix, `isInTune` stayed `true` through signal interruptions, preventing the `.onChange` observer from firing the `false -> true` transition needed to trigger `UINotificationFeedbackGenerator` haptic feedback.
- This particularly impacts blind/VI users who rely on haptic feedback to know when a string is in tune.
- Includes the additional `resetDisplay()` fix suggested by @beanscg in issue #211 comments.

Closes #211

## Test plan
- [ ] Tune a string until haptic fires, lift instrument away from mic, play same in-tune note again -- verify haptic fires again
- [ ] Verify haptic fires after toggling tuner off and back on
- [ ] Verify normal tuning flow still works (haptic on first in-tune detection)
- [ ] VoiceOver navigation on tuner screen is unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the tuner's accuracy indicator to reliably clear when audio input falls below audible thresholds or when pitch cannot be detected, ensuring more consistent and accurate tuning feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->