### PR TITLE
Fix: add frame-dropping backpressure to MelodyViewModel audio callback

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import os
 import shared
 
 enum NoteDuration: String, CaseIterable, Codable {
@@ -88,6 +89,7 @@ final class MelodyViewModel: ObservableObject {
     private let tonePlayer = TonePlayer()
     private var playbackTask: Task<Void, Never>?
     private let audioEngine = AudioCaptureEngine()
+    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
     private var stableCount = 0
     private var lastDetectedPitchClass: Int? = nil
 
@@ -290,41 +292,48 @@ final class MelodyViewModel: ObservableObject {
         lastDetectedPitchClass = nil
 
         audioEngine.onBuffer = { [weak self] samples in
-            Task { @MainActor in
             guard let self else { return }
-            let floatArray = KotlinFloatArray(size: Int32(samples.count))
-            for i in 0..<samples.count {
-                floatArray.set(index: Int32(i), value: samples[i])
+            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
+                if isProcessing { return false }
+                isProcessing = true
+                return true
             }
-
-            let result = PitchDetector.shared.detect(
-                samples: floatArray,
-                sampleRate: Int32(AudioCaptureEngine.sampleRate),
-                threshold: 0.15,
-                previousFrequency: nil
-            )
-
-            guard let result, result.confidence > 0.8 else {
+            guard shouldProcess else { return }
             Task { @MainActor in
-                self.detectedNote = nil
-                self.stableCount = 0
-                self.lastDetectedPitchClass = nil
-                self.stabilizationProgress = 0
-            }
-            return
-            }
+                let floatArray = KotlinFloatArray(size: Int32(samples.count))
+                for i in 0..<samples.count {
+                    floatArray.set(index: Int32(i), value: samples[i])
+                }
 
-            let noteInfo = TunerNoteMapper.shared.mapFrequency(
-                hz: result.frequencyHz,
-                a4Reference: 440.0
-            )
+                let result = PitchDetector.shared.detect(
+                    samples: floatArray,
+                    sampleRate: Int32(AudioCaptureEngine.sampleRate),
+                    threshold: 0.15,
+                    previousFrequency: nil
+                )
 
-            guard let noteInfo else { return }
+                guard let result, result.confidence > 0.8 else {
+                    self.detectedNote = nil
+                    self.stableCount = 0
+                    self.lastDetectedPitchClass = nil
+                    self.stabilizationProgress = 0
+                    self.processingLock.withLock { $0 = false }
+                    return
+                }
 
-            let pc = Int(noteInfo.pitchClass)
-            let oct = Int(noteInfo.octave)
+                let noteInfo = TunerNoteMapper.shared.mapFrequency(
+                    hz: result.frequencyHz,
+                    a4Reference: 440.0
+                )
 
-            Task { @MainActor in
+                guard let noteInfo else {
+                    self.processingLock.withLock { $0 = false }
+                    return
+                }
+
+                let pc = Int(noteInfo.pitchClass)
+                let oct = Int(noteInfo.octave)
+
                 self.detectedNote = noteInfo.noteName + "\(oct)"
 
                 if pc == self.lastDetectedPitchClass {
@@ -343,7 +352,8 @@ final class MelodyViewModel: ObservableObject {
                     self.detectedNote = nil
                     self.stabilizationProgress = 0
                 }
-            }
+
+                self.processingLock.withLock { $0 = false }
             }
         }
 


### PR DESCRIPTION
## Summary
- Add an `OSAllocatedUnfairLock`-based frame-dropping guard to `MelodyViewModel.beginCapture()`, matching the backpressure pattern from `PitchMonitorViewModel`.
- The lock check runs on the audio thread and drops frames while a previous Task is still executing on MainActor, preventing unbounded Task pile-up under thermal throttling.
- Also flattens the redundant nested `Task { @MainActor }` blocks into the single outer Task, releasing the lock on every exit path.

Closes #212

## Test plan
- [ ] Melody recording detects notes correctly
- [ ] Note stabilization and auto-add still work
- [ ] No UI lag during sustained recording

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio processing stability by preventing concurrent buffer processing conflicts, ensuring reliable melody detection during active audio streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->