### PR TITLE
Fix: gate state clearing behind isProcessing to prevent race condition

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -14,6 +14,7 @@ import com.baijum.ukufretboard.data.SoundSettings
 import com.baijum.ukufretboard.domain.NoteInfo
 import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.TunerNoteMapper
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -106,6 +107,7 @@ class MelodyViewModel : ViewModel() {
     private var previousRms = 0f
     private var blankingFramesRemaining = 0
     private var previousFrequency: Double? = null
+    private val isProcessing = AtomicBoolean(false)
     private val recentFrequencies = ArrayDeque<Double>(SMOOTHING_WINDOW)
     private var stableNoteInfo: NoteInfo? = null
     private var stabilizationFrames = 0
@@ -437,13 +439,18 @@ class MelodyViewModel : ViewModel() {
         val ctx = appContext ?: return
         if (_uiState.value.isPlaying) stopPlayback()
 
-        resetRecordingState()
-        _uiState.update {
-            it.copy(
-                isRecording = true,
-                detectedNote = null,
-                stabilizationProgress = 0f,
-            )
+        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        try {
+            resetRecordingState()
+            _uiState.update {
+                it.copy(
+                    isRecording = true,
+                    detectedNote = null,
+                    stabilizationProgress = 0f,
+                )
+            }
+        } finally {
+            isProcessing.set(false)
         }
 
         AudioCaptureEngine.start(
@@ -502,6 +509,15 @@ class MelodyViewModel : ViewModel() {
      */
     private fun processRecordingBuffer(samples: FloatArray) {
         if (!_uiState.value.isRecording) return
+        if (!isProcessing.compareAndSet(false, true)) return
+        try {
+            processRecordingBufferInner(samples)
+        } finally {
+            isProcessing.set(false)
+        }
+    }
+
+    private fun processRecordingBufferInner(samples: FloatArray) {
         val currentRms = PitchDetector.rms(samples)
         if (previousRms > 0f && currentRms / previousRms > ONSET_RATIO_THRESHOLD) {
             blankingFramesRemaining = BLANKING_FRAMES

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -269,32 +269,37 @@ class PitchMonitorViewModel : ViewModel() {
 
         initializeNeuralSupervisor()
 
-        _uiState.update { it.copy(isListening = true) }
-        recentFrequencies.clear()
-        lastChordName = null
-        chordHoldCount = 0
-        displayedChord = null
-        displayedChordNotes = emptyList()
-        lastChordConfidence = 0f
-        chordMissCount = 0
-        chordFrameCounter = 0
-        lastChromaEnergy = FloatArray(12)
-        arpeggioDetector.clear()
-        lastArpeggioChordName = null
-        arpeggioHoldCount = 0
-        displayedArpeggioChord = null
-        displayedArpeggioChordNotes = emptyList()
-        lastSimultaneousChordMs = 0L
-        lastArpeggioChordMs = 0L
-        previousRms = 0f
-        blankingFramesRemaining = 0
-        previousFrequency = null
-        neuralFrameCounter = 0
-        lastNeuralResult = null
-        neuralResultAgeFrames = Int.MAX_VALUE
-        lastNeuralFrequencyForConsistency = null
-        neuralConsistencyFrames = 0
-        telemetryFrameCounter = 0
+        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        try {
+            _uiState.update { it.copy(isListening = true) }
+            recentFrequencies.clear()
+            lastChordName = null
+            chordHoldCount = 0
+            displayedChord = null
+            displayedChordNotes = emptyList()
+            lastChordConfidence = 0f
+            chordMissCount = 0
+            chordFrameCounter = 0
+            lastChromaEnergy = FloatArray(12)
+            arpeggioDetector.clear()
+            lastArpeggioChordName = null
+            arpeggioHoldCount = 0
+            displayedArpeggioChord = null
+            displayedArpeggioChordNotes = emptyList()
+            lastSimultaneousChordMs = 0L
+            lastArpeggioChordMs = 0L
+            previousRms = 0f
+            blankingFramesRemaining = 0
+            previousFrequency = null
+            neuralFrameCounter = 0
+            lastNeuralResult = null
+            neuralResultAgeFrames = Int.MAX_VALUE
+            lastNeuralFrequencyForConsistency = null
+            neuralConsistencyFrames = 0
+            telemetryFrameCounter = 0
+        } finally {
+            isProcessing.set(false)
+        }
 
         AudioCaptureEngine.start(
             viewModelScope,

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -360,35 +360,40 @@ class TunerViewModel : ViewModel() {
         if (_uiState.value.isListening) return
         val ctx = appContext ?: return
 
-        _uiState.update {
-            it.copy(
-                isListening = true,
-                tuningStatus = TuningStatus.SILENT,
-                lastSettledNote = null,
-                lastSettledCents = 0.0,
-            )
+        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        try {
+            _uiState.update {
+                it.copy(
+                    isListening = true,
+                    tuningStatus = TuningStatus.SILENT,
+                    lastSettledNote = null,
+                    lastSettledCents = 0.0,
+                )
+            }
+            recentFrequencies.clear()
+            inTuneFrames = 0
+            inTuneStringIndex = -1
+            previousRms = 0f
+            rmsEma = 0f
+            blankingFramesRemaining = 0
+            lostSignalFrames = 0
+            previousFrequency = null
+            displayCentsFiltered = 0.0
+            settledNoteName = null
+            settledNoteFrames = 0
+            settledNoteCents = 0.0
+            neuralFrameCounter = 0
+            lastNeuralResult = null
+            neuralResultAgeFrames = Int.MAX_VALUE
+            consecutiveNeuralFailures = 0
+            lastNeuralFrequencyForConsistency = null
+            neuralConsistencyFrames = 0
+            telemetryFrameCounter = 0
+            telemetryOverrideCount = 0
+            lastLoggedStatus = TuningStatus.SILENT
+        } finally {
+            isProcessing.set(false)
         }
-        recentFrequencies.clear()
-        inTuneFrames = 0
-        inTuneStringIndex = -1
-        previousRms = 0f
-        rmsEma = 0f
-        blankingFramesRemaining = 0
-        lostSignalFrames = 0
-        previousFrequency = null
-        displayCentsFiltered = 0.0
-        settledNoteName = null
-        settledNoteFrames = 0
-        settledNoteCents = 0.0
-        neuralFrameCounter = 0
-        lastNeuralResult = null
-        neuralResultAgeFrames = Int.MAX_VALUE
-        consecutiveNeuralFailures = 0
-        lastNeuralFrequencyForConsistency = null
-        neuralConsistencyFrames = 0
-        telemetryFrameCounter = 0
-        telemetryOverrideCount = 0
-        lastLoggedStatus = TuningStatus.SILENT
 
         AudioCaptureEngine.start(
             viewModelScope,


### PR DESCRIPTION
## Summary
- Acquire the `isProcessing` AtomicBoolean via spin-wait in `startListening()`/`startTuning()`/`startRecording()` before clearing `recentFrequencies` and other internal state, ensuring no in-flight `processBufferInner()` is concurrently iterating the non-thread-safe `ArrayDeque`.
- Add `isProcessing` AtomicBoolean + CAS guard to `MelodyViewModel.processRecordingBuffer()` which previously had no frame-dropping backpressure on Android.
- Prevents `ConcurrentModificationException` / `IndexOutOfBoundsException` crash under rapid stop/start transitions.

Closes #214

## Test plan
- [ ] Tuner: rapid start/stop toggling does not crash
- [ ] Pitch Monitor: rapid start/stop toggling does not crash
- [ ] Melody recording: rapid start/stop toggling does not crash
- [ ] Normal tuning, chord detection, and melody recording still work correctly

Made with [Cursor](https://cursor.com)