### PR TITLE
Update: provide user feedback for empty Play Along progression

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -195,6 +195,20 @@ fun PlayAlongView(
 
         Spacer(modifier = Modifier.height(12.dp))
 
+        if (chordNames.isEmpty()) {
+            Text(
+                text = stringResource(R.string.play_along_empty_progression),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+                    .semantics { liveRegion = LiveRegionMode.Assertive },
+                textAlign = TextAlign.Center,
+            )
+            return
+        }
+
         // Microphone permission
         if (!hasMicPermission) {
             Card(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -559,6 +559,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">العزف المصاحب</string>
     <string name="play_along_subtitle">استمع واعزف الأوتار الصحيحة!</string>
+    <string name="play_along_empty_progression">لا توجد أوتار في هذا التسلسل. يرجى اختيار تسلسل يحتوي على أوتار.</string>
     <string name="play_along_mic_needed">يلزم الوصول إلى الميكروفون لاكتشاف الأوتار</string>
     <string name="cd_grant_permission">منح إذن الميكروفون</string>
     <string name="play_along_grant">منح الإذن</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -554,6 +554,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">跟弹练习</string>
     <string name="play_along_subtitle">聆听并弹奏正确的和弦！</string>
+    <string name="play_along_empty_progression">此和弦进行中没有和弦。请选择包含和弦的进行。</string>
     <string name="play_along_mic_needed">和弦检测需要麦克风权限</string>
     <string name="cd_grant_permission">授予麦克风权限</string>
     <string name="play_along_grant">授予权限</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">Mitspielen</string>
     <string name="play_along_subtitle">Höre zu und spiele die richtigen Akkorde!</string>
+    <string name="play_along_empty_progression">Keine Akkorde in dieser Progression. Bitte wähle eine Progression mit Akkorden.</string>
     <string name="play_along_mic_needed">Mikrofonzugriff für Akkorderkennung erforderlich</string>
     <string name="cd_grant_permission">Mikrofonberechtigung erteilen</string>
     <string name="play_along_grant">Berechtigung erteilen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Tocar junto ───────────────────────────────────────────────── -->
     <string name="play_along_title">Tocar junto</string>
     <string name="play_along_subtitle">¡Escucha y toca los acordes correctos!</string>
+    <string name="play_along_empty_progression">No hay acordes en esta progresión. Por favor selecciona una progresión con acordes.</string>
     <string name="play_along_mic_needed">Se necesita acceso al micrófono para la detección de acordes</string>
     <string name="cd_grant_permission">Conceder permiso de micrófono</string>
     <string name="play_along_grant">Conceder permiso</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Jouer ensemble ────────────────────────────────────────────── -->
     <string name="play_along_title">Jouer ensemble</string>
     <string name="play_along_subtitle">Écoutez et jouez les bons accords !</string>
+    <string name="play_along_empty_progression">Aucun accord dans cette progression. Veuillez sélectionner une progression avec des accords.</string>
     <string name="play_along_mic_needed">Accès au microphone requis pour la détection d\'accords</string>
     <string name="cd_grant_permission">Autoriser l\'accès au microphone</string>
     <string name="play_along_grant">Autoriser</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">साथ बजाएँ</string>
     <string name="play_along_subtitle">सुनें और सही कॉर्ड बजाएँ!</string>
+    <string name="play_along_empty_progression">इस प्रगति में कोई कॉर्ड नहीं हैं। कृपया कॉर्ड वाली प्रगति चुनें।</string>
     <string name="play_along_mic_needed">कॉर्ड पहचान के लिए माइक्रोफ़ोन एक्सेस आवश्यक</string>
     <string name="cd_grant_permission">माइक्रोफ़ोन अनुमति दें</string>
     <string name="play_along_grant">अनुमति दें</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -554,6 +554,7 @@
     <!-- ── Bermain Bersama ────────────────────────────────────────────── -->
     <string name="play_along_title">Bermain Bersama</string>
     <string name="play_along_subtitle">Dengarkan dan mainkan akor yang tepat!</string>
+    <string name="play_along_empty_progression">Tidak ada akor dalam progresi ini. Silakan pilih progresi yang memiliki akor.</string>
     <string name="play_along_mic_needed">Akses mikrofon diperlukan untuk deteksi akor</string>
     <string name="cd_grant_permission">Berikan izin mikrofon</string>
     <string name="play_along_grant">Berikan Izin</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Suona insieme ──────────────────────────────────────────────── -->
     <string name="play_along_title">Suona insieme</string>
     <string name="play_along_subtitle">Ascolta e suona gli accordi giusti!</string>
+    <string name="play_along_empty_progression">Nessun accordo in questa progressione. Seleziona una progressione con accordi.</string>
     <string name="play_along_mic_needed">Accesso al microfono necessario per il rilevamento degli accordi</string>
     <string name="cd_grant_permission">Concedi permesso microfono</string>
     <string name="play_along_grant">Concedi permesso</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -554,6 +554,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">一緒に演奏</string>
     <string name="play_along_subtitle">聴いて正しいコードを弾きましょう！</string>
+    <string name="play_along_empty_progression">このコード進行にはコードがありません。コードのある進行を選択してください。</string>
     <string name="play_along_mic_needed">コード検出にマイクへのアクセスが必要です</string>
     <string name="cd_grant_permission">マイクの権限を許可</string>
     <string name="play_along_grant">許可する</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -554,6 +554,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">함께 연주</string>
     <string name="play_along_subtitle">듣고 올바른 코드를 연주하세요!</string>
+    <string name="play_along_empty_progression">이 코드 진행에 코드가 없습니다. 코드가 포함된 진행을 선택하세요.</string>
     <string name="play_along_mic_needed">코드 감지를 위해 마이크 접근이 필요합니다</string>
     <string name="cd_grant_permission">마이크 권한 허용</string>
     <string name="play_along_grant">권한 허용</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Meespelen ──────────────────────────────────────────────────── -->
     <string name="play_along_title">Meespelen</string>
     <string name="play_along_subtitle">Luister en speel de juiste akkoorden!</string>
+    <string name="play_along_empty_progression">Geen akkoorden in deze progressie. Selecteer een progressie met akkoorden.</string>
     <string name="play_along_mic_needed">Microfoontoegang nodig voor akkoorddetectie</string>
     <string name="cd_grant_permission">Microfoontoestemming verlenen</string>
     <string name="play_along_grant">Toestemming verlenen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -557,6 +557,7 @@
     <!-- ── Graj razem ─────────────────────────────────────────────────── -->
     <string name="play_along_title">Graj razem</string>
     <string name="play_along_subtitle">Słuchaj i graj właściwe akordy!</string>
+    <string name="play_along_empty_progression">Brak akordów w tej progresji. Wybierz progresję z akordami.</string>
     <string name="play_along_mic_needed">Dostęp do mikrofonu wymagany do wykrywania akordów</string>
     <string name="cd_grant_permission">Przyznaj uprawnienie do mikrofonu</string>
     <string name="play_along_grant">Przyznaj uprawnienie</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Tocar junto ───────────────────────────────────────────────── -->
     <string name="play_along_title">Tocar junto</string>
     <string name="play_along_subtitle">Ouça e toque os acordes certos!</string>
+    <string name="play_along_empty_progression">Nenhum acorde nesta progressão. Selecione uma progressão com acordes.</string>
     <string name="play_along_mic_needed">Acesso ao microfone necessário para detecção de acordes</string>
     <string name="cd_grant_permission">Conceder permissão de microfone</string>
     <string name="play_along_grant">Conceder permissão</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -557,6 +557,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">Играть вместе</string>
     <string name="play_along_subtitle">Слушайте и играйте правильные аккорды!</string>
+    <string name="play_along_empty_progression">В этой последовательности нет аккордов. Выберите последовательность с аккордами.</string>
     <string name="play_along_mic_needed">Для определения аккордов нужен доступ к микрофону</string>
     <string name="cd_grant_permission">Предоставить доступ к микрофону</string>
     <string name="play_along_grant">Предоставить доступ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -555,6 +555,7 @@
     <!-- ── Eşlik Et ───────────────────────────────────────────────────── -->
     <string name="play_along_title">Eşlik Et</string>
     <string name="play_along_subtitle">Dinleyin ve doğru akorları çalın!</string>
+    <string name="play_along_empty_progression">Bu ilerlemede akor yok. Lütfen akor içeren bir ilerleme seçin.</string>
     <string name="play_along_mic_needed">Akor algılama için mikrofon erişimi gerekli</string>
     <string name="cd_grant_permission">Mikrofon izni ver</string>
     <string name="play_along_grant">İzin Ver</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -609,6 +609,7 @@
     <!-- ── Play Along ───────────────────────────────────────────────── -->
     <string name="play_along_title">Play Along</string>
     <string name="play_along_subtitle">Listen and play the right chords!</string>
+    <string name="play_along_empty_progression">No chords in this progression. Please select a progression with chords.</string>
     <string name="play_along_mic_needed">Microphone access needed for chord detection</string>
     <string name="cd_grant_permission">Grant microphone permission</string>
     <string name="play_along_grant">Grant Permission</string>

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -67712,6 +67712,106 @@
         }
       }
     },
+    "play_along_empty_progression": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No chords in this progression. Please select a progression with chords."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun accord dans cette progression. Veuillez sélectionner une progression avec des accords."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Akkorde in dieser Progression. Bitte wähle eine Progression mit Akkorden."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay acordes en esta progresión. Por favor selecciona una progresión con acordes."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun accordo in questa progressione. Seleziona una progressione con accordi."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum acorde nesta progressão. Selecione uma progressão com acordes."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geen akkoorden in deze progressie. Selecteer een progressie met akkoorden."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В этой последовательности нет аккордов. Выберите последовательность с аккордами."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu ilerlemede akor yok. Lütfen akor içeren bir ilerleme seçin."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak akordów w tej progresji. Wybierz progresję z akordami."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このコード進行にはコードがありません。コードのある進行を選択してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 코드 진행에 코드가 없습니다. 코드가 포함된 진행을 선택하세요."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "इस प्रगति में कोई कॉर्ड नहीं हैं। कृपया कॉर्ड वाली प्रगति चुनें।"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tidak ada akor dalam progresi ini. Silakan pilih progresi yang memiliki akor."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد أوتار في هذا التسلسل. يرجى اختيار تسلسل يحتوي على أوتار."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此和弦进行中没有和弦。请选择包含和弦的进行。"
+          }
+        }
+      }
+    },
     "play_along_grade": {
       "localizations": {
         "en": {
@@ -82922,106 +83022,6 @@
         }
       }
     },
-    "Open Source Licenses": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Source Licenses"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licences open source"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open-Source-Lizenzen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencias de código abierto"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenze open source"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licenças de código aberto"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opensourcelicenties"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Лицензии с открытым исходным кодом"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Açık Kaynak Lisansları"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Licencje open source"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オープンソースライセンス"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오픈소스 라이선스"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ओपन सोर्स लाइसेंस"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lisensi Sumber Terbuka"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "تراخيص المصادر المفتوحة"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开源许可证"
-          }
-        }
-      }
-    },
     "settings_noise_gate_filtering": {
       "localizations": {
         "en": {
@@ -83318,6 +83318,106 @@
           "stringUnit": {
             "state": "translated",
             "value": "音符时长"
+          }
+        }
+      }
+    },
+    "settings_open_source_licenses": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Source Licenses"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licences open source"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open-Source-Lizenzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencias de código abierto"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenze open source"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licenças de código aberto"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opensourcelicenties"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лицензии с открытым исходным кодом"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık Kaynak Lisansları"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Licencje open source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オープンソースライセンス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오픈소스 라이선스"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ओपन सोर्स लाइसेंस"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lisensi Sumber Terbuka"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تراخيص المصادر المفتوحة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开源许可证"
           }
         }
       }
@@ -102618,6 +102718,106 @@
           "stringUnit": {
             "state": "translated",
             "value": "SwiftF0 Fallback"
+          }
+        }
+      }
+    },
+    "tuner_swiftf0_loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SwiftF0 Loading…"
           }
         }
       }

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -14,6 +14,7 @@ final class PlayAlongViewModel: ObservableObject {
     @Published var detectedChord: String?
     @Published var isChordCorrect: Bool?
     @Published var score: PlayAlongScorer.PlayAlongScore?
+    @Published var errorMessage: String?
 
     // MARK: - Dependencies
 
@@ -67,7 +68,11 @@ final class PlayAlongViewModel: ObservableObject {
         rootPitchClass: Int32,
         isMinorScale: Bool
     ) {
-        guard !degrees.isEmpty else { return }
+        guard !degrees.isEmpty else {
+            errorMessage = "No chords in this progression. Please select a progression first."
+            return
+        }
+        errorMessage = nil
         self.degrees = degrees
         self.bpm = bpm
         self.beatsPerChord = beatsPerChord

--- a/iosApp/UkuleleCompanion/Views/PlayAlongView.swift
+++ b/iosApp/UkuleleCompanion/Views/PlayAlongView.swift
@@ -160,6 +160,7 @@ struct PlayAlongView: View {
                                 )
                             }
                             .buttonStyle(.borderedProminent)
+                            .disabled(degrees.isEmpty)
                         }
                     }
                 }
@@ -168,6 +169,14 @@ struct PlayAlongView: View {
         }
         .navigationTitle("Play Along")
         .onDisappear { viewModel.stop() }
+        .alert("Play Along", isPresented: Binding(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("OK") { viewModel.errorMessage = nil }
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
     }
 
     // MARK: - Chord Feedback


### PR DESCRIPTION
## Summary
- **iOS:** Disable the Play button when `degrees` is empty, and show a fallback `.alert` via a new `@Published var errorMessage` on `PlayAlongViewModel`.
- **Android:** Show an error message with `LiveRegionMode.Assertive` (accessible to TalkBack) and early-return when `chordNames` is empty.
- Add `play_along_empty_progression` string to all 16 locales (15 translations + English source) and regenerate iOS `Localizable.xcstrings`.

Closes #219

## Test plan
- [ ] iOS: Play button is disabled when no progression is selected or progression has empty degrees
- [ ] iOS: Alert appears if empty degrees bypass reaches the ViewModel guard
- [ ] Android: Error message shown when chordNames is empty
- [ ] VoiceOver (iOS) announces the alert; TalkBack (Android) announces the error text
- [ ] Normal Play Along flow is unaffected on both platforms

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- The Play Along feature now prevents users from attempting playback when a progression contains no chords, displaying a helpful error message that guides them to select a progression with chords instead.
- Added localized error messages across 16 languages (including Arabic, Chinese, German, Spanish, French, Hindi, and more) to ensure clear user guidance worldwide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->