### PR TITLE
Fix: normalize iOS backup timestamps for cross-platform restore

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
@@ -552,41 +552,34 @@ class BackupRestoreManager(
 
         if ("exportedAt" !in root) return jsonContent
 
+        val arrayFields = mapOf(
+            "setlists" to arrayOf("createdAt", "updatedAt"),
+            "customStrumPatterns" to arrayOf("createdAt"),
+            "customFingerpickingPatterns" to arrayOf("createdAt"),
+        )
+        val objectFields = mapOf(
+            "practiceTimer" to arrayOf("lastSessionTime"),
+        )
+
         var modified = false
         val out = buildJsonObject {
             for ((key, value) in root) {
-                when (key) {
-                    "setlists" -> {
+                val arrTsFields = arrayFields[key]
+                val objTsFields = objectFields[key]
+                when {
+                    arrTsFields != null -> {
                         val arr = value as? JsonArray
                         if (arr != null) {
-                            put(key, normalizeTimestampArray(arr, "createdAt", "updatedAt"))
+                            put(key, normalizeTimestampArray(arr, *arrTsFields))
                             modified = true
                         } else {
                             put(key, value)
                         }
                     }
-                    "customStrumPatterns" -> {
-                        val arr = value as? JsonArray
-                        if (arr != null) {
-                            put(key, normalizeTimestampArray(arr, "createdAt"))
-                            modified = true
-                        } else {
-                            put(key, value)
-                        }
-                    }
-                    "customFingerpickingPatterns" -> {
-                        val arr = value as? JsonArray
-                        if (arr != null) {
-                            put(key, normalizeTimestampArray(arr, "createdAt"))
-                            modified = true
-                        } else {
-                            put(key, value)
-                        }
-                    }
-                    "practiceTimer" -> {
+                    objTsFields != null -> {
                         val obj = value as? JsonObject
                         if (obj != null) {
-                            put(key, normalizeTimestampObject(obj, "lastSessionTime"))
+                            put(key, normalizeTimestampObject(obj, *objTsFields))
                             modified = true
                         } else {
                             put(key, value)
@@ -618,7 +611,7 @@ class BackupRestoreManager(
     ): JsonObject = buildJsonObject {
         for ((k, v) in obj) {
             if (k in tsFields) {
-                val ts = v.jsonPrimitive.doubleOrNull
+                val ts = (v as? JsonPrimitive)?.doubleOrNull
                 if (ts != null) {
                     val millis = if (ts < 100_000_000_000) {
                         (ts * 1000).toLong()

--- a/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
@@ -228,7 +228,8 @@ class BackupRestoreManager(
      * @param jsonContent The JSON string from a backup file.
      */
     fun importBackup(jsonContent: String) {
-        val normalized = normalizeIosFormat(jsonContent)
+        val afterLegacy = normalizeIosFormat(jsonContent)
+        val normalized = normalizeKmpTimestamps(afterLegacy)
         val backup = json.decodeFromString(BackupData.serializer(), normalized)
 
         // --- Favorites ---
@@ -532,6 +533,106 @@ class BackupRestoreManager(
         }
 
         return json.encodeToString(JsonObject.serializer(), out)
+    }
+
+    /**
+     * Normalizes timestamp fields in KMP-format backups that may contain
+     * fractional Doubles (from iOS JSONSerialization) or epoch-seconds values.
+     *
+     * Truncates fractional parts so kotlinx.serialization can decode to Long,
+     * and converts seconds to milliseconds using the same heuristic as
+     * [normalizeIosFavorites].
+     */
+    private fun normalizeKmpTimestamps(jsonContent: String): String {
+        val root = try {
+            json.parseToJsonElement(jsonContent).jsonObject
+        } catch (_: Exception) {
+            return jsonContent
+        }
+
+        if ("exportedAt" !in root) return jsonContent
+
+        var modified = false
+        val out = buildJsonObject {
+            for ((key, value) in root) {
+                when (key) {
+                    "setlists" -> {
+                        val arr = value as? JsonArray
+                        if (arr != null) {
+                            put(key, normalizeTimestampArray(arr, "createdAt", "updatedAt"))
+                            modified = true
+                        } else {
+                            put(key, value)
+                        }
+                    }
+                    "customStrumPatterns" -> {
+                        val arr = value as? JsonArray
+                        if (arr != null) {
+                            put(key, normalizeTimestampArray(arr, "createdAt"))
+                            modified = true
+                        } else {
+                            put(key, value)
+                        }
+                    }
+                    "customFingerpickingPatterns" -> {
+                        val arr = value as? JsonArray
+                        if (arr != null) {
+                            put(key, normalizeTimestampArray(arr, "createdAt"))
+                            modified = true
+                        } else {
+                            put(key, value)
+                        }
+                    }
+                    "practiceTimer" -> {
+                        val obj = value as? JsonObject
+                        if (obj != null) {
+                            put(key, normalizeTimestampObject(obj, "lastSessionTime"))
+                            modified = true
+                        } else {
+                            put(key, value)
+                        }
+                    }
+                    else -> put(key, value)
+                }
+            }
+        }
+
+        return if (modified) json.encodeToString(JsonObject.serializer(), out)
+        else jsonContent
+    }
+
+    private fun normalizeTimestampArray(
+        arr: JsonArray,
+        vararg tsFields: String,
+    ): JsonArray = buildJsonArray {
+        for (elem in arr) {
+            val obj = elem as? JsonObject
+            if (obj == null) { add(elem); continue }
+            add(normalizeTimestampObject(obj, *tsFields))
+        }
+    }
+
+    private fun normalizeTimestampObject(
+        obj: JsonObject,
+        vararg tsFields: String,
+    ): JsonObject = buildJsonObject {
+        for ((k, v) in obj) {
+            if (k in tsFields) {
+                val ts = v.jsonPrimitive.doubleOrNull
+                if (ts != null) {
+                    val millis = if (ts < 100_000_000_000) {
+                        (ts * 1000).toLong()
+                    } else {
+                        ts.toLong()
+                    }
+                    put(k, JsonPrimitive(millis))
+                } else {
+                    put(k, v)
+                }
+            } else {
+                put(k, v)
+            }
+        }
     }
 
     private fun copyArray(src: JsonObject, srcKey: String): JsonArray? =

--- a/app/src/test/java/com/baijum/ukufretboard/data/sync/IosBackupNormalizationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/sync/IosBackupNormalizationTest.kt
@@ -12,6 +12,7 @@ import com.baijum.ukufretboard.data.LearningProgressRepository
 import com.baijum.ukufretboard.data.MelodyRepository
 import com.baijum.ukufretboard.data.NoteDuration
 import com.baijum.ukufretboard.data.PracticeTimerRepository
+import com.baijum.ukufretboard.data.SetlistRepository
 import com.baijum.ukufretboard.viewmodel.SettingsViewModel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -278,6 +279,65 @@ class IosBackupNormalizationTest {
                 vm.exportSettings().display.themeMode.name,
             )
         }
+    }
+
+    @Test
+    fun kmpFormatFractionalTimestampsNormalized() {
+        val kmpBackup = """
+        {
+            "version": 3,
+            "exportedAt": 1700000000000,
+            "favorites": [],
+            "favoriteFolders": [],
+            "chordSheets": [],
+            "customProgressions": [],
+            "customStrumPatterns": [
+                {"id":"sp1","name":"Island","beats":[{"direction":"DOWN","emphasis":true}],"createdAt":1700000000.123,"timeSignature":"4/4"}
+            ],
+            "customFingerpickingPatterns": [
+                {"id":"fp1","name":"Travis","steps":[{"finger":"THUMB","stringIndex":3,"emphasis":false}],"createdAt":1700000000.456,"timeSignature":"4/4"}
+            ],
+            "setlists": [
+                {"id":"sl1","name":"Gig","songIds":[],"createdAt":1700000000000.789,"updatedAt":1700000000000.999}
+            ],
+            "melodies": [],
+            "learningProgress": {"entries":{}},
+            "achievements": {},
+            "practiceTimer": {"totalMinutes":10,"totalSessions":2,"longestSession":8,"lastSessionTime":1700000000.321,"dailyGoal":15,"dailyMinutes":{}},
+            "settings": {"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true},
+            "knownChords": []
+        }
+        """.trimIndent()
+        manager.importBackup(kmpBackup)
+
+        val strumRepo = CustomStrumPatternRepository(app)
+        val strumAll = strumRepo.getAll()
+        assertEquals(1, strumAll.size)
+        assertTrue(
+            "Strum createdAt (seconds) should be converted to millis",
+            strumAll[0].createdAt >= 1_000_000_000_000,
+        )
+
+        val fpRepo = CustomFingerpickingPatternRepository(app)
+        val fpAll = fpRepo.getAll()
+        assertEquals(1, fpAll.size)
+        assertTrue(
+            "Fingerpick createdAt (seconds) should be converted to millis",
+            fpAll[0].createdAt >= 1_000_000_000_000,
+        )
+
+        val setlistRepo = SetlistRepository(app)
+        val setlists = setlistRepo.getAll()
+        assertEquals(1, setlists.size)
+        assertEquals("Gig", setlists[0].name)
+        assertEquals(1700000000000L, setlists[0].createdAt)
+        assertEquals(1700000000000L, setlists[0].updatedAt)
+
+        val practiceRepo = PracticeTimerRepository(app)
+        assertTrue(
+            "Practice lastSessionTime (seconds) should be converted to millis",
+            practiceRepo.lastSessionTime() >= 1_000_000_000_000,
+        )
     }
 
     // ── Helper ───────────────────────────────────────────────────────

--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -73,14 +73,14 @@ final class BackupRestoreManager: ObservableObject {
             "favoriteFolders": convertFoldersToKMP(folders),
             "chordSheets": convertChordSheetsToKMP(songbookVM.exportData()),
             "customProgressions": convertProgressionsToKMP(progressionsVM.exportData()),
-            "customStrumPatterns": customPatternsVM.exportStrumData(),
+            "customStrumPatterns": convertStrumToKMP(customPatternsVM.exportStrumData()),
             "customFingerpickingPatterns": convertFingerpickToKMP(customPatternsVM.exportFingerpickData()),
-            "setlists": setlistVM.exportData(),
+            "setlists": convertSetlistsToKMP(setlistVM.exportData()),
             "melodies": convertMelodiesToKMP(melodyVM.exportData()),
             "learningProgress": convertLearnProgressToKMP(learnData),
             "settings": convertSettingsToKMP(settingsVM.exportSettings()),
             "achievements": extractAchievementsForKMP(learnData),
-            "practiceTimer": practiceTimerVM.exportData(),
+            "practiceTimer": convertPracticeTimerToKMP(practiceTimerVM.exportData()),
             "knownChords": [] as [String],
         ]
         do {
@@ -320,9 +320,22 @@ final class BackupRestoreManager: ObservableObject {
         Dictionary(uniqueKeysWithValues: fingerToKMP.map { ($0.value, $0.key) })
     }()
 
+    private func convertStrumToKMP(_ patterns: [[String: Any]]) -> [[String: Any]] {
+        patterns.map { p in
+            var out = p
+            if let createdAt = p["createdAt"] as? Double {
+                out["createdAt"] = Int64(createdAt * 1000)
+            }
+            return out
+        }
+    }
+
     private func convertFingerpickToKMP(_ patterns: [[String: Any]]) -> [[String: Any]] {
         patterns.map { p in
             var out = p
+            if let createdAt = p["createdAt"] as? Double {
+                out["createdAt"] = Int64(createdAt * 1000)
+            }
             if let steps = p["steps"] as? [[String: Any]] {
                 out["steps"] = steps.map { step in
                     var s = step
@@ -334,6 +347,27 @@ final class BackupRestoreManager: ObservableObject {
             }
             return out
         }
+    }
+
+    private func convertSetlistsToKMP(_ setlists: [[String: Any]]) -> [[String: Any]] {
+        setlists.map { sl in
+            var out = sl
+            if let createdAt = sl["createdAt"] as? Double {
+                out["createdAt"] = Int64(createdAt)
+            }
+            if let updatedAt = sl["updatedAt"] as? Double {
+                out["updatedAt"] = Int64(updatedAt)
+            }
+            return out
+        }
+    }
+
+    private func convertPracticeTimerToKMP(_ timer: [String: Any]) -> [String: Any] {
+        var out = timer
+        if let lastSessionTime = timer["lastSessionTime"] as? Double {
+            out["lastSessionTime"] = Int64(lastSessionTime * 1000)
+        }
+        return out
     }
 
     private func convertMelodiesToKMP(_ melodies: [[String: Any]]) -> [[String: Any]] {

--- a/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
@@ -125,8 +125,9 @@ final class CustomPatternsViewModel: ObservableObject {
                   !existingIds.contains(id),
                   let name = dict["name"] as? String,
                   let beatDicts = dict["beats"] as? [[String: Any]],
-                  let createdAt = dict["createdAt"] as? Double
+                  let rawCreatedAt = dict["createdAt"] as? Double
             else { continue }
+            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
             let timeSignature = dict["timeSignature"] as? String ?? "4/4"
             let beats = beatDicts.compactMap { bd -> StrumBeatData? in
                 guard let dir = bd["direction"] as? String,
@@ -159,8 +160,9 @@ final class CustomPatternsViewModel: ObservableObject {
                   !existingIds.contains(id),
                   let name = dict["name"] as? String,
                   let stepDicts = dict["steps"] as? [[String: Any]],
-                  let createdAt = dict["createdAt"] as? Double
+                  let rawCreatedAt = dict["createdAt"] as? Double
             else { continue }
+            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
             let timeSignature = dict["timeSignature"] as? String ?? "4/4"
             let steps = stepDicts.compactMap { sd -> FingerpickStepData? in
                 guard let finger = sd["finger"] as? String,

--- a/iosApp/UkuleleCompanion/ViewModels/PracticeTimerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PracticeTimerViewModel.swift
@@ -97,7 +97,8 @@ final class PracticeTimerViewModel: ObservableObject {
             data.longestSession = max(data.longestSession, longest)
         }
         if let lastTime = dict["lastSessionTime"] as? Double {
-            data.lastSessionTime = max(data.lastSessionTime, lastTime)
+            let normalized = lastTime > 100_000_000_000 ? lastTime / 1000.0 : lastTime
+            data.lastSessionTime = max(data.lastSessionTime, normalized)
         }
         if let goal = dict["dailyGoal"] as? Int {
             data.dailyGoal = goal


### PR DESCRIPTION
## Summary

Fixes #226 — iOS backup exports fractional Double timestamps into Long fields, causing Android restore to fail entirely.

- **iOS exporter**: converts strum/fingerpick `createdAt` (seconds to ms), setlist `createdAt`/`updatedAt` (truncate fraction), and practice timer `lastSessionTime` (seconds to ms) to integral `Int64` before serialization
- **Android importer**: adds a `normalizeKmpTimestamps` pre-deserialization pass that truncates fractional Doubles and converts epoch-seconds to ms for KMP-format backups (keeps old iOS backups restorable)
- **iOS importer**: normalizes incoming millisecond timestamps to seconds when importing Android/KMP backups for practice timer, strum, and fingerpicking patterns

## Test plan

- [x] New unit test `kmpFormatFractionalTimestampsNormalized` passes — verifies KMP-format backup with fractional Double timestamps and seconds-unit values imports successfully with correct millisecond values
- [x] All existing `IosBackupNormalizationTest` and `BackupRestoreManagerTest` tests pass
- [x] Shared module tests pass
- [x] iOS build succeeds
- [ ] Manual: export backup on iOS with setlist + strum pattern + practice session, restore on Android — verify data appears correctly
- [ ] Manual: export backup on Android, restore on iOS — verify practice timer and pattern timestamps render correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced backup import functionality to properly normalize timestamp data across platforms
  * Fixed restoration of custom patterns and practice session data to ensure consistency when importing backups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->