### PR TITLE
Fix: drain in-flight audio processing before closing ONNX session

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -356,7 +356,12 @@ class PitchMonitorViewModel : ViewModel() {
             s
         }
         AudioCaptureEngine.stop()
-        supervisor?.close()
+        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        try {
+            supervisor?.close()
+        } finally {
+            isProcessing.set(false)
+        }
     }
 
     // --- Internal pipeline ---------------------------------------------------

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -455,7 +455,12 @@ class TunerViewModel : ViewModel() {
             s
         }
         AudioCaptureEngine.stop()
-        supervisor?.close()
+        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        try {
+            supervisor?.close()
+        } finally {
+            isProcessing.set(false)
+        }
         shutdownTts()
     }
 


### PR DESCRIPTION
## Summary

Fixes #227 — `onCleared()` could call `supervisor.close()` (freeing native ONNX memory) while `estimate()` -> `session.run()` was still executing on `Dispatchers.Default`, causing a native use-after-free (SIGSEGV).

- Added the existing `isProcessing` spin-wait pattern to `TunerViewModel.onCleared()` and `PitchMonitorViewModel.onCleared()` to drain any in-flight `processBuffer` before closing the ONNX session
- This is the same pattern already used in `startTuning()` and `startListening()` for the same class of race

## Test plan

- [x] Android build compiles successfully
- [x] All unit tests pass
- [ ] Manual: open Tuner, start listening, rapidly back out of the app — no crash
- [ ] Manual: open Pitch Monitor, start listening, rapidly back out — no crash
- [ ] Stress test: repeat start/stop/exit cycle 50+ times with neural supervisor active


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio processing resource cleanup during app shutdown, ensuring the tuner and pitch monitor features properly close resources for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->