### PR TITLE
Fix: prevent AudioResampler data race and add neural inference backpressure

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -31,6 +31,7 @@ final class PitchMonitorViewModel: ObservableObject {
 
     // Frame-dropping (backpressure) — checked on audio thread, not MainActor
     private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
+    private nonisolated(unsafe) let neuralInferenceLock = OSAllocatedUnfairLock(initialState: false)
 
     // Neural state
     private var neuralFrameCounter: Int = 0
@@ -373,18 +374,26 @@ final class PitchMonitorViewModel: ObservableObject {
         neuralFrameCounter += 1
 
         if neuralFrameCounter % Self.neuralSupervisorInterval == 0 {
-            Task.detached(priority: .userInitiated) { [weak self] in
-                let estimate = supervisor.estimate(samples)
-                await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    self.lastNeuralResult = estimate
-                    self.neuralResultAgeFrames = 0
-                    if let estimate = estimate {
-                        self.updateNeuralConsistency(estimate.frequencyHz)
-                    } else {
-                        self.neuralConsistencyFrames = 0
-                        self.lastNeuralFrequencyForConsistency = nil
+            let canRun = neuralInferenceLock.withLock { inFlight -> Bool in
+                if inFlight { return false }
+                inFlight = true
+                return true
+            }
+            if canRun {
+                Task.detached(priority: .userInitiated) { [weak self] in
+                    let estimate = supervisor.estimate(samples)
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        self.lastNeuralResult = estimate
+                        self.neuralResultAgeFrames = 0
+                        if let estimate = estimate {
+                            self.updateNeuralConsistency(estimate.frequencyHz)
+                        } else {
+                            self.neuralConsistencyFrames = 0
+                            self.lastNeuralFrequencyForConsistency = nil
+                        }
                     }
+                    self?.neuralInferenceLock.withLock { $0 = false }
                 }
             }
         } else if neuralResultAgeFrames < Int.max {

--- a/iosApp/UkuleleCompanion/Views/TunerView.swift
+++ b/iosApp/UkuleleCompanion/Views/TunerView.swift
@@ -401,6 +401,7 @@ final class TunerViewModel: ObservableObject {
 
     // Frame-dropping (backpressure) — checked on audio thread, not MainActor
     private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
+    private nonisolated(unsafe) let neuralInferenceLock = OSAllocatedUnfairLock(initialState: false)
 
     // Neural pitch supervision
     private var neuralSupervisor: NeuralPitchSupervisor?
@@ -622,24 +623,32 @@ final class TunerViewModel: ObservableObject {
         neuralFrameCounter += 1
 
         if neuralFrameCounter % Self.neuralSupervisorInterval == 0 {
-            Task.detached(priority: .userInitiated) { [weak self] in
-                let estimate = supervisor.estimate(samples)
-                await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    self.lastNeuralResult = estimate
-                    self.neuralResultAgeFrames = 0
-                    if let estimate = estimate {
-                        self.consecutiveNeuralFailures = 0
-                        self.updateNeuralConsistency(estimate.frequencyHz)
-                        self.neuralStatus = .active
-                    } else {
-                        self.consecutiveNeuralFailures += 1
-                        self.neuralConsistencyFrames = 0
-                        self.lastNeuralFrequencyForConsistency = nil
-                        if self.consecutiveNeuralFailures >= Self.neuralFailureThreshold {
-                            self.neuralStatus = .fallback
+            let canRun = neuralInferenceLock.withLock { inFlight -> Bool in
+                if inFlight { return false }
+                inFlight = true
+                return true
+            }
+            if canRun {
+                Task.detached(priority: .userInitiated) { [weak self] in
+                    let estimate = supervisor.estimate(samples)
+                    await MainActor.run { [weak self] in
+                        guard let self else { return }
+                        self.lastNeuralResult = estimate
+                        self.neuralResultAgeFrames = 0
+                        if let estimate = estimate {
+                            self.consecutiveNeuralFailures = 0
+                            self.updateNeuralConsistency(estimate.frequencyHz)
+                            self.neuralStatus = .active
+                        } else {
+                            self.consecutiveNeuralFailures += 1
+                            self.neuralConsistencyFrames = 0
+                            self.lastNeuralFrequencyForConsistency = nil
+                            if self.consecutiveNeuralFailures >= Self.neuralFailureThreshold {
+                                self.neuralStatus = .fallback
+                            }
                         }
                     }
+                    self?.neuralInferenceLock.withLock { $0 = false }
                 }
             }
         } else if neuralResultAgeFrames < Int.max {

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioResampler.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioResampler.kt
@@ -56,7 +56,7 @@ object AudioResampler {
                 output[i] = filtered[baseIdx] * (1f - frac) + filtered[nextIdx] * frac
             }
 
-            output
+            output.copyOf()
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #229 — `AudioResampler.downsample44kTo16k()` returned its internal cached buffer, allowing concurrent callers to corrupt each other's data. iOS neural inference tasks had no backpressure, enabling unbounded concurrent `estimate()` calls that triggered the race.

- **Shared module**: return `output.copyOf()` from the resampler lock so callers get independent snapshots
- **iOS TunerView + PitchMonitorViewModel**: add `neuralInferenceLock` (`OSAllocatedUnfairLock<Bool>`) to skip neural frames when a previous inference is still in flight — mirrors the Android `isProcessing` pattern

## Test plan

- [x] Shared module tests pass (`./gradlew :shared:allTests`)
- [x] Android AudioResampler tests pass
- [x] iOS build compiles successfully
- [ ] Manual: open Tuner on iOS under thermal throttle (older device / Low Power Mode), verify no pitch jumps or garbage neural estimates
- [ ] Manual: open Pitch Monitor on iOS under load, verify chord detection is stable


Made with [Cursor](https://cursor.com)