### PR TITLE
Fix: prevent crash when AudioCaptureEngine is deallocated mid-capture

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -104,15 +104,15 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             }
         }
         if started {
-            Task { @MainActor in
-                self.isCapturing = true
+            Task { @MainActor [weak self] in
+                self?.isCapturing = true
             }
         }
     }
 
-    func stop() {
-        let didStop: Bool = sessionQueue.sync {
-            guard _isRunning else { return false }
+    private func tearDown() {
+        sessionQueue.sync {
+            guard _isRunning else { return }
 
             if let observer = interruptionObserver {
                 NotificationCenter.default.removeObserver(observer)
@@ -132,12 +132,13 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             ringBuffer = [Float](repeating: 0, count: Self.frameSize)
             analysisBuf = [Float](repeating: 0, count: Self.frameSize)
             bufferLock.unlock()
-            return true
         }
-        if didStop {
-            Task { @MainActor in
-                self.isCapturing = false
-            }
+    }
+
+    func stop() {
+        tearDown()
+        Task { @MainActor [weak self] in
+            self?.isCapturing = false
         }
     }
 
@@ -216,6 +217,6 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
     }
 
     deinit {
-        stop()
+        tearDown()
     }
 }


### PR DESCRIPTION
## Summary

Fixes #230 — `AudioCaptureEngine.deinit` called `stop()` which spawned `Task { self.isCapturing = false }`, strongly capturing `self` during deallocation — a Swift runtime trap.

- Extracted `tearDown()` for synchronous hardware cleanup (stop engine, remove tap, deactivate session, clear buffers) with no escaping closures
- `deinit` now calls `tearDown()` directly — no Task, no retain of deallocating self
- `stop()` calls `tearDown()` then updates `isCapturing` via `[weak self]` Task
- `start()` Task also hardened with `[weak self]` for consistency

## Test plan

- [x] iOS build compiles successfully
- [ ] Manual: rapidly dismiss a screen with active audio capture — no crash
- [ ] Manual: force-kill app while Tuner is listening — no crash on next launch


Made with [Cursor](https://cursor.com)