### PR TITLE
Fix: validate pitchClass and stringIndex at backup import boundary

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/audio/ToneGenerator.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/audio/ToneGenerator.kt
@@ -151,7 +151,7 @@ object ToneGenerator {
         volume: Float = 1f,
     ) {
         val sp = soundPool ?: return
-        val sampleId = sampleIds[pitchClass % 12]
+        val sampleId = sampleIds[Math.floorMod(pitchClass, 12)]
         if (sampleId == 0) return
 
         val rate = playbackRate(octave)
@@ -189,7 +189,7 @@ object ToneGenerator {
         playbackMutex.withLock {
             withContext(Dispatchers.Default) {
                 notes.forEachIndexed { index, (pitchClass, octave) ->
-                    val sampleId = sampleIds[pitchClass % 12]
+                    val sampleId = sampleIds[Math.floorMod(pitchClass, 12)]
                     if (sampleId != 0) {
                         val rate = playbackRate(octave)
                         sp.play(sampleId, vol, vol, 1, 0, rate)
@@ -216,7 +216,7 @@ object ToneGenerator {
      */
     fun fireNote(pitchClass: Int, octave: Int, volume: Float = 1f) {
         val sp = soundPool ?: return
-        val sampleId = sampleIds[pitchClass % 12]
+        val sampleId = sampleIds[Math.floorMod(pitchClass, 12)]
         if (sampleId == 0) return
         val rate = playbackRate(octave)
         val vol = volume.coerceIn(0f, 1f)
@@ -244,7 +244,7 @@ object ToneGenerator {
 
         withContext(Dispatchers.Default) {
             notes.forEachIndexed { index, (pitchClass, octave) ->
-                val sampleId = sampleIds[pitchClass % 12]
+                val sampleId = sampleIds[Math.floorMod(pitchClass, 12)]
                 if (sampleId != 0) {
                     val rate = playbackRate(octave)
                     sp.play(sampleId, vol, vol, 1, 0, rate)

--- a/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
@@ -233,7 +233,8 @@ class BackupRestoreManager(
         val backup = json.decodeFromString(BackupData.serializer(), normalized)
 
         // --- Favorites ---
-        favoritesRepo.importAll(backup.favorites.map { f ->
+        favoritesRepo.importAll(backup.favorites.mapNotNull { f ->
+            if (f.rootPitchClass !in 0..11) return@mapNotNull null
             // Backward compat: if folderIds is empty but old folderId is present, migrate
             val ids = f.folderIds.ifEmpty {
                 listOfNotNull(f.folderId)
@@ -422,13 +423,16 @@ class BackupRestoreManager(
     private fun importFingerpickingPatterns(items: List<BackupFingerpickingPattern>) {
         val domainItems = items.mapNotNull { bfp ->
             try {
-                val steps = bfp.steps.map { s ->
+                val validRange = 0 until com.baijum.ukufretboard.data.FingerpickingPatterns.STRING_NAMES.size
+                val steps = bfp.steps.mapNotNull { s ->
+                    if (s.stringIndex !in validRange) return@mapNotNull null
                     com.baijum.ukufretboard.data.FingerpickStep(
                         finger = com.baijum.ukufretboard.data.Finger.valueOf(s.finger),
                         stringIndex = s.stringIndex,
                         emphasis = s.emphasis,
                     )
                 }
+                if (steps.isEmpty()) return@mapNotNull null
                 val notation = steps.joinToString(" ") { s ->
                     val stringName = com.baijum.ukufretboard.data.FingerpickingPatterns.STRING_NAMES[s.stringIndex]
                     "${s.finger.label}($stringName)"
@@ -461,10 +465,10 @@ class BackupRestoreManager(
                     name = bm.name,
                     notes = bm.notes.map { n ->
                         MelodyNote(
-                            pitchClass = n.pitchClass,
-                            octave = n.octave,
+                            pitchClass = n.pitchClass?.takeIf { it in 0..11 },
+                            octave = n.octave.coerceIn(3, 5),
                             duration = NoteDuration.valueOf(n.duration),
-                            stringIndex = n.stringIndex,
+                            stringIndex = n.stringIndex?.takeIf { it in 0..3 },
                             fret = n.fret,
                         )
                     },

--- a/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/MelodyNotepadView.kt
@@ -513,7 +513,7 @@ private fun NoteBlock(
 ) {
     val pc = note.pitchClass
     val noteName = if (pc != null) {
-        noteNames[pc]
+        noteNames.getOrElse(pc) { "?" }
     } else {
         "\u2014"
     }

--- a/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
@@ -167,10 +167,12 @@ final class CustomPatternsViewModel: ObservableObject {
             let steps = stepDicts.compactMap { sd -> FingerpickStepData? in
                 guard let finger = sd["finger"] as? String,
                       let strIdx = sd["stringIndex"] as? Int,
+                      (0...3).contains(strIdx),
                       let emph = sd["emphasis"] as? Bool
                 else { return nil }
                 return FingerpickStepData(finger: finger, stringIndex: strIdx, emphasis: emph)
             }
+            guard !steps.isEmpty else { continue }
             fingerpickingPatterns.append(CustomFingerpickingData(
                 id: id, name: name, steps: steps, createdAt: createdAt, timeSignature: timeSignature))
         }

--- a/iosApp/UkuleleCompanion/ViewModels/FavoritesViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/FavoritesViewModel.swift
@@ -229,6 +229,7 @@ final class FavoritesViewModel: ObservableObject {
     func importData(favorites: [[String: Any]], folders: [[String: Any]]) {
         for dict in favorites {
             guard let rpc = dict["rootPitchClass"] as? Int,
+                  (0...11).contains(rpc),
                   let sym = dict["chordSymbol"] as? String,
                   let frets = dict["frets"] as? [Int],
                   let addedAt = dict["addedAt"] as? Double

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -51,6 +51,20 @@ struct MelodyData: Codable, Identifiable {
     var notes: [MelodyNoteData]
     var bpm: Int
     var createdAt: Double
+
+    func sanitized() -> MelodyData {
+        var copy = self
+        copy.notes = notes.map { note in
+            MelodyNoteData(
+                id: note.id,
+                pitchClass: note.pitchClass.flatMap { (0...11).contains($0) ? $0 : nil },
+                octave: min(max(note.octave, 3), 5),
+                duration: note.duration,
+                isRest: note.isRest
+            )
+        }
+        return copy
+    }
 }
 
 enum MelodyInputMode {
@@ -412,8 +426,9 @@ final class MelodyViewModel: ObservableObject {
         let decoder = JSONDecoder()
         for item in incoming {
             guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
-                  let melody = try? decoder.decode(MelodyData.self, from: jsonData)
+                  let decoded = try? decoder.decode(MelodyData.self, from: jsonData)
             else { continue }
+            let melody = decoded.sanitized()
             if let idx = savedMelodies.firstIndex(where: { $0.id == melody.id }) {
                 // Keep the one with the latest createdAt
                 if melody.createdAt > savedMelodies[idx].createdAt {

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
@@ -54,11 +54,10 @@ object Notes {
      * using the standard enharmonic spellings ([NOTE_NAMES_STANDARD]).
      *
      * @param pitchClass An integer from 0 to 11 representing a pitch class.
-     * @return The note name (e.g., "C", "F#", "Bb").
-     * @throws IndexOutOfBoundsException if [pitchClass] is not in 0..11.
+     * @return The note name (e.g., "C", "F#", "Bb"), or "?" if out of range.
      */
     fun pitchClassToName(pitchClass: Int): String =
-        NOTE_NAMES_STANDARD[pitchClass]
+        NOTE_NAMES_STANDARD.getOrElse(pitchClass) { "?" }
 
     /**
      * Key roots (pitch classes) whose major scales use flats.

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
@@ -244,6 +244,56 @@ class BackupDataTest {
         assertTrue(data.practiceTimer.dailyMinutes.isEmpty())
     }
 
+    @Test
+    fun melodyNoteWithOutOfRangePitchClassDeserializes() {
+        val noteJson = """{"pitchClass": 12, "octave": 4, "duration": "QUARTER"}"""
+        val note = json.decodeFromString<BackupMelodyNote>(noteJson)
+        assertEquals(12, note.pitchClass)
+        val sanitized = note.pitchClass?.takeIf { it in 0..11 }
+        assertEquals(null, sanitized)
+    }
+
+    @Test
+    fun melodyNoteWithNegativePitchClassDeserializes() {
+        val noteJson = """{"pitchClass": -1, "octave": 4, "duration": "QUARTER"}"""
+        val note = json.decodeFromString<BackupMelodyNote>(noteJson)
+        assertEquals(-1, note.pitchClass)
+        val sanitized = note.pitchClass?.takeIf { it in 0..11 }
+        assertEquals(null, sanitized)
+    }
+
+    @Test
+    fun melodyNoteWithValidPitchClassPassesValidation() {
+        for (pc in 0..11) {
+            val noteJson = """{"pitchClass": $pc, "octave": 4, "duration": "QUARTER"}"""
+            val note = json.decodeFromString<BackupMelodyNote>(noteJson)
+            val sanitized = note.pitchClass?.takeIf { it in 0..11 }
+            assertEquals(pc, sanitized)
+        }
+    }
+
+    @Test
+    fun favoriteWithOutOfRangeRootPitchClassIsDetected() {
+        val fav = BackupFavorite(
+            rootPitchClass = 12,
+            chordSymbol = "",
+            frets = listOf(0, 0, 0, 3),
+            addedAt = 1000L,
+        )
+        assertTrue(fav.rootPitchClass !in 0..11)
+    }
+
+    @Test
+    fun favoriteWithNegativeRootPitchClassIsDetected() {
+        val fav = BackupFavorite(
+            rootPitchClass = -1,
+            chordSymbol = "m",
+            frets = listOf(2, 0, 0, 0),
+            addedAt = 1000L,
+        )
+        assertTrue(fav.rootPitchClass !in 0..11)
+    }
+
     /**
      * Verifies that a JSON string representing a normalized iOS backup
      * (with KMP field names and structure) round-trips correctly through

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/NotesTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/NotesTest.kt
@@ -62,6 +62,21 @@ class NotesTest {
         assertEquals("Bb", Notes.pitchClassToName(10))
     }
 
+    @Test
+    fun pitchClassToNameReturnsQuestionMarkForNegative() {
+        assertEquals("?", Notes.pitchClassToName(-1))
+    }
+
+    @Test
+    fun pitchClassToNameReturnsQuestionMarkFor12() {
+        assertEquals("?", Notes.pitchClassToName(12))
+    }
+
+    @Test
+    fun pitchClassToNameReturnsQuestionMarkForLargeValue() {
+        assertEquals("?", Notes.pitchClassToName(100))
+    }
+
     // --- enharmonicForKey ---
 
     @Test


### PR DESCRIPTION
## Summary

Closes #236.

- Validates `pitchClass` (0..11), `octave` (3..5), and `stringIndex` (0..3) at the backup import boundary on both Android and iOS, converting out-of-range melody notes to rests and dropping invalid favorites/fingerpick steps
- Hardens shared crash sites (`Notes.pitchClassToName`, `ToneGenerator`, `MelodyNotepadView`) as defense-in-depth so they can never throw on out-of-range input
- Adds unit tests for `pitchClassToName` boundary values and backup data validation patterns

## Test plan

- [x] Shared module unit tests pass (`./gradlew :shared:jvmTest`)
- [ ] Android builds without errors (`./gradlew assembleDebug`)
- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Import a hand-crafted backup JSON containing `"pitchClass": 12` and `"pitchClass": -1` on Android -- melody opens without crash, invalid notes shown as rests
- [ ] Import the same backup on iOS -- melody opens without crash
- [ ] Import a backup with `"stringIndex": 5` in a fingerpick pattern -- pattern imports with invalid steps dropped
- [ ] Import a backup with `"rootPitchClass": -1` on a favorite -- favorite is silently dropped

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of backup data during import to reject out-of-range pitch and string values
  * Added safeguards for displaying and importing melodic data with invalid pitch or octave values
  * Enhanced error handling with fallback display ("?") when encountering invalid note information

* **Tests**
  * Added test coverage for data validation during backup restoration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->