### PR TITLE
Fix: close ONNX session on ViewModel cancellation during async init

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -635,20 +635,25 @@ class PitchMonitorViewModel : ViewModel() {
         }
         val ctx = appContext ?: return
         viewModelScope.launch {
-            val supervisor = withContext(Dispatchers.IO) {
-                try {
-                    NeuralPitchSupervisor(ctx)
-                } catch (e: Exception) {
-                    Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
-                    null
+            var supervisor: NeuralPitchSupervisor? = null
+            var registered = false
+            try {
+                supervisor = withContext(Dispatchers.IO) {
+                    try {
+                        NeuralPitchSupervisor(ctx)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
+                        null
+                    }
                 }
-            }
-            synchronized(supervisorLock) {
-                if (isCleared) {
-                    supervisor?.close()
-                    return@launch
+                synchronized(supervisorLock) {
+                    if (!isCleared) {
+                        neuralSupervisor = supervisor
+                        registered = true
+                    }
                 }
-                neuralSupervisor = supervisor
+            } finally {
+                if (!registered) supervisor?.close()
             }
         }
     }

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -737,33 +737,38 @@ class TunerViewModel : ViewModel() {
             status = NeuralRuntimeStatus.LOADING,
         )
         viewModelScope.launch {
-            val supervisor = withContext(Dispatchers.IO) {
-                try {
-                    NeuralPitchSupervisor(ctx)
-                } catch (e: Exception) {
-                    Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
-                    null
+            var supervisor: NeuralPitchSupervisor? = null
+            var registered = false
+            try {
+                supervisor = withContext(Dispatchers.IO) {
+                    try {
+                        NeuralPitchSupervisor(ctx)
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
+                        null
+                    }
                 }
-            }
-            synchronized(supervisorLock) {
-                if (isCleared) {
-                    supervisor?.close()
-                    return@launch
+                synchronized(supervisorLock) {
+                    if (!isCleared) {
+                        neuralSupervisor = supervisor
+                        registered = true
+                    }
                 }
-                neuralSupervisor = supervisor
-            }
-            if (supervisor != null) {
-                updateNeuralStatus(
-                    available = true,
-                    active = true,
-                    status = NeuralRuntimeStatus.ACTIVE,
-                )
-            } else {
-                updateNeuralStatus(
-                    available = false,
-                    active = false,
-                    status = NeuralRuntimeStatus.FALLBACK,
-                )
+                if (registered && supervisor != null) {
+                    updateNeuralStatus(
+                        available = true,
+                        active = true,
+                        status = NeuralRuntimeStatus.ACTIVE,
+                    )
+                } else if (registered) {
+                    updateNeuralStatus(
+                        available = false,
+                        active = false,
+                        status = NeuralRuntimeStatus.FALLBACK,
+                    )
+                }
+            } finally {
+                if (!registered) supervisor?.close()
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #237.

- Wraps the `initializeNeuralSupervisor()` coroutine in `try/finally` in both `TunerViewModel` and `PitchMonitorViewModel` so the native `OrtSession` is closed if `viewModelScope` is cancelled during async model loading
- Uses a `registered` flag to track whether the supervisor was successfully assigned to the ViewModel field; the `finally` block closes it if not

## Test plan

- [ ] Android builds without errors (`./gradlew assembleDebug`)
- [ ] Open Tuner, immediately navigate back (within ~200ms); repeat 20+ times; monitor native memory via Android Studio Profiler to confirm no session accumulation
- [ ] Same test with Pitch Monitor screen
- [ ] Normal Tuner/Pitch Monitor usage still works (model loads, neural status shows ACTIVE)

Made with [Cursor](https://cursor.com)