### PR TITLE
Fix: merge learning progress on backup restore instead of overwriting

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/LearningProgressRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/LearningProgressRepository.kt
@@ -331,20 +331,39 @@ class LearningProgressRepository(context: Context) {
     }
 
     /**
-     * Imports learning progress from a map of key-value pairs.
-     * Numeric values (Int) are detected and stored as integers;
-     * "true"/"false" strings are stored as booleans; all else as strings.
+     * Imports learning progress from a backup, merging with existing data
+     * so that restoring never loses progress:
+     * - Booleans (lesson flags): OR — once completed, stays completed.
+     * - Integers (counters, streaks, bests): max(existing, imported).
+     * - `last_activity_date`: keep the more recent date.
+     * - Other strings: keep existing if present, else use imported.
      */
     fun importAll(entries: Map<String, String>) {
         val editor = prefs.edit()
         for ((key, value) in entries) {
             when {
-                value == "true" || value == "false" ->
-                    editor.putBoolean(key, value.toBoolean())
-                value.toIntOrNull() != null ->
-                    editor.putInt(key, value.toInt())
-                else ->
-                    editor.putString(key, value)
+                value == "true" || value == "false" -> {
+                    val incoming = value.toBoolean()
+                    if (incoming) {
+                        editor.putBoolean(key, true)
+                    }
+                }
+                value.toIntOrNull() != null -> {
+                    val incoming = value.toInt()
+                    val existing = prefs.getInt(key, 0)
+                    editor.putInt(key, maxOf(existing, incoming))
+                }
+                key == KEY_LAST_ACTIVITY -> {
+                    val existing = prefs.getString(key, null)
+                    if (existing == null || value > existing) {
+                        editor.putString(key, value)
+                    }
+                }
+                else -> {
+                    if (!prefs.contains(key)) {
+                        editor.putString(key, value)
+                    }
+                }
             }
         }
         editor.apply()

--- a/app/src/test/java/com/baijum/ukufretboard/data/LearningProgressImportTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/LearningProgressImportTest.kt
@@ -1,0 +1,101 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LearningProgressImportTest {
+
+    private lateinit var repo: LearningProgressRepository
+
+    @Before
+    fun setUp() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        repo = LearningProgressRepository(context)
+    }
+
+    @Test
+    fun intMaxMergePreservesHigherLocal() {
+        repo.importAll(mapOf("quiz_total_ALL" to "800"))
+        repo.importAll(mapOf("quiz_total_ALL" to "90"))
+        val exported = repo.exportAll()
+        assertEquals("800", exported["quiz_total_ALL"])
+    }
+
+    @Test
+    fun intMaxMergeAcceptsHigherImport() {
+        repo.importAll(mapOf("quiz_total_ALL" to "800"))
+        repo.importAll(mapOf("quiz_total_ALL" to "900"))
+        val exported = repo.exportAll()
+        assertEquals("900", exported["quiz_total_ALL"])
+    }
+
+    @Test
+    fun booleanOrNeverRevertsTrue() {
+        repo.importAll(mapOf("lesson_done_chords" to "true"))
+        repo.importAll(mapOf("lesson_done_chords" to "false"))
+        val exported = repo.exportAll()
+        assertEquals("true", exported["lesson_done_chords"])
+    }
+
+    @Test
+    fun booleanTrueImported() {
+        repo.importAll(mapOf("lesson_done_scales" to "true"))
+        val exported = repo.exportAll()
+        assertEquals("true", exported["lesson_done_scales"])
+    }
+
+    @Test
+    fun dateKeepsNewerLocal() {
+        repo.importAll(mapOf("last_activity_date" to "2026-06-10"))
+        repo.importAll(mapOf("last_activity_date" to "2025-01-01"))
+        val exported = repo.exportAll()
+        assertEquals("2026-06-10", exported["last_activity_date"])
+    }
+
+    @Test
+    fun dateUpdatesWhenImportIsNewer() {
+        repo.importAll(mapOf("last_activity_date" to "2026-06-10"))
+        repo.importAll(mapOf("last_activity_date" to "2026-07-01"))
+        val exported = repo.exportAll()
+        assertEquals("2026-07-01", exported["last_activity_date"])
+    }
+
+    @Test
+    fun stringNotOverwritten() {
+        repo.importAll(mapOf("custom_key" to "original"))
+        repo.importAll(mapOf("custom_key" to "overwrite"))
+        val exported = repo.exportAll()
+        assertEquals("original", exported["custom_key"])
+    }
+
+    @Test
+    fun bestStreakMaxMerged() {
+        repo.importAll(mapOf("best_streak_days" to "45"))
+        repo.importAll(mapOf("best_streak_days" to "10"))
+        val exported = repo.exportAll()
+        assertEquals("45", exported["best_streak_days"])
+    }
+
+    @Test
+    fun streakDaysMaxMerged() {
+        repo.importAll(mapOf("streak_days" to "12"))
+        repo.importAll(mapOf("streak_days" to "5"))
+        val exported = repo.exportAll()
+        assertEquals("12", exported["streak_days"])
+    }
+
+    @Test
+    fun booleanFalseNotWrittenToEmptyPrefs() {
+        repo.importAll(mapOf("lesson_done_new" to "false"))
+        val exported = repo.exportAll()
+        assertFalse(exported.containsKey("lesson_done_new"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #238.

- Rewrites `LearningProgressRepository.importAll()` to merge per key type instead of unconditionally overwriting, so restoring an older backup never regresses lifetime stats or destroys streaks
- Booleans (lesson flags): OR -- once completed, stays completed
- Integers (counters, streaks, bests): `max(existing, imported)` -- same pattern as `PracticeTimerRepository`
- `last_activity_date`: keep the more recent date
- Other strings: keep existing if present, else use imported
- Matches the iOS merge logic already in `LearnViewModel.importProgress`
- Adds 10 Robolectric unit tests covering all merge rules

## Test plan

- [x] Unit tests pass (`./gradlew testDebugUnitTest --tests LearningProgressImportTest`)
- [ ] Android builds without errors (`./gradlew assembleDebug`)
- [ ] Restore a backup older than local data -- verify quiz totals, best streaks, and daily streak are not regressed
- [ ] Restore a backup with higher stats than local -- verify stats are updated to the higher values
- [ ] Restore a backup with `lesson_done_*=false` for a completed lesson -- verify lesson stays completed

Made with [Cursor](https://cursor.com)