### PR TITLE
Fix: preserve negative resampler carry across buffer boundaries on iOS

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -18,6 +18,8 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
     private var _isRunning = false  // only accessed on sessionQueue
     private var hardwareSampleRate: Double = sampleRate
     private var resampleAccumulator: Double = 0.0
+    private var lastResampleSample: Float = 0
+    private var hasLastResampleSample = false
 
     /// Ring buffer holding the most recent `frameSize` samples.
     private var ringBuffer: [Float]
@@ -129,6 +131,8 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             writePos = 0
             filled = 0
             resampleAccumulator = 0.0
+            lastResampleSample = 0
+            hasLastResampleSample = false
             ringBuffer = [Float](repeating: 0, count: Self.frameSize)
             analysisBuf = [Float](repeating: 0, count: Self.frameSize)
             bufferLock.unlock()
@@ -155,18 +159,25 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
         if needsResample {
             let step = hardwareSampleRate / Self.sampleRate
             var srcPos = resampleAccumulator
-            while Int(srcPos) + 1 < count {
-                let idx = Int(srcPos)
-                let frac = Float(srcPos - Double(idx))
-                let s0 = samples[idx]
-                let s1 = samples[idx + 1]
-                ringBuffer[writePos] = s0 + frac * (s1 - s0)
+            while srcPos < Double(count - 1) {
+                let interpolated: Float
+                if srcPos < 0 {
+                    guard hasLastResampleSample else { srcPos = 0; continue }
+                    let frac = Float(srcPos + 1)
+                    interpolated = lastResampleSample + frac * (samples[0] - lastResampleSample)
+                } else {
+                    let idx = Int(srcPos)
+                    let frac = Float(srcPos - Double(idx))
+                    interpolated = samples[idx] + frac * (samples[idx + 1] - samples[idx])
+                }
+                ringBuffer[writePos] = interpolated
                 writePos = (writePos + 1) % Self.frameSize
                 filled += 1
                 srcPos += step
             }
             resampleAccumulator = srcPos - Double(count)
-            if resampleAccumulator < 0 { resampleAccumulator = 0 }
+            lastResampleSample = samples[count - 1]
+            hasLastResampleSample = true
         } else {
             for i in 0..<count {
                 ringBuffer[writePos] = samples[i]


### PR DESCRIPTION
## Summary

Closes #239.

- Fixes the iOS `AudioCaptureEngine` resampler that clamped the fractional accumulator to zero at buffer boundaries, dropping a boundary sample ~92% of the time on 48 kHz hardware and introducing a systematic sharp bias (~0.2-0.7 cents)
- Carries the previous buffer's last sample across calls via new `lastResampleSample`/`hasLastResampleSample` fields, enabling cross-boundary interpolation when the accumulator is negative
- Removes the clamp so the sampling grid stays continuous across buffers
- Resets the new fields in `tearDown()` alongside existing buffer state

## Test plan

- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] On a 48 kHz device: play a reference A4 = 440 Hz tone, verify the tuner reads 0 cents (no sharp bias)
- [ ] Tuner still works correctly on 44.1 kHz hardware (non-resample path is untouched)
- [ ] Start/stop capture multiple times -- verify no state leakage between sessions

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio resampling across buffer boundaries to handle edge cases more reliably, ensuring consistent audio processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->