### PR TITLE
Fix: transpose slash-chord bass notes in ChordSheetTranspose

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetTranspose.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetTranspose.kt
@@ -7,16 +7,21 @@ import com.baijum.ukufretboard.data.Notes
  * Transposition utilities for chord sheets.
  *
  * Parses inline `[ChordName]` markers from chord sheet content,
- * transposes each chord root by the given number of semitones,
- * and preserves the chord quality suffix.
+ * transposes each chord root and slash-chord bass note by the given
+ * number of semitones, and preserves the chord quality suffix.
  */
 object ChordSheetTranspose {
 
     /** Regex matching `[ChordName]` markers, capturing root and quality separately. */
     private val CHORD_MARKER = Regex("""\[(?!(?:${ChordParser.SECTION_NAMES})\b)([A-G][#b]?)([^]]*)]""")
 
+    /** Bass note at the start of the post-slash segment, e.g. "/G" or "m7/G". */
+    private val BASS_NOTE = Regex("""^([A-G][#b]?)""")
+
     /**
      * Transposes all `[Chord]` markers in the given content by [semitones].
+     *
+     * Root and slash-chord bass notes are transposed; quality suffixes are preserved.
      *
      * @param content The raw chord sheet content with `[ChordName]` markers.
      * @param semitones Number of semitones to transpose (positive = up, negative = down).
@@ -27,20 +32,36 @@ object ChordSheetTranspose {
 
         return CHORD_MARKER.replace(content) { match ->
             val rootStr = match.groupValues[1]
-            val qualitySuffix = match.groupValues[2]
+            var qualitySuffix = match.groupValues[2]
 
-            // Parse the root note to a pitch class
-            val rootPc = Notes.NOTE_NAMES_SHARP.indexOf(rootStr).takeIf { it >= 0 }
-                ?: Notes.NOTE_NAMES_FLAT.indexOf(rootStr).takeIf { it >= 0 }
-                ?: return@replace match.value // unknown root, leave as-is
+            val rootPc = parseNoteToPitchClass(rootStr)
+                ?: return@replace match.value
 
-            // Transpose
-            val newPc = Transpose.transposePitchClass(rootPc, semitones)
-            val newRoot = Notes.pitchClassToName(newPc)
+            val newRoot = Notes.pitchClassToName(
+                Transpose.transposePitchClass(rootPc, semitones),
+            )
+
+            val slashIdx = qualitySuffix.indexOf('/')
+            if (slashIdx >= 0) {
+                val afterSlash = qualitySuffix.substring(slashIdx + 1)
+                val bassMatch = BASS_NOTE.matchAt(afterSlash, 0)
+                val bassPc = bassMatch?.let { parseNoteToPitchClass(it.groupValues[1]) }
+                if (bassPc != null) {
+                    val newBass = Notes.pitchClassToName(
+                        Transpose.transposePitchClass(bassPc, semitones),
+                    )
+                    val tail = afterSlash.substring(bassMatch.range.last + 1)
+                    qualitySuffix = qualitySuffix.substring(0, slashIdx + 1) + newBass + tail
+                }
+            }
 
             "[$newRoot$qualitySuffix]"
         }
     }
+
+    private fun parseNoteToPitchClass(note: String): Int? =
+        Notes.NOTE_NAMES_SHARP.indexOf(note).takeIf { it >= 0 }
+            ?: Notes.NOTE_NAMES_FLAT.indexOf(note).takeIf { it >= 0 }
 
     /**
      * Returns the semitone description for display.

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
@@ -20,6 +20,7 @@ class ChordSheetTransposePropertyTest {
         "No chords in this line",
         "[C] simple [C] repeated",
         "[Ab]Flat [Eb]keys [Bb]only",
+        "[D/F#]Slash [C/G]chords [Am7/G]here",
     )
 
     @Test
@@ -122,6 +123,49 @@ class ChordSheetTransposePropertyTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun transposeSimpleSlashChord() {
+        assertEquals("[D/A]", ChordSheetTranspose.transpose("[C/G]", 2))
+    }
+
+    @Test
+    fun transposeQualityAndSlashChord() {
+        assertEquals("[Cm7/Bb]", ChordSheetTranspose.transpose("[Am7/G]", 3))
+    }
+
+    @Test
+    fun transposeSharpBassSlashChord() {
+        assertEquals("[E/Ab]", ChordSheetTranspose.transpose("[D/F#]", 2))
+    }
+
+    @Test
+    fun transposeFlatBassSlashChord() {
+        assertEquals("[A/E]", ChordSheetTranspose.transpose("[Ab/Eb]", 1))
+    }
+
+    @Test
+    fun transposeNonSlashChordUnchanged() {
+        assertEquals("[Dmaj7]", ChordSheetTranspose.transpose("[Cmaj7]", 2))
+    }
+
+    @Test
+    fun slashChordRoundTrip() {
+        val content = "[C/G]"
+        val transposed = ChordSheetTranspose.transpose(content, 5)
+        assertEquals("[F/C]", transposed)
+        assertEquals(content, ChordSheetTranspose.transpose(transposed, -5))
+    }
+
+    @Test
+    fun sectionLabelUntouchedByTranspose() {
+        assertEquals("[Chorus]", ChordSheetTranspose.transpose("[Chorus]", 2))
+    }
+
+    @Test
+    fun unknownBassPreservedOnTranspose() {
+        assertEquals("[D/X]", ChordSheetTranspose.transpose("[C/X]", 2))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #244.

- Fixes `ChordSheetTranspose.transpose()` to transpose slash-chord bass notes alongside the root, so `[C/G]` +2 correctly becomes `[D/A]` instead of `[D/G]`
- Shared KMP fix automatically applies to Android and iOS — Songbook "save in this key" and Songwriter mode no longer persist corrupted slash chords
- Adds 8 unit tests covering simple slash, quality+slash, sharp/flat bass, round-trip, section labels, and unknown bass preservation

## Test plan

- [x] Shared module unit tests pass (`./gradlew :shared:jvmTest --tests "com.baijum.ukufretboard.domain.ChordSheetTranspose*"`)
- [ ] Android builds without errors (`./gradlew assembleDebug`)
- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Transpose a song with `[D/F#]` +2 in Songbook — verify display shows `[E/Ab]` (standard spelling)
- [ ] "Save in this key" persists the transposed slash chords correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chord transposition to properly handle slash chords with bass notes (e.g., D/F#, C/G), transposing both the chord root and bass note while preserving chord quality.

* **Tests**
  * Added comprehensive tests for slash-chord transposition scenarios, including sharp/flat handling, round-trip transposition, and preservation of non-slash chords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->