### PR TITLE
Fix: use canonical pitch-class-to-sample mapping in scale practice and interval trainer

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/ScalePracticeViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/ScalePracticeViewModel.swift
@@ -65,12 +65,6 @@ final class ScalePracticeViewModel: ObservableObject {
         loadSettings()
     }
 
-    private static let sampleNames = [
-        "uke_a", "uke_asharp", "uke_b", "uke_c", "uke_csharp",
-        "uke_d", "uke_dsharp", "uke_e", "uke_f", "uke_fsharp",
-        "uke_g", "uke_gsharp"
-    ]
-
     var rootNoteNames: [String] {
         (0..<Int32(12)).map { Notes.shared.pitchClassToName(pitchClass: $0) }
     }
@@ -166,8 +160,7 @@ final class ScalePracticeViewModel: ObservableObject {
                 if index < notes.count {
                     self.currentNoteIndex = index
                     let pc = notes[index]
-                    let sampleIndex = (pc + 9) % 12
-                    self.tonePlayer.play(Self.sampleNames[sampleIndex])
+                    self.tonePlayer.playNote(pitchClass: Int32(pc))
                     index += 1
                 } else if self.loopPlayback {
                     index = 0

--- a/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
+++ b/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
@@ -15,11 +15,6 @@ struct IntervalTrainerView: View {
     @State private var isAudioMode = true
 
     private let tonePlayer = TonePlayer()
-    private static let sampleNames = [
-        "uke_a", "uke_asharp", "uke_b", "uke_c", "uke_csharp",
-        "uke_d", "uke_dsharp", "uke_e", "uke_f", "uke_fsharp",
-        "uke_g", "uke_gsharp"
-    ]
 
     var body: some View {
         ScrollView {
@@ -193,11 +188,9 @@ struct IntervalTrainerView: View {
                 strumDelayMs: 0
             )
         } else {
-            let idx1 = (Int(q.note1PitchClass) + 9) % 12
-            tonePlayer.play(Self.sampleNames[idx1])
+            tonePlayer.playNote(pitchClass: q.note1PitchClass)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                let idx2 = (Int(q.note2PitchClass) + 9) % 12
-                self.tonePlayer.play(Self.sampleNames[idx2])
+                self.tonePlayer.playNote(pitchClass: q.note2PitchClass)
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #245.

- Removes duplicated A-first `sampleNames` arrays from `ScalePracticeViewModel` and `IntervalTrainerView` that used broken `(pc + 9) % 12` index math, shifting every note by a tritone (+6 semitones)
- Replaces with calls to `TonePlayer.playNote(pitchClass:)` which uses the canonical `pitchClassToSample` mapping (C=0 indexed correctly)
- The harmonic interval path already used `playChord(pitchClasses:)` and was unaffected

## Test plan

- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Scale Practice: select C Major, press play -- verify audio plays C, D, E, F, G, A, B
- [ ] Interval Trainer (ascending/descending): verify sounded notes match displayed note names
- [ ] Interval Trainer (harmonic): verify chord playback still works correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified audio playback architecture for scale practice and interval training exercises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->