### PR TITLE
Fix: honor interval direction and octave in iOS playback

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
+++ b/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
@@ -7,6 +7,7 @@ import AVFoundation
 final class TonePlayer {
     private var audioEngine: AVAudioEngine?
     private var playerNodes: [AVAudioPlayerNode] = []
+    private var varispeedNodes: [AVAudioUnitVarispeed] = []
     private var cachedBuffers: [String: AVAudioPCMBuffer] = [:]
     private let nodePoolSize = 8
     private var nextNodeIndex = 0
@@ -37,9 +38,13 @@ final class TonePlayer {
 
         for _ in 0..<nodePoolSize {
             let player = AVAudioPlayerNode()
+            let varispeed = AVAudioUnitVarispeed()
             engine.attach(player)
-            engine.connect(player, to: engine.mainMixerNode, format: sampleFormat)
+            engine.attach(varispeed)
+            engine.connect(player, to: varispeed, format: sampleFormat)
+            engine.connect(varispeed, to: engine.mainMixerNode, format: sampleFormat)
             playerNodes.append(player)
+            varispeedNodes.append(varispeed)
         }
 
         do {
@@ -57,6 +62,8 @@ final class TonePlayer {
         return player
     }
 
+    private static let baseOctave: Int32 = 4
+
     /// Plays the named WAV sample from the app bundle on a single player node.
     func play(_ sampleName: String) {
         guard let player = nextPlayer(), let engine = audioEngine else { return }
@@ -64,6 +71,9 @@ final class TonePlayer {
         if !engine.isRunning {
             try? engine.start()
         }
+
+        let idx = (nextNodeIndex - 1) % nodePoolSize
+        varispeedNodes[idx].rate = 1.0
 
         if let buffer = loadBuffer(named: sampleName) {
             player.stop()
@@ -74,9 +84,29 @@ final class TonePlayer {
 
     /// Plays a single note by pitch class using the corresponding WAV sample.
     func playNote(pitchClass: Int32) {
-        if let sample = Self.pitchClassToSample[pitchClass] {
-            play(sample)
-        }
+        playNote(pitchClass: pitchClass, octave: Self.baseOctave)
+    }
+
+    /// Plays a single note by pitch class and octave.
+    ///
+    /// Samples are recorded at octave 4. Other octaves are rendered via
+    /// rate-based pitch shifting (2x rate = +1 octave).
+    func playNote(pitchClass: Int32, octave: Int32) {
+        guard let sample = Self.pitchClassToSample[pitchClass],
+              let buffer = loadBuffer(named: sample),
+              let engine = audioEngine else { return }
+
+        if !engine.isRunning { try? engine.start() }
+
+        let idx = nextNodeIndex % nodePoolSize
+        let player = playerNodes[idx]
+        let varispeed = varispeedNodes[idx]
+        nextNodeIndex += 1
+
+        varispeed.rate = Float(pow(2.0, Double(octave - Self.baseOctave)))
+        player.stop()
+        player.scheduleBuffer(buffer, at: nil, options: .interrupts)
+        player.play()
     }
 
     /// Plays a chord as a strum: notes are triggered with a configurable delay

--- a/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
+++ b/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
@@ -46,7 +46,7 @@ struct IntervalTrainerView: View {
                         Picker("Direction", selection: $direction) {
                             Text("Up").tag(IntervalTrainer.IntervalDirection.ascending)
                             Text("Down").tag(IntervalTrainer.IntervalDirection.descending)
-                            Text("Both").tag(IntervalTrainer.IntervalDirection.harmonic)
+                            Text("Harmonic").tag(IntervalTrainer.IntervalDirection.harmonic)
                         }
                         .pickerStyle(.segmented)
                     }
@@ -182,16 +182,22 @@ struct IntervalTrainerView: View {
     }
 
     private func playInterval(_ q: IntervalTrainer.IntervalQuestion) {
-        if direction == .harmonic {
-            tonePlayer.playChord(
-                pitchClasses: [q.note1PitchClass, q.note2PitchClass],
-                strumDelayMs: 0
-            )
-        } else {
-            tonePlayer.playNote(pitchClass: q.note1PitchClass)
+        switch q.direction {
+        case .ascending:
+            tonePlayer.playNote(pitchClass: q.note1PitchClass, octave: q.note1Octave)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                self.tonePlayer.playNote(pitchClass: q.note2PitchClass)
+                self.tonePlayer.playNote(pitchClass: q.note2PitchClass, octave: q.note2Octave)
             }
+        case .descending:
+            tonePlayer.playNote(pitchClass: q.note2PitchClass, octave: q.note2Octave)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                self.tonePlayer.playNote(pitchClass: q.note1PitchClass, octave: q.note1Octave)
+            }
+        case .harmonic:
+            tonePlayer.playNote(pitchClass: q.note1PitchClass, octave: q.note1Octave)
+            tonePlayer.playNote(pitchClass: q.note2PitchClass, octave: q.note2Octave)
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #246.

- Adds octave support to `TonePlayer` via `AVAudioUnitVarispeed` nodes wired between each player node and the mixer (rate 2.0 = +1 octave), enabling octave-correct playback from the single-octave sample bank
- Rewrites `IntervalTrainerView.playInterval()` to use `q.direction` from the question and pass octave fields to `playNote(pitchClass:octave:)`, matching the Android reference implementation
- Descending mode now plays note2 (higher) first, then note1 (lower)
- Harmonic mode uses individual octave-aware calls for per-note rate control
- Renames "Both" to "Harmonic" in the direction picker to match Android
- Existing `playNote(pitchClass:)` callers (scale practice, melody, etc.) are unaffected -- delegates to base octave 4 with rate 1.0

## Test plan

- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Interval Trainer ascending: A + P5 plays A4 then E5 (ascending), not A4 then E4
- [ ] Interval Trainer descending: plays higher note first, then lower
- [ ] Interval Trainer harmonic: both notes simultaneous at correct octaves
- [ ] Scale Practice / Melody playback still sounds correct (rate 1.0 path)
- [ ] Metronome clicks unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added octave selection support for note playback, enabling the same note to be played at different pitch levels throughout the app
  * Enhanced interval training with improved timing for ascending, descending, and harmonic interval playback patterns

* **UI Changes**
  * Renamed the interval direction option from "Both" to "Harmonic" for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->