### PR TITLE
Fix: use shared ChordNameParser for chord-name parsing in iOS

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/ChordTransitionsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/ChordTransitionsViewModel.swift
@@ -102,14 +102,9 @@ final class ChordTransitionsViewModel: ObservableObject {
     }
 
     func playChord(name: String) {
-        let rootName = String(name.prefix(while: { $0.isLetter || $0 == "#" || $0 == "b" }))
-        let quality = String(name.dropFirst(rootName.count))
-        let noteMap: [String: Int32] = [
-            "C": 0, "C#": 1, "Db": 1, "D": 2, "D#": 3, "Eb": 3,
-            "E": 4, "F": 5, "F#": 6, "Gb": 6, "G": 7, "G#": 8,
-            "Ab": 8, "A": 9, "A#": 10, "Bb": 10, "B": 11
-        ]
-        let rootPc = noteMap[rootName] ?? 0
+        guard let parsed = ChordNameParser.shared.parse(input: name) else { return }
+        let rootPc = parsed.rootPitchClass
+        let formula = parsed.formula
 
         let tuning = (0..<4).map { i -> shared.UkuleleString in
             let t = UkuleleTuning.highG
@@ -120,10 +115,8 @@ final class ChordTransitionsViewModel: ObservableObject {
             )
         }
 
-        let formulas = ChordFormulas.shared.ALL as! [ChordFormula]
-        let formula = formulas.first { $0.symbol == quality } ?? formulas.first { $0.symbol == "" }!
         let voicings = VoicingGenerator.shared.generate(
-            rootPitchClass: rootPc,
+            rootPitchClass: Int32(rootPc),
             formula: formula,
             tuning: tuning,
             allowMutedStrings: false
@@ -142,14 +135,9 @@ final class ChordTransitionsViewModel: ObservableObject {
     }
 
     func voicingForChord(name: String) -> ChordVoicing? {
-        let rootName = String(name.prefix(while: { $0.isLetter || $0 == "#" || $0 == "b" }))
-        let quality = String(name.dropFirst(rootName.count))
-        let noteMap: [String: Int32] = [
-            "C": 0, "C#": 1, "Db": 1, "D": 2, "D#": 3, "Eb": 3,
-            "E": 4, "F": 5, "F#": 6, "Gb": 6, "G": 7, "G#": 8,
-            "Ab": 8, "A": 9, "A#": 10, "Bb": 10, "B": 11
-        ]
-        let rootPc = noteMap[rootName] ?? 0
+        guard let parsed = ChordNameParser.shared.parse(input: name) else { return nil }
+        let rootPc = parsed.rootPitchClass
+        let formula = parsed.formula
 
         let tuning = (0..<4).map { i -> shared.UkuleleString in
             let t = UkuleleTuning.highG
@@ -160,10 +148,8 @@ final class ChordTransitionsViewModel: ObservableObject {
             )
         }
 
-        let formulas = ChordFormulas.shared.ALL as! [ChordFormula]
-        let formula = formulas.first { $0.symbol == quality } ?? formulas.first { $0.symbol == "" }!
         let voicings = VoicingGenerator.shared.generate(
-            rootPitchClass: rootPc,
+            rootPitchClass: Int32(rootPc),
             formula: formula,
             tuning: tuning,
             allowMutedStrings: false

--- a/iosApp/UkuleleCompanion/Views/ExplorerView.swift
+++ b/iosApp/UkuleleCompanion/Views/ExplorerView.swift
@@ -151,26 +151,19 @@ struct ExplorerView: View {
     }
 
     private func applySuggestedChord(_ name: String) {
-        let rootName = String(name.prefix(while: { $0.isLetter || $0 == "#" || $0 == "b" }))
-        let quality = String(name.dropFirst(rootName.count))
-        let noteMap: [String: Int32] = [
-            "C": 0, "C#": 1, "Db": 1, "D": 2, "D#": 3, "Eb": 3,
-            "E": 4, "F": 5, "F#": 6, "Gb": 6, "G": 7, "G#": 8,
-            "Ab": 8, "A": 9, "A#": 10, "Bb": 10, "B": 11
-        ]
-        let rootPc = noteMap[rootName] ?? 0
+        guard let parsed = ChordNameParser.shared.parse(input: name) else { return }
+        let rootPc = parsed.rootPitchClass
+        let formula = parsed.formula
 
-        let formulas = ChordFormulas.shared.ALL as! [ChordFormula]
-        let formula = formulas.first { $0.symbol == quality } ?? formulas.first { $0.symbol == "" }!
         let voicings = VoicingGenerator.shared.generate(
-            rootPitchClass: rootPc,
+            rootPitchClass: Int32(rootPc),
             formula: formula,
             tuning: fretboardVM.tuning,
             allowMutedStrings: false
         ) as! [ChordVoicing]
 
         if let voicing = voicings.first {
-            fretboardVM.applyVoicing(voicing, rootPitchClass: rootPc, formula: formula)
+            fretboardVM.applyVoicing(voicing, rootPitchClass: Int32(rootPc), formula: formula)
         }
     }
 

--- a/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
@@ -800,12 +800,9 @@ private struct ProgressionPlaybackBar: View {
     }
 
     private func playResolvedChord(_ resolved: String) {
-        let rootName = String(resolved.prefix(while: { $0.isLetter || $0 == "#" || $0 == "b" }))
-        let quality = String(resolved.dropFirst(rootName.count))
-        let noteMap = ["C": 0, "C#": 1, "Db": 1, "D": 2, "D#": 3, "Eb": 3,
-                       "E": 4, "F": 5, "F#": 6, "Gb": 6, "G": 7, "G#": 8,
-                       "Ab": 8, "A": 9, "A#": 10, "Bb": 10, "B": 11]
-        let rootPc = noteMap[rootName] ?? 0
+        guard let parsed = ChordNameParser.shared.parse(input: resolved) else { return }
+        let rootPc = parsed.rootPitchClass
+        let formula = parsed.formula
 
         let tuning = (0..<4).map { i -> shared.UkuleleString in
             let t = UkuleleTuning.highG
@@ -816,8 +813,6 @@ private struct ProgressionPlaybackBar: View {
             )
         }
 
-        let formulas = ChordFormulas.shared.ALL as! [ChordFormula]
-        let formula = formulas.first { $0.symbol == quality } ?? formulas.first { $0.symbol == "" }!
         let voicings = VoicingGenerator.shared.generate(
             rootPitchClass: Int32(rootPc),
             formula: formula,

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -1166,53 +1166,62 @@ struct SongViewerView: View {
 
     @ViewBuilder
     private func chordPopover(chord: String) -> some View {
-        let parsed = ChordNameParser.shared.parse(input: chord)
-        let rootPc = parsed?.rootPitchClass ?? 0
-        let formula = parsed?.formula
-            ?? (ChordFormulas.shared.ALL as! [ChordFormula]).first { $0.symbol == "" }!
+        if let parsed = ChordNameParser.shared.parse(input: chord) {
+            let rootPc = parsed.rootPitchClass
+            let formula = parsed.formula
 
-        let tuning = (0..<4).map { i -> shared.UkuleleString in
-            let t = UkuleleTuning.highG
-            return shared.UkuleleString(
-                name: t.stringNames[i] as! String,
-                openPitchClass: (t.pitchClasses[i] as! NSNumber).int32Value,
-                octave: (t.octaves[i] as! NSNumber).int32Value
-            )
-        }
+            let tuning = (0..<4).map { i -> shared.UkuleleString in
+                let t = UkuleleTuning.highG
+                return shared.UkuleleString(
+                    name: t.stringNames[i] as! String,
+                    openPitchClass: (t.pitchClasses[i] as! NSNumber).int32Value,
+                    octave: (t.octaves[i] as! NSNumber).int32Value
+                )
+            }
 
-        let voicings = VoicingGenerator.shared.generate(
-            rootPitchClass: Int32(rootPc),
-            formula: formula,
-            tuning: tuning,
-            allowMutedStrings: false
-        ) as! [ChordVoicing]
+            let voicings = VoicingGenerator.shared.generate(
+                rootPitchClass: Int32(rootPc),
+                formula: formula,
+                tuning: tuning,
+                allowMutedStrings: false
+            ) as! [ChordVoicing]
 
-        VStack(spacing: 8) {
-            Text(chord)
-                .font(.headline)
-            if let voicing = voicings.first {
-                ChordDiagramView(voicing: voicing, chordName: chord)
-                Button {
-                    let fretList = voicing.fretInts
-                    let pitchClasses = (0..<fretList.count).compactMap { i -> Int32? in
-                        let fret = fretList[i]
-                        guard fret >= 0 else { return nil }
-                        let openPc = (UkuleleTuning.highG.pitchClasses[i] as! NSNumber).int32Value
-                        return (openPc + Int32(fret)) % 12
+            VStack(spacing: 8) {
+                Text(chord)
+                    .font(.headline)
+                if let voicing = voicings.first {
+                    ChordDiagramView(voicing: voicing, chordName: chord)
+                    Button {
+                        let fretList = voicing.fretInts
+                        let pitchClasses = (0..<fretList.count).compactMap { i -> Int32? in
+                            let fret = fretList[i]
+                            guard fret >= 0 else { return nil }
+                            let openPc = (UkuleleTuning.highG.pitchClasses[i] as! NSNumber).int32Value
+                            return (openPc + Int32(fret)) % 12
+                        }
+                        tonePlayer.playChord(pitchClasses: pitchClasses, strumDelayMs: 40)
+                    } label: {
+                        Label("Play", systemImage: "play.fill")
+                            .font(.caption)
                     }
-                    tonePlayer.playChord(pitchClasses: pitchClasses, strumDelayMs: 40)
-                } label: {
-                    Label("Play", systemImage: "play.fill")
+                    .buttonStyle(.bordered)
+                } else {
+                    Text("No voicing found")
                         .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
-                .buttonStyle(.bordered)
-            } else {
-                Text("No voicing found")
+            }
+            .padding()
+        } else {
+            VStack(spacing: 8) {
+                Text(chord)
+                    .font(.headline)
+                Text("Chord not recognized")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .padding()
         }
-        .padding()
     }
 }
 

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -1166,14 +1166,14 @@ struct SongViewerView: View {
 
     @ViewBuilder
     private func chordPopover(chord: String) -> some View {
-        let rootName = String(chord.prefix(while: { $0.isLetter || $0 == "#" || $0 == "b" }))
-        let quality = String(chord.dropFirst(rootName.count))
-        let noteMap: [String: Int32] = [
-            "C": 0, "C#": 1, "Db": 1, "D": 2, "D#": 3, "Eb": 3,
-            "E": 4, "F": 5, "F#": 6, "Gb": 6, "G": 7, "G#": 8,
-            "Ab": 8, "A": 9, "A#": 10, "Bb": 10, "B": 11
-        ]
-        let rootPc = noteMap[rootName] ?? 0
+        let parsed = ChordNameParser.shared.parse(input: chord)
+        let rootPc = parsed?.rootPitchClass ?? 0
+        let formula: ChordFormula
+        if let p = parsed {
+            formula = p.formula
+        } else {
+            formula = (ChordFormulas.shared.ALL as! [ChordFormula]).first { $0.symbol == "" }!
+        }
 
         let tuning = (0..<4).map { i -> shared.UkuleleString in
             let t = UkuleleTuning.highG
@@ -1184,10 +1184,8 @@ struct SongViewerView: View {
             )
         }
 
-        let formulas = ChordFormulas.shared.ALL as! [ChordFormula]
-        let formula = formulas.first { $0.symbol == quality } ?? formulas.first { $0.symbol == "" }!
         let voicings = VoicingGenerator.shared.generate(
-            rootPitchClass: rootPc,
+            rootPitchClass: Int32(rootPc),
             formula: formula,
             tuning: tuning,
             allowMutedStrings: false

--- a/iosApp/UkuleleCompanion/Views/SongbookView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongbookView.swift
@@ -1168,12 +1168,8 @@ struct SongViewerView: View {
     private func chordPopover(chord: String) -> some View {
         let parsed = ChordNameParser.shared.parse(input: chord)
         let rootPc = parsed?.rootPitchClass ?? 0
-        let formula: ChordFormula
-        if let p = parsed {
-            formula = p.formula
-        } else {
-            formula = (ChordFormulas.shared.ALL as! [ChordFormula]).first { $0.symbol == "" }!
-        }
+        let formula = parsed?.formula
+            ?? (ChordFormulas.shared.ALL as! [ChordFormula]).first { $0.symbol == "" }!
 
         let tuning = (0..<4).map { i -> shared.UkuleleString in
             let t = UkuleleTuning.highG


### PR DESCRIPTION
## Summary

Closes #250.

- Replaces four copies of naive `prefix(while: isLetter)` chord-name parsing with `ChordNameParser.shared.parse(input:)` from the shared KMP module
- The naive parser swallowed quality suffixes (`m`, `dim`, `sus`, `maj`, etc.) into the root name, silently resolving every non-major chord as C major
- Affected sites: `SongbookView.chordPopover`, `ChordTransitionsViewModel.playChord`/`voicingForChord`, `ProgressionsView.playResolvedChord`, `ExplorerView.applySuggestedChord`
- Parsing failures now fail gracefully (early return / fallback) instead of silently substituting C major
- Net code reduction: 53 lines removed, 25 added

## Test plan

- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Songbook: tap "Am7" chord -- popover shows Am7 diagram, not C7
- [ ] Chord Transitions: set chord to "Am" -- diagram shows Am voicing (2-0-0-0), not C major (0-0-0-3)
- [ ] Progressions: play "Pop / Four Chords" (C-G-Am-F) -- Am plays correctly, not as C
- [ ] Explorer: tap suggested "Dm" -- fretboard shows Dm voicing
- [ ] Slash chords: "C/E" in songbook popover shows C with E bass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined internal chord processing logic across multiple features for improved code consistency and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->