### PR TITLE
Fix: stop progression playback when ProgressionsView disappears

### DIFF
--- a/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
@@ -50,6 +50,12 @@ struct ProgressionsView: View {
                 initialScaleType: scaleType
             )
         }
+        .onDisappear {
+            playbackState.isPlaying = false
+            playbackState.playingId = nil
+            playbackState.currentChordIndex = 0
+            tonePlayer.stop()
+        }
         .alert("Delete progression?", isPresented: showingDeleteAlert) {
             Button("Cancel", role: .cancel) {
                 deletingCustomId = nil
@@ -744,6 +750,10 @@ private struct ProgressionPlaybackBar: View {
                 .accessibilityLabel(state.loop ? "Loop on" : "Loop off")
             }
         }
+        .onDisappear {
+            timer?.invalidate()
+            timer = nil
+        }
     }
 
     private func togglePlayback() {
@@ -773,7 +783,14 @@ private struct ProgressionPlaybackBar: View {
     private func scheduleTimer() {
         timer?.invalidate()
         let t = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-            DispatchQueue.main.async { advanceChord() }
+            DispatchQueue.main.async {
+                guard state.isPlaying else {
+                    timer?.invalidate()
+                    timer = nil
+                    return
+                }
+                advanceChord()
+            }
         }
         timer = t
     }


### PR DESCRIPTION
## Summary

Closes #251.

- Adds `.onDisappear` to `ProgressionsView` to reset playback state and stop the `TonePlayer` when navigating away
- Adds `.onDisappear` to `ProgressionPlaybackBar` to invalidate its local `@State timer`
- Adds a `state.isPlaying` guard in the `scheduleTimer()` closure as defense-in-depth -- a stale timer self-terminates on the first tick
- Matches the existing cleanup pattern in `ProgressionPracticeView` (`.onDisappear { stopPlayback() }`)

## Test plan

- [ ] iOS builds without errors (`xcodebuild build`)
- [ ] Start progression playback with Loop on, navigate back -- audio stops immediately
- [ ] Re-enter Progressions -- no stale playback, UI shows stopped state
- [ ] Start playback without Loop, navigate back mid-sequence -- remaining chords do not sound
- [ ] Normal playback with Loop on/off still works correctly when staying on the screen

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Playback now properly stops when closing the progression editing screen, preventing audio from continuing unexpectedly
* Fixed issue where background timers could continue running and firing after navigating away from the progression view
* Improved playback state consistency and reliability when dismissing edit dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->