### PR TITLE
Fix: use ChordNameParser for chord-root parsing in Circle of Fifths and Chord Substitutions

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordSubstitutionsView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordSubstitutionsView.kt
@@ -1,6 +1,7 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import com.baijum.ukufretboard.domain.ChordNameParser
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -140,16 +141,11 @@ fun ChordSubstitutionsView(
  * Handles names like "C", "Am", "G7", "Db7", "Fm", "Bdim".
  */
 private fun transposeChordName(name: String, targetKey: Int): String {
-    if (name == "\u2014" || name.isBlank()) return name // em-dash or empty
-    // Extract root note (letter + optional # or b)
-    val root = name.takeWhile { it.isLetter() || it == '#' || it == 'b' }
-    val quality = name.removePrefix(root)
-    val rootPc = Notes.NOTE_NAMES_SHARP.indexOf(root).takeIf { it >= 0 }
-        ?: Notes.NOTE_NAMES_FLAT.indexOf(root).takeIf { it >= 0 }
-        ?: return name // can't parse
-    val transposedPc = (rootPc + targetKey) % 12
+    if (name == "\u2014" || name.isBlank()) return name
+    val parsed = ChordNameParser.parse(name) ?: return name
+    val transposedPc = (parsed.rootPitchClass + targetKey) % 12
     val transposedName = Notes.pitchClassToName(transposedPc)
-    return "$transposedName$quality"
+    return "$transposedName${parsed.formula.symbol}"
 }
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/ui/CircleOfFifthsView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/CircleOfFifthsView.kt
@@ -1,6 +1,7 @@
 package com.baijum.ukufretboard.ui
 
 import androidx.compose.foundation.Canvas
+import com.baijum.ukufretboard.domain.ChordNameParser
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -417,12 +418,8 @@ private fun MajorKeyDetail(
                     SuggestionChip(
                         onClick = {
                             if (onChordTapped != null) {
-                                val root = chordName.takeWhile { it.isLetter() || it == '#' || it == 'b' }
-                                val quality = chordName.removePrefix(root)
-                                val rootPc = Notes.NOTE_NAMES_SHARP.indexOf(root).takeIf { it >= 0 }
-                                    ?: Notes.NOTE_NAMES_FLAT.indexOf(root).takeIf { it >= 0 }
-                                    ?: return@SuggestionChip
-                                onChordTapped(rootPc, quality)
+                                val parsed = ChordNameParser.parse(chordName) ?: return@SuggestionChip
+                                onChordTapped(parsed.rootPitchClass, parsed.formula.symbol)
                             }
                         },
                         label = {
@@ -538,12 +535,8 @@ private fun MinorKeyDetail(
                     SuggestionChip(
                         onClick = {
                             if (onChordTapped != null) {
-                                val root = chordName.takeWhile { it.isLetter() || it == '#' || it == 'b' }
-                                val quality = chordName.removePrefix(root)
-                                val rootPc = Notes.NOTE_NAMES_SHARP.indexOf(root).takeIf { it >= 0 }
-                                    ?: Notes.NOTE_NAMES_FLAT.indexOf(root).takeIf { it >= 0 }
-                                    ?: return@SuggestionChip
-                                onChordTapped(rootPc, quality)
+                                val parsed = ChordNameParser.parse(chordName) ?: return@SuggestionChip
+                                onChordTapped(parsed.rootPitchClass, parsed.formula.symbol)
                             }
                         },
                         label = {


### PR DESCRIPTION
## Summary

Closes #252.

- Replaces three `takeWhile { isLetter() }` chord-name parsing sites with `ChordNameParser.parse()` in `CircleOfFifthsView.kt` and `ChordSubstitutionsView.kt`
- The naive parser swallowed quality suffixes (`m`, `dim`, `maj7`, etc.) into the root name, making minor/dim chord chips dead on Circle of Fifths and leaving chords untransposed in Chord Substitutions
- Matches the existing pattern in `SongbookTab.kt` which already uses `ChordNameParser.parse`
- Android counterpart of iOS fix #253

## Test plan

- [x] Android builds without errors (`./gradlew assembleDebug`)
- [ ] Circle of Fifths: tap C key, tap "Dm" chip -- loads Dm on fretboard
- [ ] Circle of Fifths: tap A minor key, tap "Bdim" chip -- loads Bdim
- [ ] Chord Substitutions: set key to D, verify "Am" row shows "Bm" (not "Am")
- [ ] Major chord chips (C, F, G) still work correctly

Made with [Cursor](https://cursor.com)