### PR TITLE
Chore: add timeout-minutes to CI jobs and fold apk-size into build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,6 +17,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -48,6 +49,7 @@ jobs:
   shared-tests:
     name: Shared Module Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -82,6 +84,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -117,6 +120,7 @@ jobs:
     name: Build
     needs: [ lint, unit-tests ]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -139,10 +143,19 @@ jobs:
           name: app-debug
           path: app/build/outputs/apk/debug/app-debug.apk
 
+      - name: Report debug APK size
+        run: |
+          APK=$(find app/build/outputs/apk/debug -name '*.apk' | head -1)
+          SIZE_BYTES=$(stat -c%s "$APK")
+          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1048576}")
+          echo "### Debug APK Size" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Debug APK**: ${SIZE_MB} MB (${SIZE_BYTES} bytes)" >> "$GITHUB_STEP_SUMMARY"
+
   release-build:
     name: Release Build
     needs: [ lint, unit-tests ]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -173,27 +186,11 @@ jobs:
           echo "### Release APK Size" >> "$GITHUB_STEP_SUMMARY"
           echo "**Release APK**: ${SIZE_MB} MB (${SIZE_BYTES} bytes)" >> "$GITHUB_STEP_SUMMARY"
 
-  apk-size:
-    name: APK Size
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download debug APK
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: app-debug
-
-      - name: Report APK size
-        run: |
-          SIZE_BYTES=$(stat -c%s app-debug.apk)
-          SIZE_MB=$(awk "BEGIN {printf \"%.2f\", $SIZE_BYTES / 1048576}")
-          echo "### APK Size" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Debug APK**: ${SIZE_MB} MB (${SIZE_BYTES} bytes)" >> "$GITHUB_STEP_SUMMARY"
-
   instrumented-tests:
     name: Instrumented Tests
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         api-level: [26, 33, 35]
@@ -243,6 +240,7 @@ jobs:
     name: Dependency Review
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     name: Build MkDocs site
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -46,6 +47,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,6 +20,7 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: macos-15
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary

Closes #255.

- Adds `timeout-minutes` to all 11 unbounded CI jobs across `android.yml`, `ios.yml`, `docs-site.yml`, and `claude.yml` (values are ~3x observed duration to absorb runner variance)
- Folds the standalone `apk-size` job into the `build` job as an inline step (matching the existing pattern in `release-build`), eliminating a wasted runner
- `fuzz.yml` and `ios-stress.yml` already had timeouts and are unchanged

## Test plan

- [ ] Android CI passes (all jobs complete within their timeouts)
- [ ] iOS CI passes
- [ ] Debug APK size appears in the Build job's step summary (not a separate job)
- [ ] No `APK Size` job appears in the workflow run

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added timeout limits to CI/CD jobs across Android, iOS, and documentation build workflows to improve pipeline reliability.
  * Updated Android debug APK size reporting in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->