### PR TITLE
Chore: add path filtering to Android and iOS CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,8 +14,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            android:
+              - 'app/**'
+              - 'shared/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - '.github/workflows/android.yml'
+
   lint:
     name: Lint
+    needs: [changes]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -48,6 +75,8 @@ jobs:
 
   shared-tests:
     name: Shared Module Tests
+    needs: [changes]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -83,6 +112,8 @@ jobs:
 
   unit-tests:
     name: Unit Tests
+    needs: [changes]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -118,7 +149,8 @@ jobs:
 
   build:
     name: Build
-    needs: [ lint, unit-tests ]
+    needs: [changes, lint, unit-tests]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -153,7 +185,8 @@ jobs:
 
   release-build:
     name: Release Build
-    needs: [ lint, unit-tests ]
+    needs: [changes, lint, unit-tests]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -188,7 +221,8 @@ jobs:
 
   instrumented-tests:
     name: Instrumented Tests
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,8 +17,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            ios:
+              - 'iosApp/**'
+              - 'shared/**'
+              - 'gradle/**'
+              - '*.gradle.kts'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - '.github/workflows/ios.yml'
+
   build-and-test:
     name: Build & Test
+    needs: [changes]
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-15
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Summary

Closes #256.

- Adds a lightweight "Detect Changes" job using `dorny/paths-filter` (pinned to SHA) to both `android.yml` and `ios.yml`
- Gates all expensive Android CI jobs (Lint, Shared Module Tests, Unit Tests, Build, Release Build, Instrumented Tests) behind `if: needs.changes.outputs.android == 'true'`
- Gates iOS `Build & Test` behind `if: needs.changes.outputs.ios == 'true'`
- Skipped jobs report success to branch protection, so required checks remain satisfied
- Docs-only changes skip both workflows; `app/`-only changes skip iOS; `iosApp/`-only changes skip Android; `shared/` and Gradle changes trigger both

## Test plan

- [ ] This PR (which touches `.github/workflows/android.yml` and `ios.yml`) triggers both full CI suites
- [ ] A docs-only PR should show all required checks as skipped (success)
- [ ] An `app/`-only PR should run Android CI but skip iOS CI
- [ ] An `iosApp/`-only PR should run iOS CI but skip Android CI
- [ ] A `shared/`-only PR should run both

Made with [Cursor](https://cursor.com)