### PR TITLE
Chore: enable Gradle build cache, parallel execution, and configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary

Closes #257.

- Enables `org.gradle.caching=true` so `gradle/actions/setup-gradle` persists build cache outputs across CI runs (unchanged tasks become `FROM-CACHE`)
- Enables `org.gradle.parallel=true` for concurrent `:app` and `:shared` compilation
- Enables `org.gradle.configuration-cache=true` for faster configuration phase (verified locally with assembleDebug, lintDebug, and koverXmlReport)
- Bumps JVM heap from `-Xmx2048m` to `-Xmx4096m` to accommodate parallel execution memory pressure

## Test plan

- [ ] Android CI passes (all jobs)
- [ ] iOS CI passes (shared framework build uses Gradle)
- [ ] `./gradlew assembleDebug` succeeds locally
- [ ] Second CI run on main shows `FROM-CACHE` for compilation tasks

Made with [Cursor](https://cursor.com)