### PR TITLE
Chore: cache AVD snapshots for instrumented test matrix

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -247,12 +247,34 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: AVD cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7 # v2.37.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Run instrumented tests with coverage
         uses: reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7 # v2.37.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
+          force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
           script: ./gradlew createDebugAndroidTestCoverageReport
 
       - name: Upload instrumented test report


### PR DESCRIPTION
## Summary

Closes #258.

- Adds AVD snapshot caching to the `instrumented-tests` matrix (API 26, 33, 35) using `actions/cache` with key `avd-${{ matrix.api-level }}`
- On cache miss: creates AVD and saves a boot snapshot for future runs
- On cache hit: skips AVD creation, boots from the cached snapshot (~1-2 min faster per leg)
- Adds `force-avd-creation: false` and `disable-animations: true` to the test step
- Follows the documented pattern from `reactivecircus/android-emulator-runner` README

## Test plan

- [ ] First run: cache miss, all 3 API levels create AVD snapshots and pass tests
- [ ] Second run: cache hit, emulators boot from snapshot, tests pass faster
- [ ] All other Android CI jobs unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Android testing pipeline with emulator image caching to reduce CI execution time and improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->