### PR TITLE
Chore: cache Kotlin/Native toolchain, ONNX xcframework, and pin xcresultparser

### DIFF
--- a/.github/workflows/ios-stress.yml
+++ b/.github/workflows/ios-stress.yml
@@ -84,8 +84,20 @@ jobs:
 
           xcrun simctl list devices available | grep "iPhone"
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
       - name: Build shared framework
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+
+      - name: Cache ONNX Runtime xcframework
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: iosApp/Frameworks
+          key: onnxruntime-${{ hashFiles('iosApp/setup_onnxruntime.sh') }}
 
       - name: Download ONNX Runtime
         run: bash iosApp/setup_onnxruntime.sh
@@ -189,8 +201,20 @@ jobs:
 
           xcrun simctl list devices available | grep "iPhone"
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
       - name: Build shared framework
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+
+      - name: Cache ONNX Runtime xcframework
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: iosApp/Frameworks
+          key: onnxruntime-${{ hashFiles('iosApp/setup_onnxruntime.sh') }}
 
       - name: Download ONNX Runtime
         run: bash iosApp/setup_onnxruntime.sh

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -155,6 +155,7 @@ jobs:
         if: always()
         run: |
           curl -fsSL -o /tmp/xcresultparser.zip https://github.com/a7ex/xcresultparser/releases/download/2.0.1/xcresultparser.zip
+          echo "0af7cadc7d77431fab6fd15c3382ebcb35ea48881172aa780a43b757edfec1b7  /tmp/xcresultparser.zip" | shasum -a 256 -c -
           unzip -o /tmp/xcresultparser.zip -d /tmp/xcresultparser
           cp /tmp/xcresultparser/product/xcresultparser /usr/local/bin/xcresultparser
           chmod +x /usr/local/bin/xcresultparser

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -155,7 +155,8 @@ jobs:
         if: always()
         run: |
           curl -fsSL -o /tmp/xcresultparser.zip https://github.com/a7ex/xcresultparser/releases/download/2.0.1/xcresultparser.zip
-          unzip -o /tmp/xcresultparser.zip -d /usr/local/bin
+          unzip -o /tmp/xcresultparser.zip -d /tmp/xcresultparser
+          cp /tmp/xcresultparser/product/xcresultparser /usr/local/bin/xcresultparser
           chmod +x /usr/local/bin/xcresultparser
 
       - name: Convert xcresult to Cobertura XML

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -93,8 +93,20 @@ jobs:
 
           xcrun simctl list devices available | grep "iPhone"
 
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
       - name: Build shared framework
         run: ./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
+
+      - name: Cache ONNX Runtime xcframework
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: iosApp/Frameworks
+          key: onnxruntime-${{ hashFiles('iosApp/setup_onnxruntime.sh') }}
 
       - name: Download ONNX Runtime
         run: bash iosApp/setup_onnxruntime.sh
@@ -139,11 +151,16 @@ jobs:
           name: ios-test-results
           path: TestResults.xcresult
 
-      - name: Convert xcresult to Cobertura XML
+      - name: Install xcresultparser
         if: always()
         run: |
-          brew install a7ex/homebrew-formulae/xcresultparser
-          xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
+          curl -fsSL -o /tmp/xcresultparser.zip https://github.com/a7ex/xcresultparser/releases/download/2.0.1/xcresultparser.zip
+          unzip -o /tmp/xcresultparser.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/xcresultparser
+
+      - name: Convert xcresult to Cobertura XML
+        if: always()
+        run: xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
 
       - name: Upload coverage to Codecov
         if: always()


### PR DESCRIPTION
## Summary

Closes #259.

- Caches `~/.konan` (Kotlin/Native compiler + platform libs) keyed on `libs.versions.toml` hash so the toolchain is not re-downloaded on every run
- Caches `iosApp/Frameworks` (ONNX Runtime xcframework) keyed on `setup_onnxruntime.sh` hash; the existing script no-ops on cache hit
- Replaces unpinned `brew install a7ex/homebrew-formulae/xcresultparser` (~75s) with a pinned v2.0.1 binary download from GitHub releases (~2s)
- Applied to `ios.yml` (Build & Test) and both jobs in `ios-stress.yml` (Stress Tests, Thread Sanitizer)

## Test plan

- [ ] iOS CI passes with caches populated on first run
- [ ] Coverage report still uploads to Codecov successfully (xcresultparser works)
- [ ] `ios-stress.yml` still valid (manual dispatch)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced iOS CI/CD pipelines with build caching for Kotlin/Native toolchain and ONNX Runtime framework to accelerate build times in both standard and stress test workflows.
  * Updated test result parser installation method in iOS workflow to use direct binary download, improving reliability of test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->