### PR TITLE
Chore: auto-file issue on nightly CI failure

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,3 +72,19 @@ jobs:
         with:
           name: fuzz-test-report
           path: app/build/reports/tests/testDebugUnitTest/
+
+      - name: File issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --label ci-failure --state open \
+            --search "in:title ${{ github.workflow }}" --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            gh issue create \
+              --title "Nightly failure: ${{ github.workflow }}" \
+              --label "ci-failure,bug" \
+              --body "Scheduled run failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — check the uploaded artifacts (crash inputs / xcresult bundles) before they expire."
+          fi

--- a/.github/workflows/ios-stress.yml
+++ b/.github/workflows/ios-stress.yml
@@ -10,6 +10,7 @@ env:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   stress-tests:
@@ -129,6 +130,22 @@ jobs:
           name: ios-crash-logs
           path: ~/Library/Logs/DiagnosticReports/UkuleleCompanion*
 
+      - name: File issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --label ci-failure --state open \
+            --search "in:title ${{ github.workflow }}" --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            gh issue create \
+              --title "Nightly failure: ${{ github.workflow }}" \
+              --label "ci-failure,bug" \
+              --body "Scheduled run failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — check the uploaded artifacts (crash inputs / xcresult bundles) before they expire."
+          fi
+
   tsan-tests:
     name: Thread Sanitizer
     runs-on: macos-15
@@ -246,3 +263,19 @@ jobs:
         with:
           name: ios-tsan-crash-logs
           path: ~/Library/Logs/DiagnosticReports/UkuleleCompanion*
+
+      - name: File issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --label ci-failure --state open \
+            --search "in:title ${{ github.workflow }}" --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            gh issue create \
+              --title "Nightly failure: ${{ github.workflow }}" \
+              --label "ci-failure,bug" \
+              --body "Scheduled run failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} — check the uploaded artifacts (crash inputs / xcresult bundles) before they expire."
+          fi


### PR DESCRIPTION
## Summary

Closes #260.

- Adds a "File issue on scheduled failure" step to the end of all three nightly CI jobs: `fuzz.yml` (fuzz), `ios-stress.yml` (stress-tests, tsan-tests)
- On `failure() && schedule`: creates a new issue with `ci-failure` + `bug` labels, or comments on an existing open issue with the same title to avoid duplicates
- Adds `issues: write` permission to both workflows
- Created the `ci-failure` label on the repository
- Step only fires on `schedule` events, not `workflow_dispatch` (manual runs)

## Test plan

- [ ] Trigger `fuzz.yml` manually via `workflow_dispatch` -- issue step should NOT run
- [ ] All existing CI checks pass (the step is conditional on failure + schedule)
- [ ] On a real scheduled failure, an issue is created with the ci-failure label

Made with [Cursor](https://cursor.com)