### PR TITLE
Chore: extract iOS simulator prep into a composite action

### DIFF
--- a/.github/actions/prepare-ios-simulator/action.yml
+++ b/.github/actions/prepare-ios-simulator/action.yml
@@ -1,0 +1,71 @@
+name: Prepare iOS Simulator
+description: Wait for iOS runtime, create device if missing, optionally boot and return UDID
+inputs:
+  device-name:
+    description: Simulator device name
+    default: iPhone 16
+  device-type:
+    description: CoreSimulator device type identifier
+    default: com.apple.CoreSimulator.SimDeviceType.iPhone-16
+  boot:
+    description: Boot the simulator and wait for bootstatus
+    default: 'false'
+outputs:
+  udid:
+    description: UDID of the prepared simulator
+    value: ${{ steps.prepare.outputs.udid }}
+runs:
+  using: composite
+  steps:
+    - id: prepare
+      shell: bash
+      run: |
+        set -e
+        for i in $(seq 1 5); do
+          if xcrun simctl list runtimes | grep -q "com.apple.CoreSimulator.SimRuntime.iOS"; then
+            break
+          fi
+          echo "Waiting for iOS simulator runtime (attempt $i/5)..."
+          sleep 10
+        done
+
+        xcrun simctl list runtimes
+
+        RUNTIME=$(xcrun simctl list runtimes | grep "^iOS" | tail -1 | awk '{print $NF}')
+        if [ -z "$RUNTIME" ]; then
+          echo "::error::No iOS simulator runtime found"
+          exit 1
+        fi
+        echo "Runtime: $RUNTIME"
+
+        if ! xcrun simctl list devices available | grep -q "${{ inputs.device-name }}"; then
+          echo "Creating ${{ inputs.device-name }} simulator..."
+          xcrun simctl create "${{ inputs.device-name }}" \
+            "${{ inputs.device-type }}" \
+            "$RUNTIME"
+        fi
+
+        SIM_UDID=$(xcrun simctl list devices available -j \
+          | python3 -c "
+        import json, sys
+        data = json.load(sys.stdin)
+        udid = None
+        for runtime in sorted(data['devices'].keys()):
+            for dev in data['devices'][runtime]:
+                if dev['name'] == '${{ inputs.device-name }}' and dev['isAvailable']:
+                    udid = dev['udid']
+        print(udid or '')
+        ")
+        if [ -z "$SIM_UDID" ]; then
+          echo "::error::Could not find ${{ inputs.device-name }} simulator UDID"
+          exit 1
+        fi
+        echo "udid=$SIM_UDID" >> "$GITHUB_OUTPUT"
+
+        if [ "${{ inputs.boot }}" = "true" ]; then
+          echo "Booting simulator $SIM_UDID ..."
+          xcrun simctl boot "$SIM_UDID" || true
+          xcrun simctl bootstatus "$SIM_UDID" -b
+        fi
+
+        xcrun simctl list devices available | grep "iPhone"

--- a/.github/workflows/ios-stress.yml
+++ b/.github/workflows/ios-stress.yml
@@ -34,56 +34,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Prepare iOS Simulator
-        run: |
-          set -e
-          for i in $(seq 1 5); do
-            if xcrun simctl list runtimes | grep -q "com.apple.CoreSimulator.SimRuntime.iOS"; then
-              break
-            fi
-            echo "Waiting for iOS simulator runtime (attempt $i/5)..."
-            sleep 10
-          done
-
-          xcrun simctl list runtimes
-
-          RUNTIME=$(xcrun simctl list runtimes | grep "^iOS" | tail -1 | awk '{print $NF}')
-          if [ -z "$RUNTIME" ]; then
-            echo "::error::No iOS simulator runtime found"
-            exit 1
-          fi
-          echo "Runtime: $RUNTIME"
-
-          if ! xcrun simctl list devices available | grep -q "iPhone 16"; then
-            echo "Creating iPhone 16 simulator..."
-            xcrun simctl create "iPhone 16" \
-              "com.apple.CoreSimulator.SimDeviceType.iPhone-16" \
-              "$RUNTIME"
-          fi
-
-          # Find UDID for the last (latest-runtime) available iPhone 16
-          SIM_UDID=$(xcrun simctl list devices available -j \
-            | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          # Devices are grouped by runtime; pick the latest runtime's iPhone 16
-          udid = None
-          for runtime in sorted(data['devices'].keys()):
-              for dev in data['devices'][runtime]:
-                  if dev['name'] == 'iPhone 16' and dev['isAvailable']:
-                      udid = dev['udid']
-          print(udid or '')
-          ")
-          if [ -z "$SIM_UDID" ]; then
-            echo "::error::Could not find iPhone 16 simulator UDID"
-            exit 1
-          fi
-          echo "Booting simulator $SIM_UDID ..."
-          xcrun simctl boot "$SIM_UDID" || true
-          # Wait for the simulator to finish booting
-          xcrun simctl bootstatus "$SIM_UDID" -b
-          echo "SIM_UDID=$SIM_UDID" >> "$GITHUB_ENV"
-
-          xcrun simctl list devices available | grep "iPhone"
+        id: sim
+        uses: ./.github/actions/prepare-ios-simulator
+        with:
+          boot: 'true'
 
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -110,7 +64,7 @@ jobs:
           xcodebuild test \
             -project iosApp/UkuleleCompanion.xcodeproj \
             -scheme UkuleleCompanion \
-            -destination "id=$SIM_UDID" \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             -only-testing:UkuleleCompanionUITests \
@@ -167,56 +121,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Prepare iOS Simulator
-        run: |
-          set -e
-          for i in $(seq 1 5); do
-            if xcrun simctl list runtimes | grep -q "com.apple.CoreSimulator.SimRuntime.iOS"; then
-              break
-            fi
-            echo "Waiting for iOS simulator runtime (attempt $i/5)..."
-            sleep 10
-          done
-
-          xcrun simctl list runtimes
-
-          RUNTIME=$(xcrun simctl list runtimes | grep "^iOS" | tail -1 | awk '{print $NF}')
-          if [ -z "$RUNTIME" ]; then
-            echo "::error::No iOS simulator runtime found"
-            exit 1
-          fi
-          echo "Runtime: $RUNTIME"
-
-          if ! xcrun simctl list devices available | grep -q "iPhone 16"; then
-            echo "Creating iPhone 16 simulator..."
-            xcrun simctl create "iPhone 16" \
-              "com.apple.CoreSimulator.SimDeviceType.iPhone-16" \
-              "$RUNTIME"
-          fi
-
-          # Find UDID for the last (latest-runtime) available iPhone 16
-          SIM_UDID=$(xcrun simctl list devices available -j \
-            | python3 -c "
-          import json, sys
-          data = json.load(sys.stdin)
-          # Devices are grouped by runtime; pick the latest runtime's iPhone 16
-          udid = None
-          for runtime in sorted(data['devices'].keys()):
-              for dev in data['devices'][runtime]:
-                  if dev['name'] == 'iPhone 16' and dev['isAvailable']:
-                      udid = dev['udid']
-          print(udid or '')
-          ")
-          if [ -z "$SIM_UDID" ]; then
-            echo "::error::Could not find iPhone 16 simulator UDID"
-            exit 1
-          fi
-          echo "Booting simulator $SIM_UDID ..."
-          xcrun simctl boot "$SIM_UDID" || true
-          # Wait for the simulator to finish booting
-          xcrun simctl bootstatus "$SIM_UDID" -b
-          echo "SIM_UDID=$SIM_UDID" >> "$GITHUB_ENV"
-
-          xcrun simctl list devices available | grep "iPhone"
+        id: sim
+        uses: ./.github/actions/prepare-ios-simulator
+        with:
+          boot: 'true'
 
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -243,7 +151,7 @@ jobs:
           xcodebuild test \
             -project iosApp/UkuleleCompanion.xcodeproj \
             -scheme UkuleleCompanion \
-            -destination "id=$SIM_UDID" \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             -enableThreadSanitizer YES \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,33 +65,8 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
 
       - name: Prepare iOS Simulator
-        run: |
-          set -e
-          for i in $(seq 1 5); do
-            if xcrun simctl list runtimes | grep -q "com.apple.CoreSimulator.SimRuntime.iOS"; then
-              break
-            fi
-            echo "Waiting for iOS simulator runtime (attempt $i/5)..."
-            sleep 10
-          done
-
-          xcrun simctl list runtimes
-
-          RUNTIME=$(xcrun simctl list runtimes | grep "^iOS" | tail -1 | awk '{print $NF}')
-          if [ -z "$RUNTIME" ]; then
-            echo "::error::No iOS simulator runtime found"
-            exit 1
-          fi
-          echo "Runtime: $RUNTIME"
-
-          if ! xcrun simctl list devices available | grep -q "iPhone 16"; then
-            echo "Creating iPhone 16 simulator..."
-            xcrun simctl create "iPhone 16" \
-              "com.apple.CoreSimulator.SimDeviceType.iPhone-16" \
-              "$RUNTIME"
-          fi
-
-          xcrun simctl list devices available | grep "iPhone"
+        id: sim
+        uses: ./.github/actions/prepare-ios-simulator
 
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary

Closes #262.

- Creates `.github/actions/prepare-ios-simulator/action.yml` — a local composite action with `boot` input and `udid` output that unifies the short (no boot) and long (boot + UDID) variants
- Replaces three copy-pasted inline scripts across `ios.yml` and `ios-stress.yml` (129 lines removed, 12 added)
- `ios-stress.yml` xcodebuild destinations now use `steps.sim.outputs.udid` instead of `$SIM_UDID` env var
- Single point of change for the next Xcode/simulator device type bump

## Test plan

- [ ] iOS CI passes (`ios.yml` -- no boot, name-based destination)
- [ ] iOS stress tests pass (manual trigger -- `boot: true`, UDID destination)
- [ ] TSan tests pass (same pattern as stress tests)

Made with [Cursor](https://cursor.com)