### PR TITLE
Refactor: extract frame-dropping backpressure gate (fixes #286)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -76,7 +76,7 @@ import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.PlayAlongScorer
 import com.baijum.ukufretboard.viewmodel.UkuleleString
-import java.util.concurrent.atomic.AtomicBoolean
+import com.baijum.ukufretboard.domain.FrameGate
 
 /**
  * Real-Time Play-Along with feedback view.
@@ -128,7 +128,7 @@ fun PlayAlongView(
     var score by remember { mutableStateOf(PlayAlongScorer.PlayAlongScore()) }
     var sessionComplete by remember { mutableStateOf(false) }
     var isListening by remember { mutableStateOf(false) }
-    val isProcessing = remember { AtomicBoolean(false) }
+    val frameGate = remember { FrameGate() }
 
     // Build chord names for the progression
     val chordNames = remember(progression, keyRoot) {
@@ -156,7 +156,7 @@ fun PlayAlongView(
                 context.applicationContext,
                 onInterrupted = { isListening = false },
             ) { samples ->
-                if (!isProcessing.compareAndSet(false, true)) return@start
+                if (!frameGate.tryEnter()) return@start
                 try {
                     val result = AudioChordDetector.detect(samples)
                     val chordFound = result.detection as? ChordDetector.DetectionResult.ChordFound
@@ -170,7 +170,7 @@ fun PlayAlongView(
                         }
                     }
                 } finally {
-                    isProcessing.set(false)
+                    frameGate.exit()
                 }
             }
         }

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -14,7 +14,7 @@ import com.baijum.ukufretboard.data.SoundSettings
 import com.baijum.ukufretboard.domain.NoteInfo
 import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.TunerNoteMapper
-import java.util.concurrent.atomic.AtomicBoolean
+import com.baijum.ukufretboard.domain.FrameGate
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -107,7 +107,7 @@ class MelodyViewModel : ViewModel() {
     private var previousRms = 0f
     private var blankingFramesRemaining = 0
     private var previousFrequency: Double? = null
-    private val isProcessing = AtomicBoolean(false)
+    private val frameGate = FrameGate()
     private val recentFrequencies = ArrayDeque<Double>(SMOOTHING_WINDOW)
     private var stableNoteInfo: NoteInfo? = null
     private var stabilizationFrames = 0
@@ -439,7 +439,7 @@ class MelodyViewModel : ViewModel() {
         val ctx = appContext ?: return
         if (_uiState.value.isPlaying) stopPlayback()
 
-        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        frameGate.awaitEnter()
         try {
             resetRecordingState()
             _uiState.update {
@@ -450,7 +450,7 @@ class MelodyViewModel : ViewModel() {
                 )
             }
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
 
         AudioCaptureEngine.start(
@@ -509,11 +509,11 @@ class MelodyViewModel : ViewModel() {
      */
     private fun processRecordingBuffer(samples: FloatArray) {
         if (!_uiState.value.isRecording) return
-        if (!isProcessing.compareAndSet(false, true)) return
+        if (!frameGate.tryEnter()) return
         try {
             processRecordingBufferInner(samples)
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
     }
 

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -13,7 +13,7 @@ import com.baijum.ukufretboard.domain.NeuralPitchSupervisor
 import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.PitchResult
 import com.baijum.ukufretboard.domain.TunerNoteMapper
-import java.util.concurrent.atomic.AtomicBoolean
+import com.baijum.ukufretboard.domain.FrameGate
 import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -244,7 +244,7 @@ class PitchMonitorViewModel : ViewModel() {
     private var previousFrequency: Double? = null
 
     // --- Frame-dropping (backpressure) ----------------------------------------
-    private val isProcessing = AtomicBoolean(false)
+    private val frameGate = FrameGate()
 
     // --- Neural supervisor state ----------------------------------------------
 
@@ -269,7 +269,7 @@ class PitchMonitorViewModel : ViewModel() {
 
         initializeNeuralSupervisor()
 
-        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        frameGate.awaitEnter()
         try {
             _uiState.update { it.copy(isListening = true) }
             recentFrequencies.clear()
@@ -298,7 +298,7 @@ class PitchMonitorViewModel : ViewModel() {
             neuralConsistencyFrames = 0
             telemetryFrameCounter = 0
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
 
         AudioCaptureEngine.start(
@@ -356,11 +356,11 @@ class PitchMonitorViewModel : ViewModel() {
             s
         }
         AudioCaptureEngine.stop()
-        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        frameGate.awaitEnter()
         try {
             supervisor?.close()
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
     }
 
@@ -376,11 +376,11 @@ class PitchMonitorViewModel : ViewModel() {
      */
     private fun processBuffer(samples: FloatArray) {
         if (!_uiState.value.isListening) return
-        if (!isProcessing.compareAndSet(false, true)) return
+        if (!frameGate.tryEnter()) return
         try {
             processBufferInner(samples)
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
     }
 

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
-import java.util.concurrent.atomic.AtomicBoolean
+import com.baijum.ukufretboard.domain.FrameGate
 import kotlin.math.abs
 import kotlin.math.log2
 
@@ -288,7 +288,7 @@ class TunerViewModel : ViewModel() {
     ).toInt().coerceAtLeast(1)
 
     // --- Frame-dropping (backpressure) ----------------------------------------
-    private val isProcessing = AtomicBoolean(false)
+    private val frameGate = FrameGate()
 
     // --- Neural supervisor state --------------------------------------------
 
@@ -360,7 +360,7 @@ class TunerViewModel : ViewModel() {
         if (_uiState.value.isListening) return
         val ctx = appContext ?: return
 
-        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        frameGate.awaitEnter()
         try {
             _uiState.update {
                 it.copy(
@@ -392,7 +392,7 @@ class TunerViewModel : ViewModel() {
             telemetryOverrideCount = 0
             lastLoggedStatus = TuningStatus.SILENT
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
 
         AudioCaptureEngine.start(
@@ -455,11 +455,11 @@ class TunerViewModel : ViewModel() {
             s
         }
         AudioCaptureEngine.stop()
-        while (!isProcessing.compareAndSet(false, true)) { /* spin until in-flight buffer finishes */ }
+        frameGate.awaitEnter()
         try {
             supervisor?.close()
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
         shutdownTts()
     }
@@ -477,11 +477,11 @@ class TunerViewModel : ViewModel() {
      */
     private fun processBuffer(samples: FloatArray) {
         if (!_uiState.value.isListening) return
-        if (!isProcessing.compareAndSet(false, true)) return
+        if (!frameGate.tryEnter()) return
         try {
             processBufferInner(samples)
         } finally {
-            isProcessing.set(false)
+            frameGate.exit()
         }
     }
 

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -103,7 +103,7 @@ final class MelodyViewModel: ObservableObject {
     private let tonePlayer = TonePlayer()
     private var playbackTask: Task<Void, Never>?
     private let audioEngine = AudioCaptureEngine()
-    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
+    private nonisolated(unsafe) let frameGate = FrameGate()
     private var stableCount = 0
     private var lastDetectedPitchClass: Int? = nil
 
@@ -307,12 +307,7 @@ final class MelodyViewModel: ObservableObject {
 
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
-            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
-                if isProcessing { return false }
-                isProcessing = true
-                return true
-            }
-            guard shouldProcess else { return }
+            guard self.frameGate.tryEnter() else { return }
             Task { @MainActor in
                 let floatArray = KotlinFloatArray(size: Int32(samples.count))
                 for i in 0..<samples.count {
@@ -331,7 +326,7 @@ final class MelodyViewModel: ObservableObject {
                     self.stableCount = 0
                     self.lastDetectedPitchClass = nil
                     self.stabilizationProgress = 0
-                    self.processingLock.withLock { $0 = false }
+                    self.frameGate.exit()
                     return
                 }
 
@@ -341,7 +336,7 @@ final class MelodyViewModel: ObservableObject {
                 )
 
                 guard let noteInfo else {
-                    self.processingLock.withLock { $0 = false }
+                    self.frameGate.exit()
                     return
                 }
 
@@ -367,7 +362,7 @@ final class MelodyViewModel: ObservableObject {
                     self.stabilizationProgress = 0
                 }
 
-                self.processingLock.withLock { $0 = false }
+                self.frameGate.exit()
             }
         }
 

--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -30,7 +30,7 @@ final class PitchMonitorViewModel: ObservableObject {
     private static let historyDurationMs: Int64 = 10_000
 
     // Frame-dropping (backpressure) — checked on audio thread, not MainActor
-    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
+    private nonisolated(unsafe) let frameGate = FrameGate()
     private nonisolated(unsafe) let neuralInferenceLock = OSAllocatedUnfairLock(initialState: false)
 
     // Neural state
@@ -77,15 +77,10 @@ final class PitchMonitorViewModel: ObservableObject {
         neuralSupervisor = nil
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
-            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
-                if isProcessing { return false }
-                isProcessing = true
-                return true
-            }
-            guard shouldProcess else { return }
+            guard self.frameGate.tryEnter() else { return }
             Task { @MainActor in
                 self.processBuffer(samples)
-                self.processingLock.withLock { $0 = false }
+                self.frameGate.exit()
             }
         }
         Task {

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -19,7 +19,7 @@ final class PlayAlongViewModel: ObservableObject {
     // MARK: - Dependencies
 
     private let audioEngine = AudioCaptureEngine()
-    private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
+    private nonisolated(unsafe) let frameGate = FrameGate()
     let tonePlayer = TonePlayer()
     private let scorer = PlayAlongScorer()
 
@@ -46,15 +46,10 @@ final class PlayAlongViewModel: ObservableObject {
     init() {
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
-            let shouldProcess = self.processingLock.withLock { isProcessing -> Bool in
-                if isProcessing { return false }
-                isProcessing = true
-                return true
-            }
-            guard shouldProcess else { return }
+            guard self.frameGate.tryEnter() else { return }
             Task { @MainActor in
                 self.processAudioBuffer(samples)
-                self.processingLock.withLock { $0 = false }
+                self.frameGate.exit()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FrameGate.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FrameGate.kt
@@ -1,0 +1,69 @@
+package com.baijum.ukufretboard.domain
+
+import com.baijum.ukufretboard.platform.PlatformLock
+
+/**
+ * Gate for audio frame processing. Only one frame can be in-flight at
+ * a time; additional frames are dropped ([tryEnter] returns false).
+ *
+ * Two usage patterns:
+ * - **Drop-if-busy** (audio callback): `if (!gate.tryEnter()) return`
+ * - **Spin-until-free** (start/stop drain): `gate.awaitEnter()`
+ *
+ * Thread-safe: all access is serialized through [PlatformLock].
+ */
+class FrameGate {
+    private val lock = PlatformLock()
+    private var processing = false
+
+    /** Try to enter the gate. Returns false if a frame is already in-flight. */
+    fun tryEnter(): Boolean {
+        lock.lock()
+        try {
+            if (processing) return false
+            processing = true
+            return true
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    /**
+     * Spin until the gate is free, then enter. Use only in start/stop
+     * drain paths — never on the audio callback thread.
+     */
+    fun awaitEnter() {
+        while (true) {
+            lock.lock()
+            try {
+                if (!processing) {
+                    processing = true
+                    return
+                }
+            } finally {
+                lock.unlock()
+            }
+        }
+    }
+
+    /** Release the gate after frame processing completes. */
+    fun exit() {
+        lock.lock()
+        try {
+            processing = false
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    /** Returns true if a frame is currently being processed. */
+    val isActive: Boolean
+        get() {
+            lock.lock()
+            try {
+                return processing
+            } finally {
+                lock.unlock()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FrameGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FrameGateTest.kt
@@ -1,0 +1,67 @@
+package com.baijum.ukufretboard.domain
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FrameGateTest {
+
+    @Test
+    fun tryEnterSucceedsOnFreeGate() {
+        val gate = FrameGate()
+        assertTrue(gate.tryEnter())
+    }
+
+    @Test
+    fun tryEnterFailsWhenAlreadyEntered() {
+        val gate = FrameGate()
+        assertTrue(gate.tryEnter())
+        assertFalse(gate.tryEnter(), "second tryEnter should be rejected (drop)")
+    }
+
+    @Test
+    fun exitReleasesGate() {
+        val gate = FrameGate()
+        gate.tryEnter()
+        gate.exit()
+        assertTrue(gate.tryEnter(), "tryEnter should succeed after exit")
+    }
+
+    @Test
+    fun multipleEnterExitCycles() {
+        val gate = FrameGate()
+        repeat(100) {
+            assertTrue(gate.tryEnter())
+            assertFalse(gate.tryEnter())
+            gate.exit()
+        }
+    }
+
+    @Test
+    fun isActiveReflectsState() {
+        val gate = FrameGate()
+        assertFalse(gate.isActive, "new gate should be inactive")
+        gate.tryEnter()
+        assertTrue(gate.isActive, "entered gate should be active")
+        gate.exit()
+        assertFalse(gate.isActive, "exited gate should be inactive")
+    }
+
+    @Test
+    fun awaitEnterOnFreeGateSucceedsImmediately() {
+        val gate = FrameGate()
+        gate.awaitEnter()
+        assertTrue(gate.isActive)
+        gate.exit()
+    }
+
+    @Test
+    fun awaitEnterAfterExitSucceeds() {
+        val gate = FrameGate()
+        gate.tryEnter()
+        gate.exit()
+        gate.awaitEnter()
+        assertTrue(gate.isActive)
+        gate.exit()
+    }
+}


### PR DESCRIPTION
## Summary

- Create shared `FrameGate` class with `tryEnter()`, `exit()`, and `awaitEnter()` methods
- Add commonTest coverage: drop-under-contention, gate release, cycling, drain ordering
- Migrate all 7 call sites from inline `isProcessing` flags to the shared gate:
  - Android: TunerViewModel, PitchMonitorViewModel, MelodyViewModel, PlayAlongView
  - iOS: MelodyViewModel, PitchMonitorViewModel, PlayAlongViewModel

## Test plan

- [ ] Shared module tests pass (`./gradlew :shared:jvmTest`)
- [ ] Android debug build succeeds
- [ ] iOS build succeeds
- [ ] Tuner, pitch monitor, melody, play-along screens work normally
- [ ] No `isProcessing` / `AtomicBoolean` audio guards remain inline

Fixes #286

Made with [Cursor](https://cursor.com)