### PR TITLE
Refactor: extract neural arbitration state machine to shared (fixes #285)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -8,6 +8,9 @@ import androidx.lifecycle.viewModelScope
 import com.baijum.ukufretboard.audio.AudioCaptureEngine
 import com.baijum.ukufretboard.data.TunerSettings
 import com.baijum.ukufretboard.data.UkuleleTuning
+import com.baijum.ukufretboard.domain.ArbitrationResult
+import com.baijum.ukufretboard.domain.FrameGate
+import com.baijum.ukufretboard.domain.NeuralArbitrator
 import com.baijum.ukufretboard.domain.NeuralPitchResult
 import com.baijum.ukufretboard.domain.NeuralPitchSupervisor
 import com.baijum.ukufretboard.domain.NoteInfo
@@ -23,9 +26,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
-import com.baijum.ukufretboard.domain.FrameGate
 import kotlin.math.abs
-import kotlin.math.log2
 
 /**
  * Tuning accuracy status shown to the user.
@@ -170,26 +171,6 @@ class TunerViewModel : ViewModel() {
          */
         private const val LOST_SIGNAL_HOLD_MS = 400L
 
-        /**
-         * Neural supervisor cadence. At ~23 ms per frame, 5 frames ≈ 115 ms.
-         */
-        private const val NEURAL_SUPERVISOR_INTERVAL = 5
-
-        /** If stale, neural estimates are ignored until refreshed. */
-        private const val NEURAL_RESULT_TTL_FRAMES = 10
-
-        /** Mark runtime fallback if this many inferences fail in a row. */
-        private const val NEURAL_FAILURE_THRESHOLD = 15
-
-        /** Ignore tiny YIN-vs-neural disagreements. */
-        private const val ARBITRATION_IGNORE_SEMITONES = 1.5
-
-        /** Strong disagreement threshold for non-octave correction. */
-        private const val ARBITRATION_STRONG_SEMITONES = 2.5
-
-        /** Required consecutive similar neural readings before override. */
-        private const val NEURAL_CONSISTENCY_FRAMES = 2
-
         /** Hysteresis for keeping previous target string assignment. */
         private const val STRING_SWITCH_HYSTERESIS_CENTS = 4.0
 
@@ -203,19 +184,6 @@ class TunerViewModel : ViewModel() {
         private const val TELEMETRY_LOG_INTERVAL_FRAMES = 25L
 
         private const val TAG = "TunerViewModel"
-
-        @androidx.annotation.VisibleForTesting
-        internal fun semitoneDistance(aHz: Double, bHz: Double): Double {
-            if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
-            return abs(12.0 * log2(aHz / bHz))
-        }
-
-        @androidx.annotation.VisibleForTesting
-        internal fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
-            if (aHz <= 0.0 || bHz <= 0.0) return false
-            val semitones = semitoneDistance(aHz, bHz)
-            return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
-        }
     }
 
     // --- State ---------------------------------------------------------------
@@ -295,12 +263,7 @@ class TunerViewModel : ViewModel() {
     private val supervisorLock = Any()
     private var isCleared = false
     private var neuralSupervisor: NeuralPitchSupervisor? = null
-    private var neuralFrameCounter = 0
-    private var lastNeuralResult: NeuralPitchResult? = null
-    private var neuralResultAgeFrames = Int.MAX_VALUE
-    private var consecutiveNeuralFailures = 0
-    private var lastNeuralFrequencyForConsistency: Double? = null
-    private var neuralConsistencyFrames = 0
+    private val neuralArbitrator = NeuralArbitrator()
 
     // --- Settled note tracking ------------------------------------------------
 
@@ -382,12 +345,7 @@ class TunerViewModel : ViewModel() {
             settledNoteName = null
             settledNoteFrames = 0
             settledNoteCents = 0.0
-            neuralFrameCounter = 0
-            lastNeuralResult = null
-            neuralResultAgeFrames = Int.MAX_VALUE
-            consecutiveNeuralFailures = 0
-            lastNeuralFrequencyForConsistency = null
-            neuralConsistencyFrames = 0
+            neuralArbitrator.reset()
             telemetryFrameCounter = 0
             telemetryOverrideCount = 0
             lastLoggedStatus = TuningStatus.SILENT
@@ -577,17 +535,16 @@ class TunerViewModel : ViewModel() {
         lostSignalFrames = 0
 
         val neuralResultForFrame = runNeuralSupervisor(samples)
-        val arbitration = arbitrate(result, neuralResultForFrame)
-        val finalPitch = arbitration.result
+        val arbitration = neuralArbitrator.arbitrate(result, neuralResultForFrame)
         if (arbitration.overrideApplied) {
             telemetryOverrideCount++
         }
 
         // Track for next frame's continuity constraint.
-        previousFrequency = finalPitch.frequencyHz
+        previousFrequency = arbitration.frequencyHz
 
         // --- Smoothing -------------------------------------------------------
-        recentFrequencies.addLast(finalPitch.frequencyHz)
+        recentFrequencies.addLast(arbitration.frequencyHz)
         if (recentFrequencies.size > SMOOTHING_WINDOW) {
             recentFrequencies.removeFirst()
         }
@@ -677,7 +634,7 @@ class TunerViewModel : ViewModel() {
                 detectedNote = displayNote,
                 centsDeviation = clampedCents,
                 displayCentsDeviation = displayCents,
-                confidence = finalPitch.confidence,
+                confidence = arbitration.confidence,
                 tuningStatus = status,
                 targetString = stringMatch,
                 stringProgress = progress,
@@ -702,11 +659,10 @@ class TunerViewModel : ViewModel() {
         logCalibrationTelemetry(
             yinResult = result,
             neuralResult = neuralResultForFrame,
-            finalPitch = finalPitch,
+            arbitration = arbitration,
             cents = clampedCents,
             status = status,
             stringMatch = stringMatch,
-            arbitrationReason = arbitration.reason,
         )
     }
 
@@ -775,25 +731,19 @@ class TunerViewModel : ViewModel() {
 
     private fun runNeuralSupervisor(samples: FloatArray): NeuralPitchResult? {
         val supervisor = synchronized(supervisorLock) { neuralSupervisor } ?: return null
-        neuralFrameCounter++
 
-        if (neuralFrameCounter % NEURAL_SUPERVISOR_INTERVAL == 0) {
+        if (neuralArbitrator.shouldRunInference()) {
             val estimate = supervisor.estimate(samples)
-            lastNeuralResult = estimate
-            neuralResultAgeFrames = 0
             if (estimate != null) {
-                consecutiveNeuralFailures = 0
-                updateNeuralConsistency(estimate.frequencyHz)
+                neuralArbitrator.onInferenceResult(estimate)
                 updateNeuralStatus(
                     available = true,
                     active = true,
                     status = NeuralRuntimeStatus.ACTIVE,
                 )
             } else {
-                consecutiveNeuralFailures++
-                neuralConsistencyFrames = 0
-                lastNeuralFrequencyForConsistency = null
-                if (consecutiveNeuralFailures >= NEURAL_FAILURE_THRESHOLD) {
+                val disabled = neuralArbitrator.onInferenceFailure()
+                if (disabled) {
                     updateNeuralStatus(
                         available = true,
                         active = false,
@@ -801,104 +751,11 @@ class TunerViewModel : ViewModel() {
                     )
                 }
             }
-        } else if (neuralResultAgeFrames < Int.MAX_VALUE) {
-            neuralResultAgeFrames++
         }
 
-        return if (neuralResultAgeFrames <= NEURAL_RESULT_TTL_FRAMES) {
-            lastNeuralResult
-        } else {
-            null
-        }
+        return neuralArbitrator.currentResult()
     }
 
-    private data class ArbitrationDecision(
-        val result: PitchResult,
-        val overrideApplied: Boolean,
-        val reason: String,
-    )
-
-    private fun arbitrate(
-        yinResult: PitchResult,
-        neuralResult: NeuralPitchResult?,
-    ): ArbitrationDecision {
-        if (neuralResult == null) {
-            return ArbitrationDecision(
-                result = yinResult,
-                overrideApplied = false,
-                reason = "no_neural",
-            )
-        }
-
-        val semitoneGap = semitoneDistance(yinResult.frequencyHz, neuralResult.frequencyHz)
-        if (semitoneGap <= ARBITRATION_IGNORE_SEMITONES) {
-            return ArbitrationDecision(
-                result = yinResult,
-                overrideApplied = false,
-                reason = "small_gap",
-            )
-        }
-
-        if (neuralConsistencyFrames < NEURAL_CONSISTENCY_FRAMES) {
-            return ArbitrationDecision(
-                result = yinResult,
-                overrideApplied = false,
-                reason = "neural_inconsistent",
-            )
-        }
-
-        if (isOctaveRelation(yinResult.frequencyHz, neuralResult.frequencyHz) &&
-            neuralResult.confidence >= 0.85 &&
-            yinResult.confidence >= 0.12
-        ) {
-            return ArbitrationDecision(
-                result = yinResult.copy(frequencyHz = neuralResult.frequencyHz),
-                overrideApplied = true,
-                reason = "octave_correction",
-            )
-        }
-
-        return if (semitoneGap >= ARBITRATION_STRONG_SEMITONES &&
-            neuralResult.confidence >= 0.93 &&
-            yinResult.confidence >= 0.16
-        ) {
-            ArbitrationDecision(
-                result = yinResult.copy(frequencyHz = neuralResult.frequencyHz),
-                overrideApplied = true,
-                reason = "strong_disagreement",
-            )
-        } else {
-            ArbitrationDecision(
-                result = yinResult,
-                overrideApplied = false,
-                reason = "keep_yin",
-            )
-        }
-    }
-
-    private fun semitoneDistance(aHz: Double, bHz: Double): Double =
-        Companion.semitoneDistance(aHz, bHz)
-
-    private fun isOctaveRelation(aHz: Double, bHz: Double): Boolean =
-        Companion.isOctaveRelation(aHz, bHz)
-
-    private fun updateNeuralConsistency(neuralFrequencyHz: Double) {
-        if (neuralFrequencyHz <= 0.0) {
-            neuralConsistencyFrames = 0
-            lastNeuralFrequencyForConsistency = null
-            return
-        }
-
-        val previous = lastNeuralFrequencyForConsistency
-        neuralConsistencyFrames = if (previous != null &&
-            semitoneDistance(previous, neuralFrequencyHz) <= 0.5
-        ) {
-            neuralConsistencyFrames + 1
-        } else {
-            1
-        }
-        lastNeuralFrequencyForConsistency = neuralFrequencyHz
-    }
 
     private fun smoothDisplayCents(rawCents: Double): Double {
         val target = if (abs(rawCents) < DISPLAY_DEADBAND_CENTS) 0.0 else rawCents
@@ -1007,11 +864,10 @@ class TunerViewModel : ViewModel() {
     private fun logCalibrationTelemetry(
         yinResult: PitchResult,
         neuralResult: NeuralPitchResult?,
-        finalPitch: PitchResult,
+        arbitration: ArbitrationResult,
         cents: Double,
         status: TuningStatus,
         stringMatch: StringMatch,
-        arbitrationReason: String,
     ) {
         if (!Log.isLoggable(TAG, Log.DEBUG)) return
 
@@ -1038,9 +894,9 @@ class TunerViewModel : ViewModel() {
             "Telemetry frame=$telemetryFrameCounter " +
                 "yinHz=${"%.2f".format(yinResult.frequencyHz)} yinConf=${"%.2f".format(yinResult.confidence)} " +
                 "neuralHz=$neuralFreq neuralConf=$neuralConf neuralMs=$inferenceMs " +
-                "finalHz=${"%.2f".format(finalPitch.frequencyHz)} finalConf=${"%.2f".format(finalPitch.confidence)} " +
+                "finalHz=${"%.2f".format(arbitration.frequencyHz)} finalConf=${"%.2f".format(arbitration.confidence)} " +
                 "string=${stringMatch.stringName} cents=${"%.2f".format(cents)} status=$status " +
-                "reason=$arbitrationReason overrides=$telemetryOverrideCount",
+                "reason=${arbitration.reason} overrides=$telemetryOverrideCount",
         )
     }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/TunerArbitrationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/TunerArbitrationTest.kt
@@ -1,15 +1,18 @@
 package com.baijum.ukufretboard.viewmodel
 
+import com.baijum.ukufretboard.domain.NeuralArbitrator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Tests for the pitch arbitration helper functions in [TunerViewModel].
+ * Tests for the pitch arbitration helper functions.
  *
- * These verify semitone distance calculations and octave detection logic
- * used to arbitrate between YIN and neural pitch estimates.
+ * Semitone distance and octave detection logic now live in
+ * [NeuralArbitrator] in the shared KMP module. This test class
+ * exercises them from the Android side and verifies that the
+ * [TunerViewModel] tuning-status thresholds remain correct.
  */
 class TunerArbitrationTest {
 
@@ -17,39 +20,39 @@ class TunerArbitrationTest {
 
     @Test
     fun semitoneDistanceUnisonIsZero() {
-        assertEquals(0.0, TunerViewModel.semitoneDistance(440.0, 440.0), 0.001)
+        assertEquals(0.0, NeuralArbitrator.semitoneDistance(440.0, 440.0), 0.001)
     }
 
     @Test
     fun semitoneDistanceOctaveIsTwelve() {
-        assertEquals(12.0, TunerViewModel.semitoneDistance(440.0, 880.0), 0.01)
-        assertEquals(12.0, TunerViewModel.semitoneDistance(880.0, 440.0), 0.01)
+        assertEquals(12.0, NeuralArbitrator.semitoneDistance(440.0, 880.0), 0.01)
+        assertEquals(12.0, NeuralArbitrator.semitoneDistance(880.0, 440.0), 0.01)
     }
 
     @Test
     fun semitoneDistanceTwoOctavesIsTwentyFour() {
-        assertEquals(24.0, TunerViewModel.semitoneDistance(220.0, 880.0), 0.01)
+        assertEquals(24.0, NeuralArbitrator.semitoneDistance(220.0, 880.0), 0.01)
     }
 
     @Test
     fun semitoneDistancePerfectFifthIsSeven() {
         val a4 = 440.0
         val e5 = a4 * Math.pow(2.0, 7.0 / 12.0)
-        assertEquals(7.0, TunerViewModel.semitoneDistance(a4, e5), 0.01)
+        assertEquals(7.0, NeuralArbitrator.semitoneDistance(a4, e5), 0.01)
     }
 
     @Test
     fun semitoneDistanceZeroOrNegativeReturnsMaxValue() {
-        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(0.0, 440.0), 0.0)
-        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(440.0, 0.0), 0.0)
-        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(-1.0, 440.0), 0.0)
-        assertEquals(Double.MAX_VALUE, TunerViewModel.semitoneDistance(440.0, -1.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(0.0, 440.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(440.0, 0.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(-1.0, 440.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(440.0, -1.0), 0.0)
     }
 
     @Test
     fun semitoneDistanceIsSymmetric() {
-        val d1 = TunerViewModel.semitoneDistance(440.0, 523.25)
-        val d2 = TunerViewModel.semitoneDistance(523.25, 440.0)
+        val d1 = NeuralArbitrator.semitoneDistance(440.0, 523.25)
+        val d2 = NeuralArbitrator.semitoneDistance(523.25, 440.0)
         assertEquals(d1, d2, 0.001)
     }
 
@@ -57,37 +60,37 @@ class TunerArbitrationTest {
 
     @Test
     fun isOctaveRelationTrueForExactOctave() {
-        assertTrue(TunerViewModel.isOctaveRelation(440.0, 880.0))
-        assertTrue(TunerViewModel.isOctaveRelation(880.0, 440.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(440.0, 880.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(880.0, 440.0))
     }
 
     @Test
     fun isOctaveRelationTrueForDoubleOctave() {
-        assertTrue(TunerViewModel.isOctaveRelation(220.0, 880.0))
-        assertTrue(TunerViewModel.isOctaveRelation(880.0, 220.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(220.0, 880.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(880.0, 220.0))
     }
 
     @Test
     fun isOctaveRelationTrueWithSlightDetuning() {
         val slightlySharp = 880.0 * Math.pow(2.0, 0.8 / 12.0)
-        assertTrue(TunerViewModel.isOctaveRelation(440.0, slightlySharp))
+        assertTrue(NeuralArbitrator.isOctaveRelation(440.0, slightlySharp))
     }
 
     @Test
     fun isOctaveRelationFalseForUnison() {
-        assertFalse(TunerViewModel.isOctaveRelation(440.0, 440.0))
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, 440.0))
     }
 
     @Test
     fun isOctaveRelationFalseForFifth() {
         val e5 = 440.0 * Math.pow(2.0, 7.0 / 12.0)
-        assertFalse(TunerViewModel.isOctaveRelation(440.0, e5))
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, e5))
     }
 
     @Test
     fun isOctaveRelationFalseForZeroOrNegative() {
-        assertFalse(TunerViewModel.isOctaveRelation(0.0, 440.0))
-        assertFalse(TunerViewModel.isOctaveRelation(440.0, -1.0))
+        assertFalse(NeuralArbitrator.isOctaveRelation(0.0, 440.0))
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, -1.0))
     }
 
     // ── Tuning status thresholds ─────────────────────────────────────

--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -51,19 +51,7 @@ final class TunerViewModel: ObservableObject {
 
     // Neural pitch supervision
     private var neuralSupervisor: NeuralPitchSupervisor?
-    private var neuralFrameCounter: Int = 0
-    private var lastNeuralResult: NeuralPitchResult?
-    private var neuralResultAgeFrames: Int = Int.max
-    private var consecutiveNeuralFailures: Int = 0
-    private var neuralConsistencyFrames: Int = 0
-    private var lastNeuralFrequencyForConsistency: Double?
-
-    private static let neuralSupervisorInterval = 5
-    private static let neuralResultTTLFrames = 10
-    private static let neuralFailureThreshold = 15
-    private static let neuralConsistencyRequired = 2
-    private static let arbitrationIgnoreSemitones = 1.5
-    private static let arbitrationStrongSemitones = 2.5
+    private let neuralArbitrator = NeuralArbitrator()
 
     var noteAccessibilityLabel: String {
         if noteName == "--" { return "No note detected" }
@@ -185,18 +173,11 @@ final class TunerViewModel: ObservableObject {
             guard let self = self else { return }
 
             if let result = result {
-                // Apply arbitration between YIN and neural results
-                let finalHz: Double
-                if let neural = neuralResult {
-                    let arbitrated = self.arbitrate(
-                        yinFreq: result.frequencyHz,
-                        yinConf: result.confidence,
-                        neuralResult: neural
-                    )
-                    finalHz = arbitrated
-                } else {
-                    finalHz = result.frequencyHz
-                }
+                let arbitration = self.neuralArbitrator.arbitrate(
+                    yinResult: result,
+                    neuralResult: neuralResult
+                )
+                let finalHz = arbitration.frequencyHz
 
                 self.previousFrequency = finalHz
 
@@ -266,9 +247,8 @@ final class TunerViewModel: ObservableObject {
 
     private func maybeRunNeural(_ samples: [Float]) -> NeuralPitchResult? {
         guard let supervisor = neuralSupervisor else { return nil }
-        neuralFrameCounter += 1
 
-        if neuralFrameCounter % Self.neuralSupervisorInterval == 0 {
+        if neuralArbitrator.shouldRunInference() {
             let canRun = neuralInferenceLock.withLock { inFlight -> Bool in
                 if inFlight { return false }
                 inFlight = true
@@ -279,17 +259,12 @@ final class TunerViewModel: ObservableObject {
                     let estimate = supervisor.estimate(samples)
                     await MainActor.run { [weak self] in
                         guard let self else { return }
-                        self.lastNeuralResult = estimate
-                        self.neuralResultAgeFrames = 0
                         if let estimate = estimate {
-                            self.consecutiveNeuralFailures = 0
-                            self.updateNeuralConsistency(estimate.frequencyHz)
+                            self.neuralArbitrator.onInferenceResult(result: estimate)
                             self.neuralStatus = .active
                         } else {
-                            self.consecutiveNeuralFailures += 1
-                            self.neuralConsistencyFrames = 0
-                            self.lastNeuralFrequencyForConsistency = nil
-                            if self.consecutiveNeuralFailures >= Self.neuralFailureThreshold {
+                            let disabled = self.neuralArbitrator.onInferenceFailure()
+                            if disabled {
                                 self.neuralStatus = .fallback
                             }
                         }
@@ -297,65 +272,11 @@ final class TunerViewModel: ObservableObject {
                     self?.neuralInferenceLock.withLock { $0 = false }
                 }
             }
-        } else if neuralResultAgeFrames < Int.max {
-            neuralResultAgeFrames += 1
         }
 
-        return neuralResultAgeFrames <= Self.neuralResultTTLFrames ? lastNeuralResult : nil
+        return neuralArbitrator.currentResult()
     }
 
-    private func arbitrate(yinFreq: Double, yinConf: Double, neuralResult: NeuralPitchResult) -> Double {
-        let semitoneGap = semitoneDistance(yinFreq, neuralResult.frequencyHz)
-
-        if semitoneGap <= Self.arbitrationIgnoreSemitones {
-            return yinFreq
-        }
-
-        if neuralConsistencyFrames < Self.neuralConsistencyRequired {
-            return yinFreq
-        }
-
-        if isOctaveRelation(yinFreq, neuralResult.frequencyHz)
-            && neuralResult.confidence >= 0.85
-            && yinConf >= 0.12 {
-            return neuralResult.frequencyHz
-        }
-
-        if semitoneGap >= Self.arbitrationStrongSemitones
-            && neuralResult.confidence >= 0.93
-            && yinConf >= 0.16 {
-            return neuralResult.frequencyHz
-        }
-
-        return yinFreq
-    }
-
-    private func semitoneDistance(_ aHz: Double, _ bHz: Double) -> Double {
-        guard aHz > 0, bHz > 0 else { return Double.greatestFiniteMagnitude }
-        return abs(12.0 * log2(aHz / bHz))
-    }
-
-    private func isOctaveRelation(_ aHz: Double, _ bHz: Double) -> Bool {
-        guard aHz > 0, bHz > 0 else { return false }
-        let semitones = semitoneDistance(aHz, bHz)
-        return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
-    }
-
-    private func updateNeuralConsistency(_ neuralFrequencyHz: Double) {
-        guard neuralFrequencyHz > 0 else {
-            neuralConsistencyFrames = 0
-            lastNeuralFrequencyForConsistency = nil
-            return
-        }
-
-        if let previous = lastNeuralFrequencyForConsistency,
-           semitoneDistance(previous, neuralFrequencyHz) <= 0.5 {
-            neuralConsistencyFrames += 1
-        } else {
-            neuralConsistencyFrames = 1
-        }
-        lastNeuralFrequencyForConsistency = neuralFrequencyHz
-    }
 
     // MARK: - Spoken Feedback
 
@@ -415,5 +336,6 @@ final class TunerViewModel: ObservableObject {
         activeStringIndex = nil
         settledFrames = 0
         isInTune = false
+        neuralArbitrator.reset()
     }
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
@@ -1,0 +1,259 @@
+package com.baijum.ukufretboard.domain
+
+import kotlin.math.abs
+import kotlin.math.log2
+
+/**
+ * Result of the YIN-vs-neural pitch arbitration.
+ *
+ * [frequencyHz] and [confidence] represent the final pitch to use.
+ * When neural overrides YIN, [frequencyHz] comes from neural while
+ * [confidence] is always the YIN confidence (since YIN confidence is
+ * a well-calibrated quality metric).
+ */
+data class ArbitrationResult(
+    val frequencyHz: Double,
+    val confidence: Double,
+    val source: PitchSource,
+    val reason: String,
+) {
+    val overrideApplied: Boolean get() = source == PitchSource.NEURAL
+}
+
+enum class PitchSource { YIN, NEURAL }
+
+/**
+ * Encapsulates the neural-vs-YIN pitch arbitration state machine.
+ *
+ * Both the Android and iOS tuners run a primary YIN pitch detector on
+ * every frame and a heavier neural (ONNX) estimator at a lower cadence.
+ * This class owns the frame-interval gating, result-TTL aging, failure
+ * tracking, consistency window, and the final arbitration decision. It
+ * contains **no platform dependencies** — audio capture, ONNX calls,
+ * and UI updates remain in the platform ViewModels.
+ *
+ * Typical per-frame flow:
+ * ```
+ * if (arbitrator.shouldRunInference()) {
+ *     val estimate = supervisor.estimate(samples)   // platform
+ *     if (estimate != null) arbitrator.onInferenceResult(estimate)
+ *     else arbitrator.onInferenceFailure()
+ * }
+ * val neuralResult = arbitrator.currentResult()
+ * val decision = arbitrator.arbitrate(yinResult, neuralResult)
+ * ```
+ */
+class NeuralArbitrator {
+
+    companion object {
+        /** Run neural inference every N audio frames. */
+        const val SUPERVISOR_INTERVAL = 5
+
+        /** Neural result expires after this many frames without refresh. */
+        const val RESULT_TTL_FRAMES = 10
+
+        /** Consecutive inference failures before disabling neural. */
+        const val FAILURE_THRESHOLD = 15
+
+        /** Ignore YIN-vs-neural gaps smaller than this (semitones). */
+        const val ARBITRATION_IGNORE_SEMITONES = 1.5
+
+        /** Strong-disagreement threshold for non-octave correction (semitones). */
+        const val ARBITRATION_STRONG_SEMITONES = 2.5
+
+        /** Required consecutive similar neural readings before override. */
+        const val CONSISTENCY_FRAMES = 2
+
+        fun semitoneDistance(aHz: Double, bHz: Double): Double {
+            if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
+            return abs(12.0 * log2(aHz / bHz))
+        }
+
+        fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
+            if (aHz <= 0.0 || bHz <= 0.0) return false
+            val semitones = semitoneDistance(aHz, bHz)
+            return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
+        }
+    }
+
+    // --- State ---------------------------------------------------------------
+
+    private var frameCounter = 0
+    private var lastResult: NeuralPitchResult? = null
+    private var resultAgeFrames = Int.MAX_VALUE
+    private var consecutiveFailures = 0
+    private var lastFrequencyForConsistency: Double? = null
+    private var consistencyFrames = 0
+
+    /** True when [FAILURE_THRESHOLD] consecutive failures have occurred. */
+    val isDisabledByFailures: Boolean
+        get() = consecutiveFailures >= FAILURE_THRESHOLD
+
+    // --- Frame-interval gating -----------------------------------------------
+
+    /**
+     * Advances the frame counter and returns `true` every [SUPERVISOR_INTERVAL]
+     * frames, signalling the caller to run neural inference.
+     *
+     * On non-inference frames the neural result TTL is aged automatically.
+     */
+    fun shouldRunInference(): Boolean {
+        frameCounter++
+        if (frameCounter % SUPERVISOR_INTERVAL == 0) {
+            return true
+        }
+        if (resultAgeFrames < Int.MAX_VALUE) {
+            resultAgeFrames++
+        }
+        return false
+    }
+
+    // --- Inference result callbacks ------------------------------------------
+
+    /**
+     * Records a successful neural inference result.
+     * Resets the failure counter and updates the consistency window.
+     */
+    fun onInferenceResult(result: NeuralPitchResult) {
+        lastResult = result
+        resultAgeFrames = 0
+        consecutiveFailures = 0
+        updateConsistency(result.frequencyHz)
+    }
+
+    /**
+     * Records a failed neural inference (supervisor returned null).
+     * Resets the consistency window.
+     *
+     * @return `true` if the failure threshold has been reached and neural
+     *         should be marked as disabled/fallback.
+     */
+    fun onInferenceFailure(): Boolean {
+        lastResult = null
+        resultAgeFrames = 0
+        consecutiveFailures++
+        consistencyFrames = 0
+        lastFrequencyForConsistency = null
+        return isDisabledByFailures
+    }
+
+    // --- Result access -------------------------------------------------------
+
+    /**
+     * Returns the most recent neural result if it is still within the
+     * [RESULT_TTL_FRAMES] window, or `null` if stale / unavailable.
+     */
+    fun currentResult(): NeuralPitchResult? {
+        return if (resultAgeFrames <= RESULT_TTL_FRAMES) lastResult else null
+    }
+
+    // --- Arbitration ---------------------------------------------------------
+
+    /**
+     * Decides the final pitch from the YIN result and an optional neural result.
+     *
+     * Decision cascade:
+     * 1. No neural result → use YIN.
+     * 2. Gap ≤ [ARBITRATION_IGNORE_SEMITONES] → use YIN (close enough).
+     * 3. Neural not yet consistent → use YIN.
+     * 4. Octave relation with neural confidence ≥ 0.85 → correct to neural Hz.
+     * 5. Strong disagreement (≥ [ARBITRATION_STRONG_SEMITONES]) with neural
+     *    confidence ≥ 0.93 → override with neural Hz.
+     * 6. Otherwise → use YIN.
+     */
+    fun arbitrate(
+        yinResult: PitchResult,
+        neuralResult: NeuralPitchResult?,
+    ): ArbitrationResult {
+        if (neuralResult == null) {
+            return ArbitrationResult(
+                frequencyHz = yinResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.YIN,
+                reason = "no_neural",
+            )
+        }
+
+        val semitoneGap = semitoneDistance(yinResult.frequencyHz, neuralResult.frequencyHz)
+        if (semitoneGap <= ARBITRATION_IGNORE_SEMITONES) {
+            return ArbitrationResult(
+                frequencyHz = yinResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.YIN,
+                reason = "small_gap",
+            )
+        }
+
+        if (consistencyFrames < CONSISTENCY_FRAMES) {
+            return ArbitrationResult(
+                frequencyHz = yinResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.YIN,
+                reason = "neural_inconsistent",
+            )
+        }
+
+        if (isOctaveRelation(yinResult.frequencyHz, neuralResult.frequencyHz) &&
+            neuralResult.confidence >= 0.85 &&
+            yinResult.confidence >= 0.12
+        ) {
+            return ArbitrationResult(
+                frequencyHz = neuralResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.NEURAL,
+                reason = "octave_correction",
+            )
+        }
+
+        return if (semitoneGap >= ARBITRATION_STRONG_SEMITONES &&
+            neuralResult.confidence >= 0.93 &&
+            yinResult.confidence >= 0.16
+        ) {
+            ArbitrationResult(
+                frequencyHz = neuralResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.NEURAL,
+                reason = "strong_disagreement",
+            )
+        } else {
+            ArbitrationResult(
+                frequencyHz = yinResult.frequencyHz,
+                confidence = yinResult.confidence,
+                source = PitchSource.YIN,
+                reason = "keep_yin",
+            )
+        }
+    }
+
+    // --- Reset ---------------------------------------------------------------
+
+    /** Resets all state. Call when the tuner starts or restarts. */
+    fun reset() {
+        frameCounter = 0
+        lastResult = null
+        resultAgeFrames = Int.MAX_VALUE
+        consecutiveFailures = 0
+        lastFrequencyForConsistency = null
+        consistencyFrames = 0
+    }
+
+    // --- Internal ------------------------------------------------------------
+
+    private fun updateConsistency(neuralFrequencyHz: Double) {
+        if (neuralFrequencyHz <= 0.0) {
+            consistencyFrames = 0
+            lastFrequencyForConsistency = null
+            return
+        }
+
+        val previous = lastFrequencyForConsistency
+        consistencyFrames = if (previous != null &&
+            semitoneDistance(previous, neuralFrequencyHz) <= 0.5
+        ) {
+            consistencyFrames + 1
+        } else {
+            1
+        }
+        lastFrequencyForConsistency = neuralFrequencyHz
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NeuralArbitratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NeuralArbitratorTest.kt
@@ -1,0 +1,400 @@
+package com.baijum.ukufretboard.domain
+
+import kotlin.math.pow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NeuralArbitratorTest {
+
+    // ── shouldRunInference (frame-interval gating) ──────────────────
+
+    @Test
+    fun shouldRunInferenceReturnsTrueEveryIntervalFrames() {
+        val arb = NeuralArbitrator()
+        val results = (1..20).map { arb.shouldRunInference() }
+        val trueIndices = results.mapIndexedNotNull { i, v -> if (v) i else null }
+        assertEquals(
+            listOf(4, 9, 14, 19),
+            trueIndices,
+            "shouldRunInference should be true at frames 5, 10, 15, 20 (0-indexed 4,9,14,19)",
+        )
+    }
+
+    @Test
+    fun shouldRunInferenceFirstFrameIsNotInference() {
+        val arb = NeuralArbitrator()
+        assertFalse(arb.shouldRunInference(), "frame 1 should not trigger inference")
+    }
+
+    // ── Result TTL aging ────────────────────────────────────────────
+
+    @Test
+    fun currentResultReturnsNullInitially() {
+        val arb = NeuralArbitrator()
+        assertNull(arb.currentResult())
+    }
+
+    @Test
+    fun currentResultReturnsResultWithinTTL() {
+        val arb = NeuralArbitrator()
+        val result = NeuralPitchResult(frequencyHz = 440.0, confidence = 0.9)
+
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(result)
+
+        assertNotNull(arb.currentResult())
+        assertEquals(440.0, arb.currentResult()!!.frequencyHz)
+    }
+
+    @Test
+    fun currentResultExpiresAfterTTLFrames() {
+        val arb = NeuralArbitrator()
+        val result = NeuralPitchResult(frequencyHz = 440.0, confidence = 0.9)
+
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(result)
+
+        // Only non-inference frames age the result. Advance enough frames
+        // (skipping inference frames that return true) to exceed the TTL.
+        var aged = 0
+        while (aged <= NeuralArbitrator.RESULT_TTL_FRAMES) {
+            assertNotNull(arb.currentResult(), "result should still be valid at age $aged")
+            val isInference = arb.shouldRunInference()
+            if (!isInference) aged++
+        }
+        assertNull(arb.currentResult(), "result should be expired after TTL")
+    }
+
+    // ── Failure threshold ───────────────────────────────────────────
+
+    @Test
+    fun isDisabledByFailuresAfterThreshold() {
+        val arb = NeuralArbitrator()
+        assertFalse(arb.isDisabledByFailures)
+
+        repeat(NeuralArbitrator.FAILURE_THRESHOLD - 1) {
+            arb.onInferenceFailure()
+            assertFalse(arb.isDisabledByFailures, "should not be disabled after ${it + 1} failures")
+        }
+
+        arb.onInferenceFailure()
+        assertTrue(arb.isDisabledByFailures, "should be disabled after ${NeuralArbitrator.FAILURE_THRESHOLD} failures")
+    }
+
+    @Test
+    fun successfulInferenceResetsFailureCount() {
+        val arb = NeuralArbitrator()
+        repeat(NeuralArbitrator.FAILURE_THRESHOLD - 1) { arb.onInferenceFailure() }
+        assertFalse(arb.isDisabledByFailures)
+
+        arb.onInferenceResult(NeuralPitchResult(frequencyHz = 440.0, confidence = 0.9))
+        assertFalse(arb.isDisabledByFailures)
+
+        repeat(NeuralArbitrator.FAILURE_THRESHOLD - 1) { arb.onInferenceFailure() }
+        assertFalse(arb.isDisabledByFailures, "counter should have been reset by successful result")
+    }
+
+    @Test
+    fun onInferenceFailureReturnsTrueAtThreshold() {
+        val arb = NeuralArbitrator()
+        repeat(NeuralArbitrator.FAILURE_THRESHOLD - 1) {
+            assertFalse(arb.onInferenceFailure())
+        }
+        assertTrue(arb.onInferenceFailure())
+    }
+
+    // ── Consistency window ──────────────────────────────────────────
+
+    @Test
+    fun arbitrateRejectsNeuralBeforeConsistencyWindow() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.15)
+        val neural = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.95)
+
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source)
+        assertEquals("neural_inconsistent", decision.reason)
+    }
+
+    @Test
+    fun arbitrateAcceptsNeuralAfterConsistencyWindow() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.2)
+        val neural = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.95)
+
+        repeat(NeuralArbitrator.CONSISTENCY_FRAMES) {
+            advanceToInferenceFrame(arb)
+            arb.onInferenceResult(neural)
+        }
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.NEURAL, decision.source)
+        assertEquals("strong_disagreement", decision.reason)
+    }
+
+    @Test
+    fun consistencyResetsByDivergentReading() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.2)
+        val neural1 = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.95)
+        val neural2 = NeuralPitchResult(frequencyHz = 330.0, confidence = 0.95)
+
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(neural1)
+
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(neural2)
+
+        val decision = arb.arbitrate(yin, neural2)
+        assertEquals(PitchSource.YIN, decision.source, "divergent reading should reset consistency")
+    }
+
+    // ── Octave correction ───────────────────────────────────────────
+
+    @Test
+    fun arbitrateAppliesOctaveCorrectionWhenConfident() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.15)
+        val neural = NeuralPitchResult(frequencyHz = 880.0, confidence = 0.90)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.NEURAL, decision.source)
+        assertEquals("octave_correction", decision.reason)
+        assertEquals(880.0, decision.frequencyHz)
+        assertEquals(0.15, decision.confidence, "confidence should come from YIN")
+    }
+
+    @Test
+    fun arbitrateSkipsOctaveCorrectionWhenNeuralConfidenceLow() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.15)
+        val neural = NeuralPitchResult(frequencyHz = 880.0, confidence = 0.80)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source, "neural conf 0.80 < 0.85 threshold")
+    }
+
+    @Test
+    fun arbitrateSkipsOctaveCorrectionWhenYinConfidenceTooLow() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.10)
+        val neural = NeuralPitchResult(frequencyHz = 880.0, confidence = 0.90)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source, "yin conf 0.10 < 0.12 threshold")
+    }
+
+    @Test
+    fun arbitrateHandlesDoubleOctave() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 220.0, confidence = 0.15)
+        val neural = NeuralPitchResult(frequencyHz = 880.0, confidence = 0.90)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals("octave_correction", decision.reason)
+        assertEquals(880.0, decision.frequencyHz)
+    }
+
+    // ── Strong disagreement override ────────────────────────────────
+
+    @Test
+    fun arbitrateOverridesOnStrongDisagreement() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.2)
+        val neural = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.95)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.NEURAL, decision.source)
+        assertEquals("strong_disagreement", decision.reason)
+        assertEquals(660.0, decision.frequencyHz)
+        assertEquals(0.2, decision.confidence, "confidence should come from YIN")
+    }
+
+    @Test
+    fun arbitrateKeepsYinWhenNeuralConfidenceBelowStrongThreshold() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.2)
+        val neural = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.90)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source, "neural conf 0.90 < 0.93 threshold")
+        assertEquals("keep_yin", decision.reason)
+    }
+
+    @Test
+    fun arbitrateKeepsYinWhenYinConfidenceBelowStrongThreshold() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.14)
+        val neural = NeuralPitchResult(frequencyHz = 660.0, confidence = 0.95)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source, "yin conf 0.14 < 0.16 threshold")
+    }
+
+    // ── Small gap (no override needed) ──────────────────────────────
+
+    @Test
+    fun arbitrateKeepsYinWhenGapIsSmall() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.15)
+        val detuned = 440.0 * 2.0.pow(1.0 / 12.0)
+        val neural = NeuralPitchResult(frequencyHz = detuned, confidence = 0.95)
+
+        buildConsistency(arb, neural)
+
+        val decision = arb.arbitrate(yin, neural)
+        assertEquals(PitchSource.YIN, decision.source)
+        assertEquals("small_gap", decision.reason)
+    }
+
+    // ── No neural result ────────────────────────────────────────────
+
+    @Test
+    fun arbitrateReturnsYinWhenNoNeural() {
+        val arb = NeuralArbitrator()
+        val yin = PitchResult(frequencyHz = 440.0, confidence = 0.15)
+
+        val decision = arb.arbitrate(yin, null)
+        assertEquals(PitchSource.YIN, decision.source)
+        assertEquals("no_neural", decision.reason)
+        assertEquals(440.0, decision.frequencyHz)
+        assertFalse(decision.overrideApplied)
+    }
+
+    // ── Reset ────────────────────────────────────────────────────────
+
+    @Test
+    fun resetClearsAllState() {
+        val arb = NeuralArbitrator()
+        val neural = NeuralPitchResult(frequencyHz = 440.0, confidence = 0.9)
+
+        repeat(10) { arb.shouldRunInference() }
+        advanceToInferenceFrame(arb)
+        arb.onInferenceResult(neural)
+        repeat(5) { arb.onInferenceFailure() }
+
+        arb.reset()
+
+        assertNull(arb.currentResult(), "result should be null after reset")
+        assertFalse(arb.isDisabledByFailures, "failures should be cleared after reset")
+
+        val firstInference = (1..NeuralArbitrator.SUPERVISOR_INTERVAL).map {
+            arb.shouldRunInference()
+        }
+        assertEquals(
+            NeuralArbitrator.SUPERVISOR_INTERVAL - 1,
+            firstInference.count { !it },
+            "frame counter should restart from 0 after reset",
+        )
+    }
+
+    // ── semitoneDistance ─────────────────────────────────────────────
+
+    @Test
+    fun semitoneDistanceUnisonIsZero() {
+        assertEquals(0.0, NeuralArbitrator.semitoneDistance(440.0, 440.0), 0.001)
+    }
+
+    @Test
+    fun semitoneDistanceOctaveIsTwelve() {
+        assertEquals(12.0, NeuralArbitrator.semitoneDistance(440.0, 880.0), 0.01)
+        assertEquals(12.0, NeuralArbitrator.semitoneDistance(880.0, 440.0), 0.01)
+    }
+
+    @Test
+    fun semitoneDistanceTwoOctavesIsTwentyFour() {
+        assertEquals(24.0, NeuralArbitrator.semitoneDistance(220.0, 880.0), 0.01)
+    }
+
+    @Test
+    fun semitoneDistancePerfectFifthIsSeven() {
+        val a4 = 440.0
+        val e5 = a4 * 2.0.pow(7.0 / 12.0)
+        assertEquals(7.0, NeuralArbitrator.semitoneDistance(a4, e5), 0.01)
+    }
+
+    @Test
+    fun semitoneDistanceZeroOrNegativeReturnsMaxValue() {
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(0.0, 440.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(440.0, 0.0), 0.0)
+        assertEquals(Double.MAX_VALUE, NeuralArbitrator.semitoneDistance(-1.0, 440.0), 0.0)
+    }
+
+    @Test
+    fun semitoneDistanceIsSymmetric() {
+        val d1 = NeuralArbitrator.semitoneDistance(440.0, 523.25)
+        val d2 = NeuralArbitrator.semitoneDistance(523.25, 440.0)
+        assertEquals(d1, d2, 0.001)
+    }
+
+    // ── isOctaveRelation ────────────────────────────────────────────
+
+    @Test
+    fun isOctaveRelationTrueForExactOctave() {
+        assertTrue(NeuralArbitrator.isOctaveRelation(440.0, 880.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(880.0, 440.0))
+    }
+
+    @Test
+    fun isOctaveRelationTrueForDoubleOctave() {
+        assertTrue(NeuralArbitrator.isOctaveRelation(220.0, 880.0))
+        assertTrue(NeuralArbitrator.isOctaveRelation(880.0, 220.0))
+    }
+
+    @Test
+    fun isOctaveRelationTrueWithSlightDetuning() {
+        val slightlySharp = 880.0 * 2.0.pow(0.8 / 12.0)
+        assertTrue(NeuralArbitrator.isOctaveRelation(440.0, slightlySharp))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForUnison() {
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, 440.0))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForFifth() {
+        val e5 = 440.0 * 2.0.pow(7.0 / 12.0)
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, e5))
+    }
+
+    @Test
+    fun isOctaveRelationFalseForZeroOrNegative() {
+        assertFalse(NeuralArbitrator.isOctaveRelation(0.0, 440.0))
+        assertFalse(NeuralArbitrator.isOctaveRelation(440.0, -1.0))
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private fun advanceToInferenceFrame(arb: NeuralArbitrator) {
+        while (!arb.shouldRunInference()) { /* advance */ }
+    }
+
+    private fun buildConsistency(arb: NeuralArbitrator, neural: NeuralPitchResult) {
+        repeat(NeuralArbitrator.CONSISTENCY_FRAMES) {
+            advanceToInferenceFrame(arb)
+            arb.onInferenceResult(neural)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Create shared `NeuralArbitrator` class with the 4 tuning constants and all decision methods
- Add comprehensive commonTest: TTL expiry, consistency window, failure threshold, octave correction at conf >= 0.85, strong-disagreement at conf >= 0.93
- Migrate Android TunerViewModel to delegate arbitration to the shared class
- Migrate iOS TunerViewModel to delegate arbitration to the shared class
- ~150 duplicated lines removed per platform

## Test plan

- [ ] Shared module tests pass
- [ ] Android builds and tuner works normally
- [ ] iOS builds and tuner works normally
- [ ] In-tune detection, note mapping, and string matching unchanged

Fixes #285

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined pitch detection arbitration between YIN and neural analysis for more stable tuning results
  * Enhanced confidence tracking for improved pitch recognition accuracy

* **Refactor**
  * Centralized pitch arbitration logic into a shared module for consistent behavior across iOS and Android platforms
  * Streamlined neural inference handling for better maintainability and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->