### PR TITLE
Refactor: extract iOS repository layer from ViewModels (fixes #289)

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -82,6 +82,16 @@
 		A10068 /* ScaleSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10068 /* ScaleSelectorView.swift */; };
 		A10069 /* PlayAlongViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10069 /* PlayAlongViewModel.swift */; };
 		A10200 /* TunerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10200 /* TunerViewModel.swift */; };
+		A10301 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10301 /* SettingsRepository.swift */; };
+		A10302 /* FavoritesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10302 /* FavoritesRepository.swift */; };
+		A10303 /* SetlistRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10303 /* SetlistRepository.swift */; };
+		A10304 /* SongbookRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10304 /* SongbookRepository.swift */; };
+		A10305 /* MelodyRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10305 /* MelodyRepository.swift */; };
+		A10306 /* ProgressionsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10306 /* ProgressionsRepository.swift */; };
+		A10307 /* LearnRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10307 /* LearnRepository.swift */; };
+		A10308 /* CustomPatternsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10308 /* CustomPatternsRepository.swift */; };
+		A10309 /* PracticeTimerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10309 /* PracticeTimerRepository.swift */; };
+		A10310 /* ScalePracticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10310 /* ScalePracticeRepository.swift */; };
 		A10070 /* PatternPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10070 /* PatternPlayer.swift */; };
 		A10071 /* FullScreenFretboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10071 /* FullScreenFretboardView.swift */; };
 		A10072 /* PracticeTimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10072 /* PracticeTimerViewModelTests.swift */; };
@@ -232,6 +242,16 @@
 		B10068 /* ScaleSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleSelectorView.swift; sourceTree = "<group>"; };
 		B10069 /* PlayAlongViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAlongViewModel.swift; sourceTree = "<group>"; };
 		B10200 /* TunerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunerViewModel.swift; sourceTree = "<group>"; };
+		B10301 /* SettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRepository.swift; sourceTree = "<group>"; };
+		B10302 /* FavoritesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesRepository.swift; sourceTree = "<group>"; };
+		B10303 /* SetlistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetlistRepository.swift; sourceTree = "<group>"; };
+		B10304 /* SongbookRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongbookRepository.swift; sourceTree = "<group>"; };
+		B10305 /* MelodyRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelodyRepository.swift; sourceTree = "<group>"; };
+		B10306 /* ProgressionsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressionsRepository.swift; sourceTree = "<group>"; };
+		B10307 /* LearnRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearnRepository.swift; sourceTree = "<group>"; };
+		B10308 /* CustomPatternsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPatternsRepository.swift; sourceTree = "<group>"; };
+		B10309 /* PracticeTimerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerRepository.swift; sourceTree = "<group>"; };
+		B10310 /* ScalePracticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalePracticeRepository.swift; sourceTree = "<group>"; };
 		B10070 /* PatternPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternPlayer.swift; sourceTree = "<group>"; };
 		B10071 /* FullScreenFretboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenFretboardView.swift; sourceTree = "<group>"; };
 		B10072 /* PracticeTimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerViewModelTests.swift; sourceTree = "<group>"; };
@@ -340,6 +360,7 @@
 				G20001 /* Audio */,
 				G30001 /* Views */,
 				G70001 /* ViewModels */,
+				G90002 /* Repositories */,
 				G80001 /* Helpers */,
 				G40001 /* Resources */,
 				B30001 /* Assets.xcassets */,
@@ -481,6 +502,23 @@
 				B10200 /* TunerViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		G90002 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				B10301 /* SettingsRepository.swift */,
+				B10302 /* FavoritesRepository.swift */,
+				B10303 /* SetlistRepository.swift */,
+				B10304 /* SongbookRepository.swift */,
+				B10305 /* MelodyRepository.swift */,
+				B10306 /* ProgressionsRepository.swift */,
+				B10307 /* LearnRepository.swift */,
+				B10308 /* CustomPatternsRepository.swift */,
+				B10309 /* PracticeTimerRepository.swift */,
+				B10310 /* ScalePracticeRepository.swift */,
+			);
+			path = Repositories;
 			sourceTree = "<group>";
 		};
 		G80001 /* Helpers */ = {
@@ -762,6 +800,16 @@
 				A10070 /* PatternPlayer.swift in Sources */,
 				A10071 /* FullScreenFretboardView.swift in Sources */,
 				A10080 /* SongwriterModeFlow.swift in Sources */,
+				A10301 /* SettingsRepository.swift in Sources */,
+				A10302 /* FavoritesRepository.swift in Sources */,
+				A10303 /* SetlistRepository.swift in Sources */,
+				A10304 /* SongbookRepository.swift in Sources */,
+				A10305 /* MelodyRepository.swift in Sources */,
+				A10306 /* ProgressionsRepository.swift in Sources */,
+				A10307 /* LearnRepository.swift in Sources */,
+				A10308 /* CustomPatternsRepository.swift in Sources */,
+				A10309 /* PracticeTimerRepository.swift in Sources */,
+				A10310 /* ScalePracticeRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -28,6 +28,16 @@ enum BackupError: LocalizedError {
 final class BackupRestoreManager: ObservableObject {
     @Published var lastBackupDate: String?
 
+    private let favoritesRepo: FavoritesRepository
+    private let songbookRepo: SongbookRepository
+    private let melodyRepo: MelodyRepository
+    private let progressionsRepo: ProgressionsRepository
+    private let learnRepo: LearnRepository
+    private let practiceTimerRepo: PracticeTimerRepository
+    private let customPatternsRepo: CustomPatternsRepository
+    private let setlistRepo: SetlistRepository
+    private let settingsRepo: SettingsRepository
+
     private let favoritesVM: FavoritesViewModel
     private let songbookVM: SongbookViewModel
     private let melodyVM: MelodyViewModel
@@ -58,6 +68,16 @@ final class BackupRestoreManager: ObservableObject {
         self.customPatternsVM = customPatternsVM
         self.setlistVM = setlistVM
         self.settingsVM = settingsVM
+
+        self.favoritesRepo = FavoritesRepository()
+        self.songbookRepo = SongbookRepository()
+        self.melodyRepo = MelodyRepository()
+        self.progressionsRepo = ProgressionsRepository()
+        self.learnRepo = LearnRepository()
+        self.practiceTimerRepo = PracticeTimerRepository()
+        self.customPatternsRepo = CustomPatternsRepository()
+        self.setlistRepo = SetlistRepository()
+        self.settingsRepo = SettingsRepository()
     }
 
     // MARK: - Export (KMP-compatible format)

--- a/iosApp/UkuleleCompanion/Repositories/CustomPatternsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/CustomPatternsRepository.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+final class CustomPatternsRepository {
+    private let strumKey = "custom_strum_patterns"
+    private let fingerpickKey = "custom_fingerpicking_patterns"
+
+    // MARK: - Strum Patterns
+
+    func getAllStrum() -> [CustomStrumPatternData] {
+        guard let data = UserDefaults.standard.data(forKey: strumKey),
+              let decoded = try? JSONDecoder().decode([CustomStrumPatternData].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func saveStrum(_ patterns: [CustomStrumPatternData]) {
+        guard let data = try? JSONEncoder().encode(patterns) else { return }
+        UserDefaults.standard.set(data, forKey: strumKey)
+    }
+
+    // MARK: - Fingerpicking Patterns
+
+    func getAllFingerpicking() -> [CustomFingerpickingData] {
+        guard let data = UserDefaults.standard.data(forKey: fingerpickKey),
+              let decoded = try? JSONDecoder().decode([CustomFingerpickingData].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func saveFingerpicking(_ patterns: [CustomFingerpickingData]) {
+        guard let data = try? JSONEncoder().encode(patterns) else { return }
+        UserDefaults.standard.set(data, forKey: fingerpickKey)
+    }
+
+    // MARK: - Export/Import
+
+    func exportStrumData(_ patterns: [CustomStrumPatternData]) -> [[String: Any]] {
+        patterns.map { p in
+            [
+                "id": p.id,
+                "name": p.name,
+                "beats": p.beats.map { ["direction": $0.direction, "emphasis": $0.emphasis] },
+                "createdAt": p.createdAt,
+                "timeSignature": p.timeSignature,
+            ]
+        }
+    }
+
+    func importStrumData(_ items: [[String: Any]], into patterns: inout [CustomStrumPatternData]) {
+        let existingIds = Set(patterns.map(\.id))
+        for dict in items {
+            guard let id = dict["id"] as? String,
+                  !existingIds.contains(id),
+                  let name = dict["name"] as? String,
+                  let beatDicts = dict["beats"] as? [[String: Any]],
+                  let rawCreatedAt = dict["createdAt"] as? Double
+            else { continue }
+            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
+            let timeSignature = dict["timeSignature"] as? String ?? "4/4"
+            let beats = beatDicts.compactMap { bd -> StrumBeatData? in
+                guard let dir = bd["direction"] as? String,
+                      let emph = bd["emphasis"] as? Bool
+                else { return nil }
+                return StrumBeatData(direction: dir, emphasis: emph)
+            }
+            patterns.append(CustomStrumPatternData(
+                id: id, name: name, beats: beats, createdAt: createdAt, timeSignature: timeSignature))
+        }
+        saveStrum(patterns)
+    }
+
+    func exportFingerpickData(_ patterns: [CustomFingerpickingData]) -> [[String: Any]] {
+        patterns.map { p in
+            [
+                "id": p.id,
+                "name": p.name,
+                "steps": p.steps.map { ["finger": $0.finger, "stringIndex": $0.stringIndex, "emphasis": $0.emphasis] as [String: Any] },
+                "createdAt": p.createdAt,
+                "timeSignature": p.timeSignature,
+            ]
+        }
+    }
+
+    func importFingerpickData(_ items: [[String: Any]], into patterns: inout [CustomFingerpickingData]) {
+        let existingIds = Set(patterns.map(\.id))
+        for dict in items {
+            guard let id = dict["id"] as? String,
+                  !existingIds.contains(id),
+                  let name = dict["name"] as? String,
+                  let stepDicts = dict["steps"] as? [[String: Any]],
+                  let rawCreatedAt = dict["createdAt"] as? Double
+            else { continue }
+            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
+            let timeSignature = dict["timeSignature"] as? String ?? "4/4"
+            let steps = stepDicts.compactMap { sd -> FingerpickStepData? in
+                guard let finger = sd["finger"] as? String,
+                      let strIdx = sd["stringIndex"] as? Int,
+                      (0...3).contains(strIdx),
+                      let emph = sd["emphasis"] as? Bool
+                else { return nil }
+                return FingerpickStepData(finger: finger, stringIndex: strIdx, emphasis: emph)
+            }
+            guard !steps.isEmpty else { continue }
+            patterns.append(CustomFingerpickingData(
+                id: id, name: name, steps: steps, createdAt: createdAt, timeSignature: timeSignature))
+        }
+        saveFingerpicking(patterns)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/FavoritesRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/FavoritesRepository.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+final class FavoritesRepository {
+    private let favoritesKey = "favorite_voicings"
+    private let foldersKey = "favorite_folders"
+
+    func getAll() -> [FavoriteVoicingData] {
+        guard let data = UserDefaults.standard.data(forKey: favoritesKey),
+              let decoded = try? JSONDecoder().decode([FavoriteVoicingData].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ favorites: [FavoriteVoicingData]) {
+        guard let data = try? JSONEncoder().encode(favorites) else { return }
+        UserDefaults.standard.set(data, forKey: favoritesKey)
+    }
+
+    func getAllFolders() -> [FavoriteFolderData] {
+        guard let data = UserDefaults.standard.data(forKey: foldersKey),
+              let decoded = try? JSONDecoder().decode([FavoriteFolderData].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func saveFolders(_ folders: [FavoriteFolderData]) {
+        guard let data = try? JSONEncoder().encode(folders) else { return }
+        UserDefaults.standard.set(data, forKey: foldersKey)
+    }
+
+    func exportData(favorites: [FavoriteVoicingData], folders: [FavoriteFolderData]) -> (favorites: [[String: Any]], folders: [[String: Any]]) {
+        let favDicts: [[String: Any]] = favorites.map { f in
+            ["rootPitchClass": f.rootPitchClass, "chordSymbol": f.chordSymbol,
+             "frets": f.frets, "addedAt": f.addedAt, "folderIds": f.folderIds]
+        }
+        let folderDicts: [[String: Any]] = folders.map { f in
+            ["id": f.id, "name": f.name, "createdAt": f.createdAt,
+             "voicingOrder": f.voicingOrder]
+        }
+        return (favDicts, folderDicts)
+    }
+
+    func importData(favorites: [[String: Any]], folders: [[String: Any]],
+                    existing: inout [FavoriteVoicingData], existingFolders: inout [FavoriteFolderData]) {
+        for dict in favorites {
+            guard let rpc = dict["rootPitchClass"] as? Int,
+                  (0...11).contains(rpc),
+                  let sym = dict["chordSymbol"] as? String,
+                  let frets = dict["frets"] as? [Int],
+                  let addedAt = dict["addedAt"] as? Double
+            else { continue }
+            let folderIds = dict["folderIds"] as? [String] ?? []
+            let fav = FavoriteVoicingData(rootPitchClass: rpc, chordSymbol: sym,
+                                          frets: frets, addedAt: addedAt, folderIds: folderIds)
+            if !existing.contains(where: { $0.key == fav.key }) {
+                existing.append(fav)
+            }
+        }
+        for dict in folders {
+            guard let id = dict["id"] as? String,
+                  let name = dict["name"] as? String,
+                  let createdAt = dict["createdAt"] as? Double
+            else { continue }
+            let order = dict["voicingOrder"] as? [String] ?? []
+            if !existingFolders.contains(where: { $0.id == id }) {
+                existingFolders.append(FavoriteFolderData(id: id, name: name,
+                                                           createdAt: createdAt, voicingOrder: order))
+            }
+        }
+        save(existing)
+        saveFolders(existingFolders)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/LearnRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/LearnRepository.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+final class LearnRepository {
+    private let defaults: UserDefaults
+
+    init() {
+        self.defaults = UserDefaults(suiteName: "learn_progress") ?? .standard
+    }
+
+    // MARK: - Primitive accessors
+
+    func bool(forKey key: String) -> Bool {
+        defaults.bool(forKey: key)
+    }
+
+    func setBool(_ value: Bool, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func integer(forKey key: String) -> Int {
+        defaults.integer(forKey: key)
+    }
+
+    func setInteger(_ value: Int, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func string(forKey key: String) -> String? {
+        defaults.string(forKey: key)
+    }
+
+    func setString(_ value: String, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    func stringArray(forKey key: String) -> [String]? {
+        defaults.stringArray(forKey: key)
+    }
+
+    func setStringArray(_ value: [String], forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    @discardableResult
+    func incrementInt(_ key: String) -> Int {
+        let newValue = defaults.integer(forKey: key) + 1
+        defaults.set(newValue, forKey: key)
+        return newValue
+    }
+
+    func updateBestStreak(_ bestKey: String, currentStreak: Int) {
+        let best = defaults.integer(forKey: bestKey)
+        if currentStreak > best {
+            defaults.set(currentStreak, forKey: bestKey)
+        }
+    }
+
+    func clearAll() {
+        let allKeys = defaults.dictionaryRepresentation().keys
+        for key in allKeys {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    // MARK: - Export/Import
+
+    func exportProgress(lessonIds: [String], quizCategories: [String],
+                        intervalSuffixes: [String], chordEarSuffixes: [String],
+                        scaleModes: [String]) -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        for lessonId in lessonIds {
+            let doneKey = "lesson_done_\(lessonId)"
+            let quizKey = "lesson_quiz_\(lessonId)"
+            if defaults.bool(forKey: doneKey) { result[doneKey] = true }
+            if defaults.bool(forKey: quizKey) { result[quizKey] = true }
+        }
+
+        for cat in quizCategories {
+            for prefix in ["quiz_total_", "quiz_correct_", "quiz_streak_", "quiz_best_"] {
+                let key = "\(prefix)\(cat)"
+                let val = defaults.integer(forKey: key)
+                if val != 0 { result[key] = val }
+            }
+        }
+
+        for suffix in intervalSuffixes {
+            for prefix in ["interval_total_", "interval_correct_", "interval_streak_", "interval_best_"] {
+                let key = "\(prefix)\(suffix)"
+                let val = defaults.integer(forKey: key)
+                if val != 0 { result[key] = val }
+            }
+        }
+
+        for key in ["note_quiz_total", "note_quiz_correct", "note_quiz_streak", "note_quiz_best"] {
+            let val = defaults.integer(forKey: key)
+            if val != 0 { result[key] = val }
+        }
+
+        for suffix in chordEarSuffixes {
+            for prefix in ["chord_ear_total_", "chord_ear_correct_", "chord_ear_streak_", "chord_ear_best_"] {
+                let key = "\(prefix)\(suffix)"
+                let val = defaults.integer(forKey: key)
+                if val != 0 { result[key] = val }
+            }
+        }
+
+        for mode in scaleModes {
+            for prefix in ["scale_practice_total_", "scale_practice_correct_", "scale_practice_streak_", "scale_practice_best_"] {
+                let key = "\(prefix)\(mode)"
+                let val = defaults.integer(forKey: key)
+                if val != 0 { result[key] = val }
+            }
+        }
+
+        if let lastDate = defaults.string(forKey: "last_activity_date") {
+            result["last_activity_date"] = lastDate
+        }
+        let streakDays = defaults.integer(forKey: "streak_days")
+        if streakDays != 0 { result["streak_days"] = streakDays }
+        let bestStreakDays = defaults.integer(forKey: "best_streak_days")
+        if bestStreakDays != 0 { result["best_streak_days"] = bestStreakDays }
+
+        if let achievements = defaults.stringArray(forKey: "unlocked_achievements"), !achievements.isEmpty {
+            result["unlocked_achievements"] = achievements
+        }
+
+        return result
+    }
+
+    func importProgress(_ data: [String: Any]) {
+        for (key, value) in data {
+            if key == "unlocked_achievements" {
+                if let incoming = value as? [String] {
+                    let existing = Set(defaults.stringArray(forKey: "unlocked_achievements") ?? [])
+                    let merged = existing.union(incoming)
+                    defaults.set(Array(merged), forKey: "unlocked_achievements")
+                }
+            } else if key == "last_activity_date" {
+                if let incoming = value as? String {
+                    let existing = defaults.string(forKey: "last_activity_date")
+                    if existing == nil || incoming > existing! {
+                        defaults.set(incoming, forKey: "last_activity_date")
+                    }
+                }
+            } else if let incoming = value as? Bool {
+                if incoming { defaults.set(true, forKey: key) }
+            } else if let incoming = value as? Int {
+                let existing = defaults.integer(forKey: key)
+                if incoming > existing {
+                    defaults.set(incoming, forKey: key)
+                }
+            }
+        }
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/MelodyRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/MelodyRepository.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+final class MelodyRepository {
+    private let userDefaultsKey = "melodies"
+
+    func getAll() -> [MelodyData] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let decoded = try? JSONDecoder().decode([MelodyData].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ melodies: [MelodyData]) {
+        guard let data = try? JSONEncoder().encode(melodies) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+
+    func exportData(_ melodies: [MelodyData]) -> [[String: Any]] {
+        let encoder = JSONEncoder()
+        return melodies.compactMap { melody in
+            guard let data = try? encoder.encode(melody),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return dict
+        }
+    }
+
+    func importData(_ incoming: [[String: Any]], into melodies: inout [MelodyData]) {
+        let decoder = JSONDecoder()
+        for item in incoming {
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
+                  let decoded = try? decoder.decode(MelodyData.self, from: jsonData)
+            else { continue }
+            let melody = decoded.sanitized()
+            if let idx = melodies.firstIndex(where: { $0.id == melody.id }) {
+                if melody.createdAt > melodies[idx].createdAt {
+                    melodies[idx] = melody
+                }
+            } else {
+                melodies.append(melody)
+            }
+        }
+        save(melodies)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+final class PracticeTimerRepository {
+    private let storageKey = "practice_timer"
+
+    func load() -> PracticeTimerData {
+        guard let stored = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(PracticeTimerData.self, from: stored)
+        else { return PracticeTimerData() }
+        return decoded
+    }
+
+    func save(_ data: PracticeTimerData) {
+        guard let encoded = try? JSONEncoder().encode(data) else { return }
+        UserDefaults.standard.set(encoded, forKey: storageKey)
+    }
+
+    func exportData(_ data: PracticeTimerData) -> [String: Any] {
+        [
+            "totalMinutes": data.totalMinutes,
+            "totalSessions": data.totalSessions,
+            "dailyMinutes": data.dailyMinutes,
+            "longestSession": data.longestSession,
+            "lastSessionTime": data.lastSessionTime,
+            "dailyGoal": data.dailyGoal,
+        ]
+    }
+
+    func importData(_ dict: [String: Any], into data: inout PracticeTimerData) {
+        if let total = dict["totalMinutes"] as? Int {
+            data.totalMinutes = max(data.totalMinutes, total)
+        }
+        if let sessions = dict["totalSessions"] as? Int {
+            data.totalSessions = max(data.totalSessions, sessions)
+        }
+        if let longest = dict["longestSession"] as? Int {
+            data.longestSession = max(data.longestSession, longest)
+        }
+        if let lastTime = dict["lastSessionTime"] as? Double {
+            let normalized = lastTime > 100_000_000_000 ? lastTime / 1000.0 : lastTime
+            data.lastSessionTime = max(data.lastSessionTime, normalized)
+        }
+        if let goal = dict["dailyGoal"] as? Int {
+            data.dailyGoal = goal
+        }
+        if let daily = dict["dailyMinutes"] as? [String: Int] {
+            for (key, value) in daily {
+                data.dailyMinutes[key] = max(data.dailyMinutes[key] ?? 0, value)
+            }
+        }
+        save(data)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/ProgressionsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/ProgressionsRepository.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+final class ProgressionsRepository {
+    private let userDefaultsKey = "custom_progressions"
+
+    func getAll() -> [CustomProgression] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let decoded = try? JSONDecoder().decode([CustomProgression].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ progressions: [CustomProgression]) {
+        guard let data = try? JSONEncoder().encode(progressions) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+
+    func exportData(_ progressions: [CustomProgression]) -> [[String: Any]] {
+        let encoder = JSONEncoder()
+        return progressions.compactMap { prog in
+            guard let data = try? encoder.encode(prog),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return dict
+        }
+    }
+
+    func importData(_ incoming: [[String: Any]], into progressions: inout [CustomProgression]) {
+        let decoder = JSONDecoder()
+        let existingIds = Set(progressions.map { $0.id })
+        for item in incoming {
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
+                  let progression = try? decoder.decode(CustomProgression.self, from: jsonData)
+            else { continue }
+            if !existingIds.contains(progression.id) {
+                progressions.append(progression)
+            }
+        }
+        save(progressions)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/ScalePracticeRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/ScalePracticeRepository.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class ScalePracticeRepository {
+    private static let settingsKey = "scale_practice_settings"
+
+    func loadSettings() -> [String: Any]? {
+        UserDefaults.standard.dictionary(forKey: Self.settingsKey)
+    }
+
+    func saveSettings(_ dict: [String: Any]) {
+        UserDefaults.standard.set(dict, forKey: Self.settingsKey)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/SetlistRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SetlistRepository.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+final class SetlistRepository {
+    private let userDefaultsKey = "setlists"
+
+    func getAll() -> [StoredSetlist] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let decoded = try? JSONDecoder().decode([StoredSetlist].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ setlists: [StoredSetlist]) {
+        guard let data = try? JSONEncoder().encode(setlists) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+
+    func exportData(_ setlists: [StoredSetlist]) -> [[String: Any]] {
+        let encoder = JSONEncoder()
+        return setlists.compactMap { setlist in
+            guard let data = try? encoder.encode(setlist),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return dict
+        }
+    }
+
+    func importData(_ incoming: [[String: Any]], into setlists: inout [StoredSetlist]) {
+        let decoder = JSONDecoder()
+        for item in incoming {
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
+                  let setlist = try? decoder.decode(StoredSetlist.self, from: jsonData)
+            else { continue }
+            if let idx = setlists.firstIndex(where: { $0.id == setlist.id }) {
+                if setlist.updatedAt > setlists[idx].updatedAt {
+                    setlists[idx] = setlist
+                }
+            } else {
+                setlists.append(setlist)
+            }
+        }
+        save(setlists)
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+final class SettingsRepository {
+    private let defaults = UserDefaults(suiteName: "app_settings") ?? .standard
+
+    func load() -> SettingsData {
+        SettingsData(
+            soundEnabled: defaults.object(forKey: "sound_enabled") as? Bool ?? true,
+            volume: defaults.object(forKey: "volume") as? Float ?? 1.0,
+            noteDurationMs: defaults.object(forKey: "note_duration_ms") as? Int ?? 600,
+            strumDelayMs: defaults.object(forKey: "strum_delay_ms") as? Int ?? 50,
+            playOnTap: defaults.bool(forKey: "play_on_tap"),
+            noiseGateFiltering: defaults.object(forKey: "noise_gate_filtering") as? Float ?? 0.75,
+            themeMode: defaults.string(forKey: "theme_mode") ?? "System",
+            showTips: defaults.object(forKey: "show_tips") as? Bool ?? true,
+            selectedTuning: defaults.string(forKey: "selected_tuning") ?? "High-G (Standard)",
+            precisionMode: defaults.bool(forKey: "precision_mode"),
+            autoAdvance: defaults.bool(forKey: "auto_advance"),
+            a4Reference: defaults.object(forKey: "a4_reference") as? Float ?? 440.0,
+            spokenFeedback: defaults.bool(forKey: "spoken_feedback"),
+            autoStartTuner: defaults.bool(forKey: "auto_start_tuner"),
+            leftHanded: defaults.bool(forKey: "left_handed"),
+            showNoteNames: defaults.object(forKey: "show_note_names") as? Bool ?? true,
+            allowMuted: defaults.bool(forKey: "allow_muted"),
+            lastFret: defaults.object(forKey: "last_fret") as? Int ?? 12,
+            showLearnTab: defaults.object(forKey: "show_learn_tab") as? Bool ?? true,
+            showReferenceTab: defaults.object(forKey: "show_reference_tab") as? Bool ?? true,
+            strumDown: defaults.object(forKey: "strum_down") as? Bool ?? true,
+            appLanguage: defaults.string(forKey: "app_language") ?? "system",
+            onboardingCompleted: defaults.bool(forKey: "onboarding_completed")
+        )
+    }
+
+    func save(_ data: SettingsData) {
+        defaults.set(data.soundEnabled, forKey: "sound_enabled")
+        defaults.set(data.volume, forKey: "volume")
+        defaults.set(data.noteDurationMs, forKey: "note_duration_ms")
+        defaults.set(data.strumDelayMs, forKey: "strum_delay_ms")
+        defaults.set(data.playOnTap, forKey: "play_on_tap")
+        defaults.set(data.noiseGateFiltering, forKey: "noise_gate_filtering")
+        defaults.set(data.themeMode, forKey: "theme_mode")
+        defaults.set(data.showTips, forKey: "show_tips")
+        defaults.set(data.selectedTuning, forKey: "selected_tuning")
+        defaults.set(data.precisionMode, forKey: "precision_mode")
+        defaults.set(data.autoAdvance, forKey: "auto_advance")
+        defaults.set(data.a4Reference, forKey: "a4_reference")
+        defaults.set(data.spokenFeedback, forKey: "spoken_feedback")
+        defaults.set(data.autoStartTuner, forKey: "auto_start_tuner")
+        defaults.set(data.leftHanded, forKey: "left_handed")
+        defaults.set(data.showNoteNames, forKey: "show_note_names")
+        defaults.set(data.allowMuted, forKey: "allow_muted")
+        defaults.set(data.lastFret, forKey: "last_fret")
+        defaults.set(data.showLearnTab, forKey: "show_learn_tab")
+        defaults.set(data.showReferenceTab, forKey: "show_reference_tab")
+        defaults.set(data.strumDown, forKey: "strum_down")
+        defaults.set(data.appLanguage, forKey: "app_language")
+        defaults.set(data.onboardingCompleted, forKey: "onboarding_completed")
+    }
+
+    func exportSettings() -> [String: Any] {
+        [
+            "sound_enabled": defaults.object(forKey: "sound_enabled") as? Bool ?? true,
+            "volume": defaults.object(forKey: "volume") as? Float ?? 1.0,
+            "note_duration_ms": defaults.object(forKey: "note_duration_ms") as? Int ?? 600,
+            "strum_delay_ms": defaults.object(forKey: "strum_delay_ms") as? Int ?? 50,
+            "play_on_tap": defaults.bool(forKey: "play_on_tap"),
+            "noise_gate_filtering": defaults.object(forKey: "noise_gate_filtering") as? Float ?? 0.75,
+            "theme_mode": defaults.string(forKey: "theme_mode") ?? "System",
+            "show_tips": defaults.object(forKey: "show_tips") as? Bool ?? true,
+            "selected_tuning": defaults.string(forKey: "selected_tuning") ?? "High-G (Standard)",
+            "precision_mode": defaults.bool(forKey: "precision_mode"),
+            "auto_advance": defaults.bool(forKey: "auto_advance"),
+            "a4_reference": defaults.object(forKey: "a4_reference") as? Float ?? 440.0,
+            "spoken_feedback": defaults.bool(forKey: "spoken_feedback"),
+            "auto_start_tuner": defaults.bool(forKey: "auto_start_tuner"),
+            "left_handed": defaults.bool(forKey: "left_handed"),
+            "show_note_names": defaults.object(forKey: "show_note_names") as? Bool ?? true,
+            "allow_muted": defaults.bool(forKey: "allow_muted"),
+            "last_fret": defaults.object(forKey: "last_fret") as? Int ?? 12,
+            "show_learn_tab": defaults.object(forKey: "show_learn_tab") as? Bool ?? true,
+            "show_reference_tab": defaults.object(forKey: "show_reference_tab") as? Bool ?? true,
+            "strum_down": defaults.object(forKey: "strum_down") as? Bool ?? true,
+            "app_language": defaults.string(forKey: "app_language") ?? "system",
+        ]
+    }
+
+    func importSettings(_ dict: [String: Any]) {
+        if let v = dict["sound_enabled"] as? Bool { defaults.set(v, forKey: "sound_enabled") }
+        if let v = dict["volume"] as? Float { defaults.set(v, forKey: "volume") }
+        if let v = dict["note_duration_ms"] as? Int { defaults.set(v, forKey: "note_duration_ms") }
+        if let v = dict["strum_delay_ms"] as? Int { defaults.set(v, forKey: "strum_delay_ms") }
+        if let v = dict["play_on_tap"] as? Bool { defaults.set(v, forKey: "play_on_tap") }
+        if let v = dict["noise_gate_filtering"] as? Float { defaults.set(v, forKey: "noise_gate_filtering") }
+        if let v = dict["theme_mode"] as? String { defaults.set(v, forKey: "theme_mode") }
+        if let v = dict["show_tips"] as? Bool { defaults.set(v, forKey: "show_tips") }
+        if let v = dict["selected_tuning"] as? String { defaults.set(v, forKey: "selected_tuning") }
+        if let v = dict["precision_mode"] as? Bool { defaults.set(v, forKey: "precision_mode") }
+        if let v = dict["auto_advance"] as? Bool { defaults.set(v, forKey: "auto_advance") }
+        if let v = dict["a4_reference"] as? Float { defaults.set(v, forKey: "a4_reference") }
+        if let v = dict["spoken_feedback"] as? Bool { defaults.set(v, forKey: "spoken_feedback") }
+        if let v = dict["auto_start_tuner"] as? Bool { defaults.set(v, forKey: "auto_start_tuner") }
+        if let v = dict["left_handed"] as? Bool { defaults.set(v, forKey: "left_handed") }
+        if let v = dict["show_note_names"] as? Bool { defaults.set(v, forKey: "show_note_names") }
+        if let v = dict["allow_muted"] as? Bool { defaults.set(v, forKey: "allow_muted") }
+        if let v = dict["last_fret"] as? Int { defaults.set(v, forKey: "last_fret") }
+        if let v = dict["show_learn_tab"] as? Bool { defaults.set(v, forKey: "show_learn_tab") }
+        if let v = dict["show_reference_tab"] as? Bool { defaults.set(v, forKey: "show_reference_tab") }
+        if let v = dict["strum_down"] as? Bool { defaults.set(v, forKey: "strum_down") }
+        if let v = dict["app_language"] as? String { defaults.set(v, forKey: "app_language") }
+    }
+}
+
+struct SettingsData {
+    var soundEnabled: Bool
+    var volume: Float
+    var noteDurationMs: Int
+    var strumDelayMs: Int
+    var playOnTap: Bool
+    var noiseGateFiltering: Float
+    var themeMode: String
+    var showTips: Bool
+    var selectedTuning: String
+    var precisionMode: Bool
+    var autoAdvance: Bool
+    var a4Reference: Float
+    var spokenFeedback: Bool
+    var autoStartTuner: Bool
+    var leftHanded: Bool
+    var showNoteNames: Bool
+    var allowMuted: Bool
+    var lastFret: Int
+    var showLearnTab: Bool
+    var showReferenceTab: Bool
+    var strumDown: Bool
+    var appLanguage: String
+    var onboardingCompleted: Bool
+}

--- a/iosApp/UkuleleCompanion/Repositories/SongbookRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SongbookRepository.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+final class SongbookRepository {
+    private let userDefaultsKey = "chord_sheets"
+
+    func getAll() -> [StoredSong] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let decoded = try? JSONDecoder().decode([StoredSong].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ songs: [StoredSong]) {
+        guard let data = try? JSONEncoder().encode(songs) else { return }
+        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+    }
+
+    func exportData(_ songs: [StoredSong]) -> [[String: Any]] {
+        let encoder = JSONEncoder()
+        return songs.compactMap { song in
+            guard let data = try? encoder.encode(song),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return dict
+        }
+    }
+
+    func importData(_ incoming: [[String: Any]], into songs: inout [StoredSong]) {
+        let decoder = JSONDecoder()
+        for item in incoming {
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
+                  let song = try? decoder.decode(StoredSong.self, from: jsonData)
+            else { continue }
+            if let idx = songs.firstIndex(where: { $0.id == song.id }) {
+                if song.updatedAt > songs[idx].updatedAt {
+                    songs[idx] = song
+                }
+            } else {
+                songs.append(song)
+            }
+        }
+        save(songs)
+    }
+}

--- a/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/CustomPatternsViewModel.swift
@@ -38,12 +38,12 @@ final class CustomPatternsViewModel: ObservableObject {
     @Published var strumPatterns: [CustomStrumPatternData] = []
     @Published var fingerpickingPatterns: [CustomFingerpickingData] = []
 
-    private let strumKey = "custom_strum_patterns"
-    private let fingerpickKey = "custom_fingerpicking_patterns"
+    private let repository: CustomPatternsRepository
 
-    init() {
-        loadStrum()
-        loadFingerpicking()
+    init(repository: CustomPatternsRepository = CustomPatternsRepository()) {
+        self.repository = repository
+        strumPatterns = repository.getAllStrum()
+        fingerpickingPatterns = repository.getAllFingerpicking()
     }
 
     // MARK: - Strum Patterns
@@ -54,12 +54,12 @@ final class CustomPatternsViewModel: ObservableObject {
         } else {
             strumPatterns.insert(pattern, at: 0)
         }
-        persistStrum()
+        repository.saveStrum(strumPatterns)
     }
 
     func deleteStrumPattern(id: String) {
         strumPatterns.removeAll { $0.id == id }
-        persistStrum()
+        repository.saveStrum(strumPatterns)
     }
 
     // MARK: - Fingerpicking Patterns
@@ -70,112 +70,29 @@ final class CustomPatternsViewModel: ObservableObject {
         } else {
             fingerpickingPatterns.insert(pattern, at: 0)
         }
-        persistFingerpicking()
+        repository.saveFingerpicking(fingerpickingPatterns)
     }
 
     func deleteFingerpickingPattern(id: String) {
         fingerpickingPatterns.removeAll { $0.id == id }
-        persistFingerpicking()
-    }
-
-    // MARK: - Persistence
-
-    private func persistStrum() {
-        guard let data = try? JSONEncoder().encode(strumPatterns) else { return }
-        UserDefaults.standard.set(data, forKey: strumKey)
-    }
-
-    private func loadStrum() {
-        guard let data = UserDefaults.standard.data(forKey: strumKey),
-              let decoded = try? JSONDecoder().decode([CustomStrumPatternData].self, from: data)
-        else { return }
-        strumPatterns = decoded
-    }
-
-    private func persistFingerpicking() {
-        guard let data = try? JSONEncoder().encode(fingerpickingPatterns) else { return }
-        UserDefaults.standard.set(data, forKey: fingerpickKey)
-    }
-
-    private func loadFingerpicking() {
-        guard let data = UserDefaults.standard.data(forKey: fingerpickKey),
-              let decoded = try? JSONDecoder().decode([CustomFingerpickingData].self, from: data)
-        else { return }
-        fingerpickingPatterns = decoded
+        repository.saveFingerpicking(fingerpickingPatterns)
     }
 
     // MARK: - Export/Import for Backup
 
     func exportStrumData() -> [[String: Any]] {
-        strumPatterns.map { p in
-            [
-                "id": p.id,
-                "name": p.name,
-                "beats": p.beats.map { ["direction": $0.direction, "emphasis": $0.emphasis] },
-                "createdAt": p.createdAt,
-                "timeSignature": p.timeSignature,
-            ]
-        }
+        repository.exportStrumData(strumPatterns)
     }
 
     func importStrumData(_ items: [[String: Any]]) {
-        let existingIds = Set(strumPatterns.map(\.id))
-        for dict in items {
-            guard let id = dict["id"] as? String,
-                  !existingIds.contains(id),
-                  let name = dict["name"] as? String,
-                  let beatDicts = dict["beats"] as? [[String: Any]],
-                  let rawCreatedAt = dict["createdAt"] as? Double
-            else { continue }
-            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
-            let timeSignature = dict["timeSignature"] as? String ?? "4/4"
-            let beats = beatDicts.compactMap { bd -> StrumBeatData? in
-                guard let dir = bd["direction"] as? String,
-                      let emph = bd["emphasis"] as? Bool
-                else { return nil }
-                return StrumBeatData(direction: dir, emphasis: emph)
-            }
-            strumPatterns.append(CustomStrumPatternData(
-                id: id, name: name, beats: beats, createdAt: createdAt, timeSignature: timeSignature))
-        }
-        persistStrum()
+        repository.importStrumData(items, into: &strumPatterns)
     }
 
     func exportFingerpickData() -> [[String: Any]] {
-        fingerpickingPatterns.map { p in
-            [
-                "id": p.id,
-                "name": p.name,
-                "steps": p.steps.map { ["finger": $0.finger, "stringIndex": $0.stringIndex, "emphasis": $0.emphasis] as [String: Any] },
-                "createdAt": p.createdAt,
-                "timeSignature": p.timeSignature,
-            ]
-        }
+        repository.exportFingerpickData(fingerpickingPatterns)
     }
 
     func importFingerpickData(_ items: [[String: Any]]) {
-        let existingIds = Set(fingerpickingPatterns.map(\.id))
-        for dict in items {
-            guard let id = dict["id"] as? String,
-                  !existingIds.contains(id),
-                  let name = dict["name"] as? String,
-                  let stepDicts = dict["steps"] as? [[String: Any]],
-                  let rawCreatedAt = dict["createdAt"] as? Double
-            else { continue }
-            let createdAt = rawCreatedAt > 100_000_000_000 ? rawCreatedAt / 1000.0 : rawCreatedAt
-            let timeSignature = dict["timeSignature"] as? String ?? "4/4"
-            let steps = stepDicts.compactMap { sd -> FingerpickStepData? in
-                guard let finger = sd["finger"] as? String,
-                      let strIdx = sd["stringIndex"] as? Int,
-                      (0...3).contains(strIdx),
-                      let emph = sd["emphasis"] as? Bool
-                else { return nil }
-                return FingerpickStepData(finger: finger, stringIndex: strIdx, emphasis: emph)
-            }
-            guard !steps.isEmpty else { continue }
-            fingerpickingPatterns.append(CustomFingerpickingData(
-                id: id, name: name, steps: steps, createdAt: createdAt, timeSignature: timeSignature))
-        }
-        persistFingerpicking()
+        repository.importFingerpickData(items, into: &fingerpickingPatterns)
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/FavoritesViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/FavoritesViewModel.swift
@@ -28,12 +28,12 @@ final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [FavoriteVoicingData] = []
     @Published var folders: [FavoriteFolderData] = []
 
-    private let favoritesKey = "favorite_voicings"
-    private let foldersKey = "favorite_folders"
+    private let repository: FavoritesRepository
 
-    init() {
-        loadFavorites()
-        loadFolders()
+    init(repository: FavoritesRepository = FavoritesRepository()) {
+        self.repository = repository
+        favorites = repository.getAll()
+        folders = repository.getAllFolders()
     }
 
     // MARK: - Favorites
@@ -48,17 +48,16 @@ final class FavoritesViewModel: ObservableObject {
         )
         guard !favorites.contains(where: { $0.key == fav.key }) else { return }
         favorites.insert(fav, at: 0)
-        saveFavorites()
+        repository.save(favorites)
     }
 
     func removeFavorite(key: String) {
         favorites.removeAll { $0.key == key }
-        // Clean up folder orderings
         for i in folders.indices {
             folders[i].voicingOrder.removeAll { $0 == key }
         }
-        saveFavorites()
-        saveFolders()
+        repository.save(favorites)
+        repository.saveFolders(folders)
     }
 
     func removeFavorite(rootPitchClass: Int, chordSymbol: String, frets: [Int]) {
@@ -76,7 +75,6 @@ final class FavoritesViewModel: ObservableObject {
         return favorites.first { $0.key == key }?.folderIds ?? []
     }
 
-    /// Adds a voicing to favorites with folder assignments, or updates folders if already favorited.
     func saveFavoriteToFolders(rootPitchClass: Int, chordSymbol: String, frets: [Int], folderIds: [String]) {
         let key = "\(rootPitchClass)|\(chordSymbol)|\(frets.map(String.init).joined(separator: ","))"
         if let idx = favorites.firstIndex(where: { $0.key == key }) {
@@ -112,8 +110,8 @@ final class FavoritesViewModel: ObservableObject {
                 }
             }
         }
-        saveFavorites()
-        saveFolders()
+        repository.save(favorites)
+        repository.saveFolders(folders)
     }
 
     // MARK: - Folders
@@ -126,13 +124,13 @@ final class FavoritesViewModel: ObservableObject {
             voicingOrder: []
         )
         folders.append(folder)
-        saveFolders()
+        repository.saveFolders(folders)
     }
 
     func renameFolder(id: String, name: String) {
         guard let idx = folders.firstIndex(where: { $0.id == id }) else { return }
         folders[idx].name = name
-        saveFolders()
+        repository.saveFolders(folders)
     }
 
     func deleteFolder(id: String) {
@@ -140,8 +138,8 @@ final class FavoritesViewModel: ObservableObject {
         for i in favorites.indices {
             favorites[i].folderIds.removeAll { $0 == id }
         }
-        saveFolders()
-        saveFavorites()
+        repository.saveFolders(folders)
+        repository.save(favorites)
     }
 
     func setFolders(voicingKey: String, folderIds: [String]) {
@@ -150,34 +148,31 @@ final class FavoritesViewModel: ObservableObject {
         let newIds = Set(folderIds)
         favorites[idx].folderIds = folderIds
 
-        // Add to newly assigned folders
         for folderId in newIds.subtracting(oldIds) {
             if let fi = folders.firstIndex(where: { $0.id == folderId }),
                !folders[fi].voicingOrder.contains(voicingKey) {
                 folders[fi].voicingOrder.append(voicingKey)
             }
         }
-        // Remove from unassigned folders
         for folderId in oldIds.subtracting(newIds) {
             if let fi = folders.firstIndex(where: { $0.id == folderId }) {
                 folders[fi].voicingOrder.removeAll { $0 == voicingKey }
             }
         }
 
-        saveFavorites()
-        saveFolders()
+        repository.save(favorites)
+        repository.saveFolders(folders)
     }
 
     func reorderInFolder(folderId: String, orderedKeys: [String]) {
         guard let idx = folders.firstIndex(where: { $0.id == folderId }) else { return }
         folders[idx].voicingOrder = orderedKeys
-        saveFolders()
+        repository.saveFolders(folders)
     }
 
     func favoritesInFolder(_ folderId: String) -> [FavoriteVoicingData] {
         guard let folder = folders.first(where: { $0.id == folderId }) else { return [] }
         let inFolder = favorites.filter { $0.folderIds.contains(folderId) }
-        // Order by folder's voicingOrder
         let keyOrder = folder.voicingOrder
         return inFolder.sorted { a, b in
             let ai = keyOrder.firstIndex(of: a.key) ?? Int.max
@@ -186,73 +181,14 @@ final class FavoritesViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Persistence
-
-    private func saveFavorites() {
-        guard let data = try? JSONEncoder().encode(favorites) else { return }
-        UserDefaults.standard.set(data, forKey: favoritesKey)
-    }
-
-    private func loadFavorites() {
-        guard let data = UserDefaults.standard.data(forKey: favoritesKey),
-              let decoded = try? JSONDecoder().decode([FavoriteVoicingData].self, from: data)
-        else { return }
-        favorites = decoded
-    }
-
-    private func saveFolders() {
-        guard let data = try? JSONEncoder().encode(folders) else { return }
-        UserDefaults.standard.set(data, forKey: foldersKey)
-    }
-
-    private func loadFolders() {
-        guard let data = UserDefaults.standard.data(forKey: foldersKey),
-              let decoded = try? JSONDecoder().decode([FavoriteFolderData].self, from: data)
-        else { return }
-        folders = decoded
-    }
-
     // MARK: - Export/Import for Backup
 
     func exportData() -> (favorites: [[String: Any]], folders: [[String: Any]]) {
-        let favDicts: [[String: Any]] = favorites.map { f in
-            ["rootPitchClass": f.rootPitchClass, "chordSymbol": f.chordSymbol,
-             "frets": f.frets, "addedAt": f.addedAt, "folderIds": f.folderIds]
-        }
-        let folderDicts: [[String: Any]] = folders.map { f in
-            ["id": f.id, "name": f.name, "createdAt": f.createdAt,
-             "voicingOrder": f.voicingOrder]
-        }
-        return (favDicts, folderDicts)
+        repository.exportData(favorites: favorites, folders: folders)
     }
 
     func importData(favorites: [[String: Any]], folders: [[String: Any]]) {
-        for dict in favorites {
-            guard let rpc = dict["rootPitchClass"] as? Int,
-                  (0...11).contains(rpc),
-                  let sym = dict["chordSymbol"] as? String,
-                  let frets = dict["frets"] as? [Int],
-                  let addedAt = dict["addedAt"] as? Double
-            else { continue }
-            let folderIds = dict["folderIds"] as? [String] ?? []
-            let fav = FavoriteVoicingData(rootPitchClass: rpc, chordSymbol: sym,
-                                          frets: frets, addedAt: addedAt, folderIds: folderIds)
-            if !self.favorites.contains(where: { $0.key == fav.key }) {
-                self.favorites.append(fav)
-            }
-        }
-        for dict in folders {
-            guard let id = dict["id"] as? String,
-                  let name = dict["name"] as? String,
-                  let createdAt = dict["createdAt"] as? Double
-            else { continue }
-            let order = dict["voicingOrder"] as? [String] ?? []
-            if !self.folders.contains(where: { $0.id == id }) {
-                self.folders.append(FavoriteFolderData(id: id, name: name,
-                                                       createdAt: createdAt, voicingOrder: order))
-            }
-        }
-        saveFavorites()
-        saveFolders()
+        repository.importData(favorites: favorites, folders: folders,
+                              existing: &self.favorites, existingFolders: &self.folders)
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/LearnViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/LearnViewModel.swift
@@ -15,32 +15,32 @@ struct LearningStats {
 final class LearnViewModel: ObservableObject {
     @Published var stateVersion: Int = 0
 
-    private let defaults: UserDefaults
+    private let repository: LearnRepository
 
-    init() {
-        self.defaults = UserDefaults(suiteName: "learn_progress") ?? .standard
+    init(repository: LearnRepository = LearnRepository()) {
+        self.repository = repository
     }
 
     // MARK: - Theory Lessons
 
     func markLessonCompleted(_ lessonId: String) {
-        defaults.set(true, forKey: "lesson_done_\(lessonId)")
+        repository.setBool(true, forKey: "lesson_done_\(lessonId)")
         recordActivity()
         stateVersion += 1
     }
 
     func isLessonCompleted(_ lessonId: String) -> Bool {
-        defaults.bool(forKey: "lesson_done_\(lessonId)")
+        repository.bool(forKey: "lesson_done_\(lessonId)")
     }
 
     func markLessonQuizPassed(_ lessonId: String) {
-        defaults.set(true, forKey: "lesson_quiz_\(lessonId)")
+        repository.setBool(true, forKey: "lesson_quiz_\(lessonId)")
         recordActivity()
         stateVersion += 1
     }
 
     func isLessonQuizPassed(_ lessonId: String) -> Bool {
-        defaults.bool(forKey: "lesson_quiz_\(lessonId)")
+        repository.bool(forKey: "lesson_quiz_\(lessonId)")
     }
 
     func completedLessonCount() -> Int {
@@ -57,18 +57,18 @@ final class LearnViewModel: ObservableObject {
 
     func recordQuizAnswer(category: QuizGenerator.QuizCategory, correct: Bool) {
         let catKey = category.name
-        incrementInt("quiz_total_\(catKey)")
-        incrementInt("quiz_total_ALL")
+        repository.incrementInt("quiz_total_\(catKey)")
+        repository.incrementInt("quiz_total_ALL")
         if correct {
-            incrementInt("quiz_correct_\(catKey)")
-            incrementInt("quiz_correct_ALL")
-            let newStreak = incrementInt("quiz_streak_\(catKey)")
-            updateBestStreak("quiz_best_\(catKey)", currentStreak: newStreak)
-            let newOverallStreak = incrementInt("quiz_streak_ALL")
-            updateBestStreak("quiz_best_ALL", currentStreak: newOverallStreak)
+            repository.incrementInt("quiz_correct_\(catKey)")
+            repository.incrementInt("quiz_correct_ALL")
+            let newStreak = repository.incrementInt("quiz_streak_\(catKey)")
+            repository.updateBestStreak("quiz_best_\(catKey)", currentStreak: newStreak)
+            let newOverallStreak = repository.incrementInt("quiz_streak_ALL")
+            repository.updateBestStreak("quiz_best_ALL", currentStreak: newOverallStreak)
         } else {
-            defaults.set(0, forKey: "quiz_streak_\(catKey)")
-            defaults.set(0, forKey: "quiz_streak_ALL")
+            repository.setInteger(0, forKey: "quiz_streak_\(catKey)")
+            repository.setInteger(0, forKey: "quiz_streak_ALL")
         }
         recordActivity()
         stateVersion += 1
@@ -80,9 +80,9 @@ final class LearnViewModel: ObservableObject {
         let correctKey = category != nil ? "quiz_correct_\(suffix)" : "quiz_correct_ALL"
         let bestKey = category != nil ? "quiz_best_\(suffix)" : "quiz_best_ALL"
         return LearningStats(
-            total: defaults.integer(forKey: totalKey),
-            correct: defaults.integer(forKey: correctKey),
-            bestStreak: defaults.integer(forKey: bestKey)
+            total: repository.integer(forKey: totalKey),
+            correct: repository.integer(forKey: correctKey),
+            bestStreak: repository.integer(forKey: bestKey)
         )
     }
 
@@ -90,18 +90,18 @@ final class LearnViewModel: ObservableObject {
 
     func recordIntervalAnswer(level: Int, correct: Bool) {
         let lvl = min(max(level, 1), 4)
-        incrementInt("interval_total_\(lvl)")
-        incrementInt("interval_total_ALL")
+        repository.incrementInt("interval_total_\(lvl)")
+        repository.incrementInt("interval_total_ALL")
         if correct {
-            incrementInt("interval_correct_\(lvl)")
-            incrementInt("interval_correct_ALL")
-            let newStreak = incrementInt("interval_streak_\(lvl)")
-            updateBestStreak("interval_best_\(lvl)", currentStreak: newStreak)
-            let newOverallStreak = incrementInt("interval_streak_ALL")
-            updateBestStreak("interval_best_ALL", currentStreak: newOverallStreak)
+            repository.incrementInt("interval_correct_\(lvl)")
+            repository.incrementInt("interval_correct_ALL")
+            let newStreak = repository.incrementInt("interval_streak_\(lvl)")
+            repository.updateBestStreak("interval_best_\(lvl)", currentStreak: newStreak)
+            let newOverallStreak = repository.incrementInt("interval_streak_ALL")
+            repository.updateBestStreak("interval_best_ALL", currentStreak: newOverallStreak)
         } else {
-            defaults.set(0, forKey: "interval_streak_\(lvl)")
-            defaults.set(0, forKey: "interval_streak_ALL")
+            repository.setInteger(0, forKey: "interval_streak_\(lvl)")
+            repository.setInteger(0, forKey: "interval_streak_ALL")
         }
         recordActivity()
         stateVersion += 1
@@ -113,22 +113,22 @@ final class LearnViewModel: ObservableObject {
         let correctKey = level != nil ? "interval_correct_\(suffix)" : "interval_correct_ALL"
         let bestKey = level != nil ? "interval_best_\(suffix)" : "interval_best_ALL"
         return LearningStats(
-            total: defaults.integer(forKey: totalKey),
-            correct: defaults.integer(forKey: correctKey),
-            bestStreak: defaults.integer(forKey: bestKey)
+            total: repository.integer(forKey: totalKey),
+            correct: repository.integer(forKey: correctKey),
+            bestStreak: repository.integer(forKey: bestKey)
         )
     }
 
     // MARK: - Note Quiz
 
     func recordNoteQuizAnswer(correct: Bool) {
-        incrementInt("note_quiz_total")
+        repository.incrementInt("note_quiz_total")
         if correct {
-            incrementInt("note_quiz_correct")
-            let newStreak = incrementInt("note_quiz_streak")
-            updateBestStreak("note_quiz_best", currentStreak: newStreak)
+            repository.incrementInt("note_quiz_correct")
+            let newStreak = repository.incrementInt("note_quiz_streak")
+            repository.updateBestStreak("note_quiz_best", currentStreak: newStreak)
         } else {
-            defaults.set(0, forKey: "note_quiz_streak")
+            repository.setInteger(0, forKey: "note_quiz_streak")
         }
         recordActivity()
         stateVersion += 1
@@ -136,9 +136,9 @@ final class LearnViewModel: ObservableObject {
 
     func noteQuizStats() -> LearningStats {
         LearningStats(
-            total: defaults.integer(forKey: "note_quiz_total"),
-            correct: defaults.integer(forKey: "note_quiz_correct"),
-            bestStreak: defaults.integer(forKey: "note_quiz_best")
+            total: repository.integer(forKey: "note_quiz_total"),
+            correct: repository.integer(forKey: "note_quiz_correct"),
+            bestStreak: repository.integer(forKey: "note_quiz_best")
         )
     }
 
@@ -146,18 +146,18 @@ final class LearnViewModel: ObservableObject {
 
     func recordChordEarAnswer(level: Int, correct: Bool) {
         let lvl = min(max(level, 1), 4)
-        incrementInt("chord_ear_total_\(lvl)")
-        incrementInt("chord_ear_total_ALL")
+        repository.incrementInt("chord_ear_total_\(lvl)")
+        repository.incrementInt("chord_ear_total_ALL")
         if correct {
-            incrementInt("chord_ear_correct_\(lvl)")
-            incrementInt("chord_ear_correct_ALL")
-            let newStreak = incrementInt("chord_ear_streak_\(lvl)")
-            updateBestStreak("chord_ear_best_\(lvl)", currentStreak: newStreak)
-            let newOverallStreak = incrementInt("chord_ear_streak_ALL")
-            updateBestStreak("chord_ear_best_ALL", currentStreak: newOverallStreak)
+            repository.incrementInt("chord_ear_correct_\(lvl)")
+            repository.incrementInt("chord_ear_correct_ALL")
+            let newStreak = repository.incrementInt("chord_ear_streak_\(lvl)")
+            repository.updateBestStreak("chord_ear_best_\(lvl)", currentStreak: newStreak)
+            let newOverallStreak = repository.incrementInt("chord_ear_streak_ALL")
+            repository.updateBestStreak("chord_ear_best_ALL", currentStreak: newOverallStreak)
         } else {
-            defaults.set(0, forKey: "chord_ear_streak_\(lvl)")
-            defaults.set(0, forKey: "chord_ear_streak_ALL")
+            repository.setInteger(0, forKey: "chord_ear_streak_\(lvl)")
+            repository.setInteger(0, forKey: "chord_ear_streak_ALL")
         }
         recordActivity()
         stateVersion += 1
@@ -169,9 +169,9 @@ final class LearnViewModel: ObservableObject {
         let correctKey = level != nil ? "chord_ear_correct_\(suffix)" : "chord_ear_correct_ALL"
         let bestKey = level != nil ? "chord_ear_best_\(suffix)" : "chord_ear_best_ALL"
         return LearningStats(
-            total: defaults.integer(forKey: totalKey),
-            correct: defaults.integer(forKey: correctKey),
-            bestStreak: defaults.integer(forKey: bestKey)
+            total: repository.integer(forKey: totalKey),
+            correct: repository.integer(forKey: correctKey),
+            bestStreak: repository.integer(forKey: bestKey)
         )
     }
 
@@ -179,18 +179,18 @@ final class LearnViewModel: ObservableObject {
 
     func recordScalePracticeAnswer(mode: String, correct: Bool) {
         let m = mode.lowercased()
-        incrementInt("scale_practice_total_\(m)")
-        incrementInt("scale_practice_total_ALL")
+        repository.incrementInt("scale_practice_total_\(m)")
+        repository.incrementInt("scale_practice_total_ALL")
         if correct {
-            incrementInt("scale_practice_correct_\(m)")
-            incrementInt("scale_practice_correct_ALL")
-            let newStreak = incrementInt("scale_practice_streak_\(m)")
-            updateBestStreak("scale_practice_best_\(m)", currentStreak: newStreak)
-            let newOverallStreak = incrementInt("scale_practice_streak_ALL")
-            updateBestStreak("scale_practice_best_ALL", currentStreak: newOverallStreak)
+            repository.incrementInt("scale_practice_correct_\(m)")
+            repository.incrementInt("scale_practice_correct_ALL")
+            let newStreak = repository.incrementInt("scale_practice_streak_\(m)")
+            repository.updateBestStreak("scale_practice_best_\(m)", currentStreak: newStreak)
+            let newOverallStreak = repository.incrementInt("scale_practice_streak_ALL")
+            repository.updateBestStreak("scale_practice_best_ALL", currentStreak: newOverallStreak)
         } else {
-            defaults.set(0, forKey: "scale_practice_streak_\(m)")
-            defaults.set(0, forKey: "scale_practice_streak_ALL")
+            repository.setInteger(0, forKey: "scale_practice_streak_\(m)")
+            repository.setInteger(0, forKey: "scale_practice_streak_ALL")
         }
         recordActivity()
         stateVersion += 1
@@ -202,9 +202,9 @@ final class LearnViewModel: ObservableObject {
         let correctKey = mode != nil ? "scale_practice_correct_\(suffix)" : "scale_practice_correct_ALL"
         let bestKey = mode != nil ? "scale_practice_best_\(suffix)" : "scale_practice_best_ALL"
         return LearningStats(
-            total: defaults.integer(forKey: totalKey),
-            correct: defaults.integer(forKey: correctKey),
-            bestStreak: defaults.integer(forKey: bestKey)
+            total: repository.integer(forKey: totalKey),
+            correct: repository.integer(forKey: correctKey),
+            bestStreak: repository.integer(forKey: bestKey)
         )
     }
 
@@ -212,8 +212,8 @@ final class LearnViewModel: ObservableObject {
 
     func recordActivity() {
         let today = todayString()
-        let lastDate = defaults.string(forKey: "last_activity_date")
-        let currentStreak = defaults.integer(forKey: "streak_days")
+        let lastDate = repository.string(forKey: "last_activity_date")
+        let currentStreak = repository.integer(forKey: "streak_days")
 
         let newStreak: Int
         if lastDate == today {
@@ -224,34 +224,34 @@ final class LearnViewModel: ObservableObject {
             newStreak = 1
         }
 
-        let bestStreak = max(defaults.integer(forKey: "best_streak_days"), newStreak)
+        let bestStreak = max(repository.integer(forKey: "best_streak_days"), newStreak)
 
-        defaults.set(today, forKey: "last_activity_date")
-        defaults.set(newStreak, forKey: "streak_days")
-        defaults.set(bestStreak, forKey: "best_streak_days")
+        repository.setString(today, forKey: "last_activity_date")
+        repository.setInteger(newStreak, forKey: "streak_days")
+        repository.setInteger(bestStreak, forKey: "best_streak_days")
     }
 
     func currentDayStreak() -> Int {
-        guard let lastDate = defaults.string(forKey: "last_activity_date") else { return 0 }
+        guard let lastDate = repository.string(forKey: "last_activity_date") else { return 0 }
         let today = todayString()
         if lastDate == today || lastDate == yesterdayString() {
-            return defaults.integer(forKey: "streak_days")
+            return repository.integer(forKey: "streak_days")
         }
         return 0
     }
 
     func bestDayStreak() -> Int {
-        defaults.integer(forKey: "best_streak_days")
+        repository.integer(forKey: "best_streak_days")
     }
 
     // MARK: - Achievements
 
     var unlockedAchievementIds: Set<String> {
         get {
-            Set(defaults.stringArray(forKey: "unlocked_achievements") ?? [])
+            Set(repository.stringArray(forKey: "unlocked_achievements") ?? [])
         }
         set {
-            defaults.set(Array(newValue), forKey: "unlocked_achievements")
+            repository.setStringArray(Array(newValue), forKey: "unlocked_achievements")
             stateVersion += 1
         }
     }
@@ -265,139 +265,34 @@ final class LearnViewModel: ObservableObject {
     // MARK: - Reset
 
     func clearAllProgress() {
-        let allKeys = defaults.dictionaryRepresentation().keys
-        for key in allKeys {
-            defaults.removeObject(forKey: key)
-        }
+        repository.clearAll()
         stateVersion += 1
     }
 
     // MARK: - Backup Export/Import
 
     func exportProgress() -> [String: Any] {
-        var result: [String: Any] = [:]
-
-        // Theory lessons
         let lessons = TheoryLessons.shared.ALL.asArray(of: TheoryLesson.self)
-        for lesson in lessons {
-            let doneKey = "lesson_done_\(lesson.id)"
-            let quizKey = "lesson_quiz_\(lesson.id)"
-            if defaults.bool(forKey: doneKey) { result[doneKey] = true }
-            if defaults.bool(forKey: quizKey) { result[quizKey] = true }
-        }
-
-        // Quiz stats
         let catNames = [
             QuizGenerator.QuizCategory.intervals,
             .chords, .keys, .scales, .progressions
         ].map { $0.name } + ["ALL"]
-        for cat in catNames {
-            for prefix in ["quiz_total_", "quiz_correct_", "quiz_streak_", "quiz_best_"] {
-                let key = "\(prefix)\(cat)"
-                let val = defaults.integer(forKey: key)
-                if val != 0 { result[key] = val }
-            }
-        }
 
-        // Interval stats
-        let intervalSuffixes = ["1", "2", "3", "4", "ALL"]
-        for suffix in intervalSuffixes {
-            for prefix in ["interval_total_", "interval_correct_", "interval_streak_", "interval_best_"] {
-                let key = "\(prefix)\(suffix)"
-                let val = defaults.integer(forKey: key)
-                if val != 0 { result[key] = val }
-            }
-        }
-
-        // Note quiz stats
-        for key in ["note_quiz_total", "note_quiz_correct", "note_quiz_streak", "note_quiz_best"] {
-            let val = defaults.integer(forKey: key)
-            if val != 0 { result[key] = val }
-        }
-
-        // Chord ear training stats
-        let chordEarSuffixes = ["1", "2", "3", "4", "ALL"]
-        for suffix in chordEarSuffixes {
-            for prefix in ["chord_ear_total_", "chord_ear_correct_", "chord_ear_streak_", "chord_ear_best_"] {
-                let key = "\(prefix)\(suffix)"
-                let val = defaults.integer(forKey: key)
-                if val != 0 { result[key] = val }
-            }
-        }
-
-        // Scale practice stats
-        let scaleModes = ["quiz", "ear", "ALL"]
-        for mode in scaleModes {
-            for prefix in ["scale_practice_total_", "scale_practice_correct_", "scale_practice_streak_", "scale_practice_best_"] {
-                let key = "\(prefix)\(mode)"
-                let val = defaults.integer(forKey: key)
-                if val != 0 { result[key] = val }
-            }
-        }
-
-        // Daily streak
-        if let lastDate = defaults.string(forKey: "last_activity_date") {
-            result["last_activity_date"] = lastDate
-        }
-        let streakDays = defaults.integer(forKey: "streak_days")
-        if streakDays != 0 { result["streak_days"] = streakDays }
-        let bestStreakDays = defaults.integer(forKey: "best_streak_days")
-        if bestStreakDays != 0 { result["best_streak_days"] = bestStreakDays }
-
-        // Achievements
-        if let achievements = defaults.stringArray(forKey: "unlocked_achievements"), !achievements.isEmpty {
-            result["unlocked_achievements"] = achievements
-        }
-
-        return result
+        return repository.exportProgress(
+            lessonIds: lessons.map { $0.id },
+            quizCategories: catNames,
+            intervalSuffixes: ["1", "2", "3", "4", "ALL"],
+            chordEarSuffixes: ["1", "2", "3", "4", "ALL"],
+            scaleModes: ["quiz", "ear", "ALL"]
+        )
     }
 
     func importProgress(_ data: [String: Any]) {
-        for (key, value) in data {
-            if key == "unlocked_achievements" {
-                // Union merge for achievements
-                if let incoming = value as? [String] {
-                    let existing = Set(defaults.stringArray(forKey: "unlocked_achievements") ?? [])
-                    let merged = existing.union(incoming)
-                    defaults.set(Array(merged), forKey: "unlocked_achievements")
-                }
-            } else if key == "last_activity_date" {
-                // Keep the more recent date
-                if let incoming = value as? String {
-                    let existing = defaults.string(forKey: "last_activity_date")
-                    if existing == nil || incoming > existing! {
-                        defaults.set(incoming, forKey: "last_activity_date")
-                    }
-                }
-            } else if let incoming = value as? Bool {
-                // lesson_done_*, lesson_quiz_*: OR merge (once done, stays done)
-                if incoming { defaults.set(true, forKey: key) }
-            } else if let incoming = value as? Int {
-                // For stats: use max() so we never lose progress
-                let existing = defaults.integer(forKey: key)
-                if incoming > existing {
-                    defaults.set(incoming, forKey: key)
-                }
-            }
-        }
+        repository.importProgress(data)
         stateVersion += 1
     }
 
     // MARK: - Helpers
-
-    @discardableResult
-    private func incrementInt(_ key: String) -> Int {
-        let newValue = defaults.integer(forKey: key) + 1
-        defaults.set(newValue, forKey: key)
-        return newValue
-    }
-
-    private func updateBestStreak(_ bestKey: String, currentStreak: Int) {
-        let best = defaults.integer(forKey: bestKey)
-        if currentStreak > best {
-            defaults.set(currentStreak, forKey: bestKey)
-        }
-    }
 
     private func todayString() -> String {
         let formatter = DateFormatter()

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -99,7 +99,7 @@ final class MelodyViewModel: ObservableObject {
     private var loadedMelodyId: String? = nil
     private static let stabilizationThreshold = 3
 
-    private let userDefaultsKey = "melodies"
+    private let repository: MelodyRepository
     private let tonePlayer = TonePlayer()
     private var playbackTask: Task<Void, Never>?
     private let audioEngine = AudioCaptureEngine()
@@ -107,8 +107,9 @@ final class MelodyViewModel: ObservableObject {
     private var stableCount = 0
     private var lastDetectedPitchClass: Int? = nil
 
-    init() {
-        loadMelodies()
+    init(repository: MelodyRepository = MelodyRepository()) {
+        self.repository = repository
+        savedMelodies = repository.getAll()
     }
 
     var noteNames: [String] {
@@ -393,7 +394,7 @@ final class MelodyViewModel: ObservableObject {
         loadedMelodyName = name
         loadedMelodyId = id
         hasUnsavedChanges = false
-        persistMelodies()
+        repository.save(savedMelodies)
     }
 
     func load(melody: MelodyData) {
@@ -409,52 +410,19 @@ final class MelodyViewModel: ObservableObject {
         if loadedMelodyId == id {
             loadedMelodyName = newName
         }
-        persistMelodies()
+        repository.save(savedMelodies)
     }
 
     func deleteMelody(id: String) {
         savedMelodies.removeAll { $0.id == id }
-        persistMelodies()
+        repository.save(savedMelodies)
     }
 
     func importData(_ incoming: [[String: Any]]) {
-        let decoder = JSONDecoder()
-        for item in incoming {
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
-                  let decoded = try? decoder.decode(MelodyData.self, from: jsonData)
-            else { continue }
-            let melody = decoded.sanitized()
-            if let idx = savedMelodies.firstIndex(where: { $0.id == melody.id }) {
-                // Keep the one with the latest createdAt
-                if melody.createdAt > savedMelodies[idx].createdAt {
-                    savedMelodies[idx] = melody
-                }
-            } else {
-                savedMelodies.append(melody)
-            }
-        }
-        persistMelodies()
+        repository.importData(incoming, into: &savedMelodies)
     }
 
     func exportData() -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return savedMelodies.compactMap { melody in
-            guard let data = try? encoder.encode(melody),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
-    }
-
-    private func loadMelodies() {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([MelodyData].self, from: data)
-        else { return }
-        savedMelodies = decoded
-    }
-
-    private func persistMelodies() {
-        guard let data = try? JSONEncoder().encode(savedMelodies) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        repository.exportData(savedMelodies)
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/PracticeTimerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PracticeTimerViewModel.swift
@@ -13,10 +13,11 @@ struct PracticeTimerData: Codable {
 final class PracticeTimerViewModel: ObservableObject {
     @Published var data = PracticeTimerData()
 
-    private let storageKey = "practice_timer"
+    private let repository: PracticeTimerRepository
 
-    init() {
-        load()
+    init(repository: PracticeTimerRepository = PracticeTimerRepository()) {
+        self.repository = repository
+        data = repository.load()
     }
 
     func recordSession(durationSeconds: Int) {
@@ -30,7 +31,7 @@ final class PracticeTimerViewModel: ObservableObject {
             data.longestSession = minutes
         }
         data.lastSessionTime = Date().timeIntervalSince1970
-        save()
+        repository.save(data)
     }
 
     var todayMinutes: Int {
@@ -49,21 +50,17 @@ final class PracticeTimerViewModel: ObservableObject {
 
     func setDailyGoal(_ minutes: Int) {
         data.dailyGoal = min(max(minutes, 5), 120)
-        save()
+        repository.save(data)
     }
 
-    // MARK: - Persistence
+    // MARK: - Export/Import for Backup
 
-    private func save() {
-        guard let encoded = try? JSONEncoder().encode(data) else { return }
-        UserDefaults.standard.set(encoded, forKey: storageKey)
+    func exportData() -> [String: Any] {
+        repository.exportData(data)
     }
 
-    private func load() {
-        guard let stored = UserDefaults.standard.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode(PracticeTimerData.self, from: stored)
-        else { return }
-        data = decoded
+    func importData(_ dict: [String: Any]) {
+        repository.importData(dict, into: &data)
     }
 
     private func todayKey() -> String {
@@ -71,43 +68,5 @@ final class PracticeTimerViewModel: ObservableObject {
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter.string(from: Date())
-    }
-
-    // MARK: - Export/Import for Backup
-
-    func exportData() -> [String: Any] {
-        [
-            "totalMinutes": data.totalMinutes,
-            "totalSessions": data.totalSessions,
-            "dailyMinutes": data.dailyMinutes,
-            "longestSession": data.longestSession,
-            "lastSessionTime": data.lastSessionTime,
-            "dailyGoal": data.dailyGoal,
-        ]
-    }
-
-    func importData(_ dict: [String: Any]) {
-        if let total = dict["totalMinutes"] as? Int {
-            data.totalMinutes = max(data.totalMinutes, total)
-        }
-        if let sessions = dict["totalSessions"] as? Int {
-            data.totalSessions = max(data.totalSessions, sessions)
-        }
-        if let longest = dict["longestSession"] as? Int {
-            data.longestSession = max(data.longestSession, longest)
-        }
-        if let lastTime = dict["lastSessionTime"] as? Double {
-            let normalized = lastTime > 100_000_000_000 ? lastTime / 1000.0 : lastTime
-            data.lastSessionTime = max(data.lastSessionTime, normalized)
-        }
-        if let goal = dict["dailyGoal"] as? Int {
-            data.dailyGoal = goal
-        }
-        if let daily = dict["dailyMinutes"] as? [String: Int] {
-            for (key, value) in daily {
-                data.dailyMinutes[key] = max(data.dailyMinutes[key] ?? 0, value)
-            }
-        }
-        save()
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/ProgressionsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/ProgressionsViewModel.swift
@@ -19,10 +19,11 @@ final class ProgressionsViewModel: ObservableObject {
     @Published var showingCreateSheet = false
     @Published var editingCustomId: String?
 
-    private let userDefaultsKey = "custom_progressions"
+    private let repository: ProgressionsRepository
 
-    init() {
-        loadCustomProgressions()
+    init(repository: ProgressionsRepository = ProgressionsRepository()) {
+        self.repository = repository
+        customProgressions = repository.getAll()
     }
 
     var rootNoteNames: [String] {
@@ -106,7 +107,7 @@ final class ProgressionsViewModel: ObservableObject {
             scaleType: selectedScaleType.name
         )
         customProgressions.insert(custom, at: 0)
-        saveCustomProgressions()
+        repository.save(customProgressions)
     }
 
     func createCustomFromDegrees(name: String, description: String, degrees: [ChordDegree], scaleType: ScaleType) {
@@ -121,7 +122,7 @@ final class ProgressionsViewModel: ObservableObject {
             scaleType: scaleType.name
         )
         customProgressions.insert(custom, at: 0)
-        saveCustomProgressions()
+        repository.save(customProgressions)
     }
 
     func updateCustom(id: String, name: String, description: String, degrees: [ChordDegree], scaleType: ScaleType) {
@@ -137,12 +138,12 @@ final class ProgressionsViewModel: ObservableObject {
             scaleType: scaleType.name
         )
         customProgressions[index] = updated
-        saveCustomProgressions()
+        repository.save(customProgressions)
     }
 
     func deleteCustom(id: String) {
         customProgressions.removeAll { $0.id == id }
-        saveCustomProgressions()
+        repository.save(customProgressions)
     }
 
     func resolvedChordNameForCustomDegree(interval: Int, quality: String) -> String {
@@ -156,38 +157,10 @@ final class ProgressionsViewModel: ObservableObject {
     }
 
     func importData(_ incoming: [[String: Any]]) {
-        let decoder = JSONDecoder()
-        let existingIds = Set(customProgressions.map { $0.id })
-        for item in incoming {
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
-                  let progression = try? decoder.decode(CustomProgression.self, from: jsonData)
-            else { continue }
-            if !existingIds.contains(progression.id) {
-                customProgressions.append(progression)
-            }
-        }
-        saveCustomProgressions()
+        repository.importData(incoming, into: &customProgressions)
     }
 
     func exportData() -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return customProgressions.compactMap { prog in
-            guard let data = try? encoder.encode(prog),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
-    }
-
-    private func loadCustomProgressions() {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([CustomProgression].self, from: data)
-        else { return }
-        customProgressions = decoded
-    }
-
-    private func saveCustomProgressions() {
-        guard let data = try? JSONEncoder().encode(customProgressions) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        repository.exportData(customProgressions)
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/ScalePracticeViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/ScalePracticeViewModel.swift
@@ -58,10 +58,10 @@ final class ScalePracticeViewModel: ObservableObject {
 
     private let tonePlayer = TonePlayer()
     private var playTimer: AnyCancellable?
-    private let defaults = UserDefaults.standard
-    private static let settingsKey = "scale_practice_settings"
+    private let repository: ScalePracticeRepository
 
-    init() {
+    init(repository: ScalePracticeRepository = ScalePracticeRepository()) {
+        self.repository = repository
         loadSettings()
     }
 
@@ -178,11 +178,11 @@ final class ScalePracticeViewModel: ObservableObject {
             "loop": loopPlayback,
             "fret_position": fretPosition.rawValue
         ]
-        defaults.set(dict, forKey: Self.settingsKey)
+        repository.saveSettings(dict)
     }
 
     private func loadSettings() {
-        guard let dict = defaults.dictionary(forKey: Self.settingsKey) else { return }
+        guard let dict = repository.loadSettings() else { return }
         if let v = dict["root"] as? Int32 { selectedRoot = v }
         if let v = dict["bpm"] as? Double { bpm = v }
         if let v = dict["direction"] as? String { playDirection = PlayDirection(rawValue: v) ?? .ascending }

--- a/iosApp/UkuleleCompanion/ViewModels/SetlistViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/SetlistViewModel.swift
@@ -13,10 +13,11 @@ struct StoredSetlist: Codable, Identifiable {
 final class SetlistViewModel: ObservableObject {
     @Published var setlists: [StoredSetlist] = []
 
-    private let userDefaultsKey = "setlists"
+    private let repository: SetlistRepository
 
-    init() {
-        load()
+    init(repository: SetlistRepository = SetlistRepository()) {
+        self.repository = repository
+        setlists = repository.getAll()
     }
 
     func create(name: String) {
@@ -29,19 +30,19 @@ final class SetlistViewModel: ObservableObject {
             updatedAt: now
         )
         setlists.insert(setlist, at: 0)
-        persist()
+        repository.save(setlists)
     }
 
     func rename(id: String, newName: String) {
         guard let idx = setlists.firstIndex(where: { $0.id == id }) else { return }
         setlists[idx].name = newName
         setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(setlists)
     }
 
     func delete(id: String) {
         setlists.removeAll { $0.id == id }
-        persist()
+        repository.save(setlists)
     }
 
     func addSong(setlistId: String, songId: String) {
@@ -49,14 +50,14 @@ final class SetlistViewModel: ObservableObject {
         guard !setlists[idx].songIds.contains(songId) else { return }
         setlists[idx].songIds.append(songId)
         setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(setlists)
     }
 
     func removeSong(setlistId: String, songId: String) {
         guard let idx = setlists.firstIndex(where: { $0.id == setlistId }) else { return }
         setlists[idx].songIds.removeAll { $0 == songId }
         setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(setlists)
     }
 
     func moveSong(setlistId: String, from: Int, to: Int) {
@@ -66,45 +67,14 @@ final class SetlistViewModel: ObservableObject {
         let item = setlists[idx].songIds.remove(at: from)
         setlists[idx].songIds.insert(item, at: to)
         setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(setlists)
     }
 
     func exportData() -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return setlists.compactMap { setlist in
-            guard let data = try? encoder.encode(setlist),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
+        repository.exportData(setlists)
     }
 
     func importData(_ incoming: [[String: Any]]) {
-        let decoder = JSONDecoder()
-        for item in incoming {
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
-                  let setlist = try? decoder.decode(StoredSetlist.self, from: jsonData)
-            else { continue }
-            if let idx = setlists.firstIndex(where: { $0.id == setlist.id }) {
-                if setlist.updatedAt > setlists[idx].updatedAt {
-                    setlists[idx] = setlist
-                }
-            } else {
-                setlists.append(setlist)
-            }
-        }
-        persist()
-    }
-
-    private func load() {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([StoredSetlist].self, from: data)
-        else { return }
-        setlists = decoded
-    }
-
-    private func persist() {
-        guard let data = try? JSONEncoder().encode(setlists) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        repository.importData(incoming, into: &setlists)
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/SettingsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/SettingsViewModel.swift
@@ -44,68 +44,66 @@ final class SettingsViewModel: ObservableObject {
     // Onboarding
     @Published var onboardingCompleted: Bool = false
 
-    private let defaults = UserDefaults(suiteName: "app_settings") ?? .standard
+    private let repository: SettingsRepository
 
-    init() {
+    init(repository: SettingsRepository = SettingsRepository()) {
+        self.repository = repository
         load()
     }
 
     func load() {
-        soundEnabled = defaults.object(forKey: "sound_enabled") as? Bool ?? true
-        volume = defaults.object(forKey: "volume") as? Float ?? 1.0
-        noteDurationMs = defaults.object(forKey: "note_duration_ms") as? Int ?? 600
-        strumDelayMs = defaults.object(forKey: "strum_delay_ms") as? Int ?? 50
-        playOnTap = defaults.bool(forKey: "play_on_tap")
-        noiseGateFiltering = defaults.object(forKey: "noise_gate_filtering") as? Float ?? 0.75
-
-        themeMode = defaults.string(forKey: "theme_mode") ?? "System"
-        showTips = defaults.object(forKey: "show_tips") as? Bool ?? true
-
-        selectedTuning = defaults.string(forKey: "selected_tuning") ?? "High-G (Standard)"
-
-        precisionMode = defaults.bool(forKey: "precision_mode")
-        autoAdvance = defaults.bool(forKey: "auto_advance")
-        a4Reference = defaults.object(forKey: "a4_reference") as? Float ?? 440.0
-        spokenFeedback = defaults.bool(forKey: "spoken_feedback")
-        autoStartTuner = defaults.bool(forKey: "auto_start_tuner")
-
-        leftHanded = defaults.bool(forKey: "left_handed")
-        showNoteNames = defaults.object(forKey: "show_note_names") as? Bool ?? true
-        allowMuted = defaults.bool(forKey: "allow_muted")
-        lastFret = defaults.object(forKey: "last_fret") as? Int ?? 12
-
-        showLearnTab = defaults.object(forKey: "show_learn_tab") as? Bool ?? true
-        showReferenceTab = defaults.object(forKey: "show_reference_tab") as? Bool ?? true
-        strumDown = defaults.object(forKey: "strum_down") as? Bool ?? true
-
-        appLanguage = defaults.string(forKey: "app_language") ?? "system"
-        onboardingCompleted = defaults.bool(forKey: "onboarding_completed")
+        let data = repository.load()
+        soundEnabled = data.soundEnabled
+        volume = data.volume
+        noteDurationMs = data.noteDurationMs
+        strumDelayMs = data.strumDelayMs
+        playOnTap = data.playOnTap
+        noiseGateFiltering = data.noiseGateFiltering
+        themeMode = data.themeMode
+        showTips = data.showTips
+        selectedTuning = data.selectedTuning
+        precisionMode = data.precisionMode
+        autoAdvance = data.autoAdvance
+        a4Reference = data.a4Reference
+        spokenFeedback = data.spokenFeedback
+        autoStartTuner = data.autoStartTuner
+        leftHanded = data.leftHanded
+        showNoteNames = data.showNoteNames
+        allowMuted = data.allowMuted
+        lastFret = data.lastFret
+        showLearnTab = data.showLearnTab
+        showReferenceTab = data.showReferenceTab
+        strumDown = data.strumDown
+        appLanguage = data.appLanguage
+        onboardingCompleted = data.onboardingCompleted
     }
 
     func save() {
-        defaults.set(soundEnabled, forKey: "sound_enabled")
-        defaults.set(volume, forKey: "volume")
-        defaults.set(noteDurationMs, forKey: "note_duration_ms")
-        defaults.set(strumDelayMs, forKey: "strum_delay_ms")
-        defaults.set(playOnTap, forKey: "play_on_tap")
-        defaults.set(noiseGateFiltering, forKey: "noise_gate_filtering")
-        defaults.set(themeMode, forKey: "theme_mode")
-        defaults.set(showTips, forKey: "show_tips")
-        defaults.set(selectedTuning, forKey: "selected_tuning")
-        defaults.set(precisionMode, forKey: "precision_mode")
-        defaults.set(autoAdvance, forKey: "auto_advance")
-        defaults.set(a4Reference, forKey: "a4_reference")
-        defaults.set(spokenFeedback, forKey: "spoken_feedback")
-        defaults.set(autoStartTuner, forKey: "auto_start_tuner")
-        defaults.set(leftHanded, forKey: "left_handed")
-        defaults.set(showNoteNames, forKey: "show_note_names")
-        defaults.set(allowMuted, forKey: "allow_muted")
-        defaults.set(lastFret, forKey: "last_fret")
-        defaults.set(showLearnTab, forKey: "show_learn_tab")
-        defaults.set(showReferenceTab, forKey: "show_reference_tab")
-        defaults.set(strumDown, forKey: "strum_down")
-        defaults.set(appLanguage, forKey: "app_language")
-        defaults.set(onboardingCompleted, forKey: "onboarding_completed")
+        repository.save(SettingsData(
+            soundEnabled: soundEnabled,
+            volume: volume,
+            noteDurationMs: noteDurationMs,
+            strumDelayMs: strumDelayMs,
+            playOnTap: playOnTap,
+            noiseGateFiltering: noiseGateFiltering,
+            themeMode: themeMode,
+            showTips: showTips,
+            selectedTuning: selectedTuning,
+            precisionMode: precisionMode,
+            autoAdvance: autoAdvance,
+            a4Reference: a4Reference,
+            spokenFeedback: spokenFeedback,
+            autoStartTuner: autoStartTuner,
+            leftHanded: leftHanded,
+            showNoteNames: showNoteNames,
+            allowMuted: allowMuted,
+            lastFret: lastFret,
+            showLearnTab: showLearnTab,
+            showReferenceTab: showReferenceTab,
+            strumDown: strumDown,
+            appLanguage: appLanguage,
+            onboardingCompleted: onboardingCompleted
+        ))
     }
 
     func applyLanguage() {
@@ -119,55 +117,11 @@ final class SettingsViewModel: ObservableObject {
     // MARK: - Export/Import for Backup
 
     func exportSettings() -> [String: Any] {
-        [
-            "sound_enabled": soundEnabled,
-            "volume": volume,
-            "note_duration_ms": noteDurationMs,
-            "strum_delay_ms": strumDelayMs,
-            "play_on_tap": playOnTap,
-            "noise_gate_filtering": noiseGateFiltering,
-            "theme_mode": themeMode,
-            "show_tips": showTips,
-            "selected_tuning": selectedTuning,
-            "precision_mode": precisionMode,
-            "auto_advance": autoAdvance,
-            "a4_reference": a4Reference,
-            "spoken_feedback": spokenFeedback,
-            "auto_start_tuner": autoStartTuner,
-            "left_handed": leftHanded,
-            "show_note_names": showNoteNames,
-            "allow_muted": allowMuted,
-            "last_fret": lastFret,
-            "show_learn_tab": showLearnTab,
-            "show_reference_tab": showReferenceTab,
-            "strum_down": strumDown,
-            "app_language": appLanguage,
-        ]
+        repository.exportSettings()
     }
 
     func importSettings(_ dict: [String: Any]) {
-        if let v = dict["sound_enabled"] as? Bool { soundEnabled = v }
-        if let v = dict["volume"] as? Float { volume = v }
-        if let v = dict["note_duration_ms"] as? Int { noteDurationMs = v }
-        if let v = dict["strum_delay_ms"] as? Int { strumDelayMs = v }
-        if let v = dict["play_on_tap"] as? Bool { playOnTap = v }
-        if let v = dict["noise_gate_filtering"] as? Float { noiseGateFiltering = v }
-        if let v = dict["theme_mode"] as? String { themeMode = v }
-        if let v = dict["show_tips"] as? Bool { showTips = v }
-        if let v = dict["selected_tuning"] as? String { selectedTuning = v }
-        if let v = dict["precision_mode"] as? Bool { precisionMode = v }
-        if let v = dict["auto_advance"] as? Bool { autoAdvance = v }
-        if let v = dict["a4_reference"] as? Float { a4Reference = v }
-        if let v = dict["spoken_feedback"] as? Bool { spokenFeedback = v }
-        if let v = dict["auto_start_tuner"] as? Bool { autoStartTuner = v }
-        if let v = dict["left_handed"] as? Bool { leftHanded = v }
-        if let v = dict["show_note_names"] as? Bool { showNoteNames = v }
-        if let v = dict["allow_muted"] as? Bool { allowMuted = v }
-        if let v = dict["last_fret"] as? Int { lastFret = v }
-        if let v = dict["show_learn_tab"] as? Bool { showLearnTab = v }
-        if let v = dict["show_reference_tab"] as? Bool { showReferenceTab = v }
-        if let v = dict["strum_down"] as? Bool { strumDown = v }
-        if let v = dict["app_language"] as? String { appLanguage = v }
-        save()
+        repository.importSettings(dict)
+        load()
     }
 }

--- a/iosApp/UkuleleCompanion/ViewModels/SongbookViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/SongbookViewModel.swift
@@ -70,10 +70,11 @@ final class SongbookViewModel: ObservableObject {
     @Published var sortOrder: SongSortOrder = .lastModified
     @Published var selectedLabels: Set<String> = []
 
-    private let userDefaultsKey = "chord_sheets"
+    private let repository: SongbookRepository
 
-    init() {
-        load()
+    init(repository: SongbookRepository = SongbookRepository()) {
+        self.repository = repository
+        songs = repository.getAll()
     }
 
     var allLabels: [String] {
@@ -120,7 +121,7 @@ final class SongbookViewModel: ObservableObject {
         } else {
             songs.insert(song, at: 0)
         }
-        persist()
+        repository.save(songs)
     }
 
     func duplicate(song: StoredSong) -> StoredSong {
@@ -139,41 +140,41 @@ final class SongbookViewModel: ObservableObject {
             updatedAt: now
         )
         songs.insert(copy, at: 0)
-        persist()
+        repository.save(songs)
         return copy
     }
 
     func delete(id: String) {
         songs.removeAll { $0.id == id }
-        persist()
+        repository.save(songs)
     }
 
     func updateLabels(id: String, labels: [String]) {
         guard let idx = songs.firstIndex(where: { $0.id == id }) else { return }
         songs[idx].labels = labels
         songs[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(songs)
     }
 
     func updateStrumPattern(id: String, patternName: String) {
         guard let idx = songs.firstIndex(where: { $0.id == id }) else { return }
         songs[idx].strumPatternName = patternName
         songs[idx].updatedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(songs)
     }
 
     func recordView(id: String) {
         guard let idx = songs.firstIndex(where: { $0.id == id }) else { return }
         songs[idx].viewCount += 1
         songs[idx].lastViewedAt = Date().timeIntervalSince1970 * 1000
-        persist()
+        repository.save(songs)
     }
 
     func recordViewTime(id: String, elapsedMs: Double) {
         guard elapsedMs > 0,
               let idx = songs.firstIndex(where: { $0.id == id }) else { return }
         songs[idx].totalViewTimeMs += elapsedMs
-        persist()
+        repository.save(songs)
     }
 
     func importPlainText(content: String, filename: String?) {
@@ -259,42 +260,10 @@ final class SongbookViewModel: ObservableObject {
     }
 
     func importData(_ incoming: [[String: Any]]) {
-        let decoder = JSONDecoder()
-        for item in incoming {
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: item),
-                  let song = try? decoder.decode(StoredSong.self, from: jsonData)
-            else { continue }
-            if let idx = songs.firstIndex(where: { $0.id == song.id }) {
-                // Keep the one with the latest updatedAt
-                if song.updatedAt > songs[idx].updatedAt {
-                    songs[idx] = song
-                }
-            } else {
-                songs.append(song)
-            }
-        }
-        persist()
+        repository.importData(incoming, into: &songs)
     }
 
     func exportData() -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return songs.compactMap { song in
-            guard let data = try? encoder.encode(song),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
-    }
-
-    private func load() {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([StoredSong].self, from: data)
-        else { return }
-        songs = decoded
-    }
-
-    private func persist() {
-        guard let data = try? JSONEncoder().encode(songs) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        repository.exportData(songs)
     }
 }


### PR DESCRIPTION
## Summary

- Create 10 repository classes in `iosApp/UkuleleCompanion/Repositories/`
- Extract UserDefaults persistence from ViewModels into repositories
- ViewModels delegate read/write to their corresponding repository
- UserDefaults keys and stored formats unchanged (byte-compatible)
- ~700 lines of persistence code moved from ViewModels to repositories

New repositories: Favorites, Setlist, Songbook, Melody, Progressions, Learn, CustomPatterns, ScalePractice, PracticeTimer, Settings

## Test plan

- [ ] iOS build succeeds
- [ ] All screens load data correctly (favorites, setlists, melodies, etc.)
- [ ] Backup/restore works (data round-trips through repositories)
- [ ] No UserDefaults access in ViewModels (grep-clean except repositories)

Fixes #289

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured the internal data persistence layer to improve organization and management of app settings, user favorites, songbook entries, custom strum and fingerpicking patterns, melodies, setlists, learning activity progress, and practice session metrics
  * Enhanced backup and restore capabilities to provide better support for user data synchronization, management, and recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->