### PR TITLE
Fix: guard JsonListRepository against data loss on parse failure (fixes #301)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
@@ -26,14 +26,9 @@ class ChordSheetRepository(context: Context) : JsonListRepository<ChordSheet>(
     override fun getAll(): List<ChordSheet> {
         val raw = prefs.getString(KEY_SHEETS, null)
         if (raw != null) {
-            return try {
-                json.decodeFromString(
-                    kotlinx.serialization.builtins.ListSerializer(ChordSheet.serializer()),
-                    raw,
-                )
-            } catch (_: Exception) {
-                emptyList()
-            }
+            return tryParse(raw)
+                ?: tryParse(prefs.getString(backupKey, null))
+                ?: migrateLegacyPipeEntries()
         }
         return migrateLegacyPipeEntries()
     }

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
@@ -36,14 +36,9 @@ class CustomFingerpickingPatternRepository(context: Context) : JsonListRepositor
     override fun getAll(): List<CustomFingerpickingPattern> {
         val raw = prefs.getString(KEY_PATTERNS, null)
         if (raw != null) {
-            return try {
-                json.decodeFromString(
-                    kotlinx.serialization.builtins.ListSerializer(CustomFingerpickingPattern.serializer()),
-                    raw,
-                )
-            } catch (_: Exception) {
-                emptyList()
-            }
+            return tryParse(raw)
+                ?: tryParse(prefs.getString(backupKey, null))
+                ?: migrateLegacyPipeEntries()
         }
         return migrateLegacyPipeEntries()
     }

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
@@ -38,14 +38,9 @@ class CustomProgressionRepository(context: Context) : JsonListRepository<CustomP
     override fun getAll(): List<CustomProgression> {
         val raw = prefs.getString(KEY_PROGRESSIONS, null)
         if (raw != null) {
-            return try {
-                json.decodeFromString(
-                    kotlinx.serialization.builtins.ListSerializer(CustomProgression.serializer()),
-                    raw,
-                )
-            } catch (_: Exception) {
-                emptyList()
-            }
+            return tryParse(raw)
+                ?: tryParse(prefs.getString(backupKey, null))
+                ?: migrateLegacyPipeEntries()
         }
         return migrateLegacyPipeEntries()
     }

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
@@ -36,14 +36,9 @@ class CustomStrumPatternRepository(context: Context) : JsonListRepository<Custom
     override fun getAll(): List<CustomStrumPattern> {
         val raw = prefs.getString(KEY_PATTERNS, null)
         if (raw != null) {
-            return try {
-                json.decodeFromString(
-                    kotlinx.serialization.builtins.ListSerializer(CustomStrumPattern.serializer()),
-                    raw,
-                )
-            } catch (_: Exception) {
-                emptyList()
-            }
+            return tryParse(raw)
+                ?: tryParse(prefs.getString(backupKey, null))
+                ?: migrateLegacyPipeEntries()
         }
         return migrateLegacyPipeEntries()
     }

--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -25,12 +25,19 @@ abstract class JsonListRepository<T>(
     abstract fun entityId(item: T): String
     abstract fun entityTimestamp(item: T): Long
 
+    protected val backupKey get() = "${key}_backup"
+
     open fun getAll(): List<T> {
         val raw = prefs.getString(key, null) ?: return emptyList()
+        return tryParse(raw) ?: tryParse(prefs.getString(backupKey, null)) ?: emptyList()
+    }
+
+    protected fun tryParse(raw: String?): List<T>? {
+        if (raw == null) return null
         return try {
             json.decodeFromString(ListSerializer(serializer), raw)
         } catch (_: Exception) {
-            emptyList()
+            null
         }
     }
 
@@ -56,6 +63,9 @@ abstract class JsonListRepository<T>(
 
     protected fun persist(items: List<T>) {
         val raw = json.encodeToString(ListSerializer(serializer), items)
-        prefs.edit().putString(key, raw).apply()
+        prefs.edit()
+            .putString(backupKey, raw)
+            .putString(key, raw)
+            .apply()
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/data/SetlistRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SetlistRepository.kt
@@ -27,26 +27,21 @@ class SetlistRepository(context: Context) : JsonListRepository<Setlist>(
 
     override fun getAll(): List<Setlist> {
         val raw = prefs.getString(KEY_SETLISTS, null) ?: return emptyList()
-        return try {
-            json.decodeFromString(
-                kotlinx.serialization.builtins.ListSerializer(Setlist.serializer()),
-                raw,
-            )
-        } catch (_: Exception) {
-            migrateLegacyOrgJson(raw)
-        }
+        return tryParse(raw)
+            ?: migrateLegacyOrgJson(raw)
+            ?: tryParse(prefs.getString(backupKey, null))
+            ?: emptyList()
     }
 
-    private fun migrateLegacyOrgJson(raw: String): List<Setlist> {
+    private fun migrateLegacyOrgJson(raw: String): List<Setlist>? {
         return try {
             val array = JSONArray(raw)
             val items = (0 until array.length()).mapNotNull { i ->
                 deserializeLegacy(array.getJSONObject(i))
             }
-            if (items.isNotEmpty()) persist(items)
-            items
+            if (items.isNotEmpty()) { persist(items); items } else null
         } catch (_: Exception) {
-            emptyList()
+            null
         }
     }
 

--- a/app/src/test/java/com/baijum/ukufretboard/data/RepositorySerializationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/RepositorySerializationTest.kt
@@ -479,4 +479,53 @@ class RepositorySerializationTest {
         repo.importAll(listOf(duplicate))
         assertEquals("Existing", repo.getAll().first().pattern.name)
     }
+
+    // ── Data-loss prevention ───────────────────────────────────────
+
+    @Test
+    fun setlistCorruptJsonFallsBackToBackup() {
+        val repo = SetlistRepository(context)
+        val setlist = Setlist(id = "s1", name = "Important", songIds = listOf("a"), createdAt = 100L, updatedAt = 200L)
+        repo.save(setlist)
+        assertEquals(1, repo.getAll().size)
+
+        val prefs = context.getSharedPreferences("setlists", 0)
+        prefs.edit().putString("setlist_data", "CORRUPTED").apply()
+
+        val recovered = repo.getAll()
+        assertEquals("Backup key should provide recovery", 1, recovered.size)
+        assertEquals("Important", recovered[0].name)
+    }
+
+    @Test
+    fun chordSheetCorruptJsonFallsBackToLegacyMigration() {
+        val repo = ChordSheetRepository(context)
+        val sheet = ChordSheet(id = "cs1", title = "My Song", artist = "", content = "[C]Hello", createdAt = 100L, updatedAt = 200L)
+        repo.save(sheet)
+        assertEquals(1, repo.getAll().size)
+
+        val prefs = context.getSharedPreferences("chord_sheets", 0)
+        prefs.edit().putString("sheets_json", "CORRUPTED").apply()
+
+        val recovered = repo.getAll()
+        assertEquals("Backup key should provide recovery", 1, recovered.size)
+        assertEquals("My Song", recovered[0].title)
+    }
+
+    @Test
+    fun saveAfterCorruptionPreservesBackup() {
+        val repo = SetlistRepository(context)
+        val original = Setlist(id = "s1", name = "Original", songIds = emptyList(), createdAt = 100L, updatedAt = 200L)
+        repo.save(original)
+
+        val prefs = context.getSharedPreferences("setlists", 0)
+        prefs.edit().putString("setlist_data", "CORRUPTED").apply()
+
+        val newItem = Setlist(id = "s2", name = "New", songIds = emptyList(), createdAt = 300L, updatedAt = 400L)
+        repo.save(newItem)
+
+        val all = repo.getAll()
+        assertTrue("New item should be saved", all.any { it.id == "s2" })
+        assertTrue("Original should be recovered from backup", all.any { it.id == "s1" })
+    }
 }


### PR DESCRIPTION
## Summary

- Every `persist()` now writes both the main key and a `_backup` key with valid JSON
- `getAll()` falls back to the backup key when the main key fails to parse
- All 5 subclass `getAll()` overrides updated with the same backup fallback chain
- 3 new unit tests verify recovery from corruption

## Test plan

- [ ] All unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Existing data loads correctly after the change
- [ ] Corrupt main key recovers from backup: verified by `setlistCorruptJsonFallsBackToBackup`
- [ ] Save after corruption preserves both new and original data

Fixes #301

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data recovery when stored user content becomes corrupted with automatic fallback mechanisms
  * Added backup storage for chord sheets, fingerpicking patterns, chord progressions, and setlists

* **Tests**
  * Added tests verifying recovery behavior from corrupted data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->