### PR TITLE
Fix: eliminate TunerViewModel stale-UI race after stopCapture (fixes #306)

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -155,6 +155,8 @@ final class PitchMonitorViewModel: ObservableObject {
     }
 
     private func processBuffer(_ samples: [Float]) {
+        guard isListening else { return }
+
         let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
         for i in 0..<samples.count {
             kotlinArray.set(index: Int32(i), value: samples[i])
@@ -175,9 +177,7 @@ final class PitchMonitorViewModel: ObservableObject {
         if blankingFramesRemaining > 0 {
             blankingFramesRemaining -= 1
             let newPoint = PitchPoint(timestampMs: now, midiNote: nil)
-            DispatchQueue.main.async { [weak self] in
-                self?.appendPoint(newPoint, now: now)
-            }
+            appendPoint(newPoint, now: now)
             return
         }
 
@@ -186,12 +186,9 @@ final class PitchMonitorViewModel: ObservableObject {
             previousFrequency = nil
             recentFrequencies.removeAll()
             let newPoint = PitchPoint(timestampMs: now, midiNote: nil)
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.appendPoint(newPoint, now: now)
-                self.currentNote = nil
-                self.chromaEnergy = Array(repeating: 0, count: 12)
-            }
+            appendPoint(newPoint, now: now)
+            currentNote = nil
+            chromaEnergy = Array(repeating: 0, count: 12)
             return
         }
 
@@ -322,23 +319,20 @@ final class PitchMonitorViewModel: ObservableObject {
             finalChord = nil; finalIsArpeggio = false
         }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.appendPoint(newPoint, now: now)
-            self.currentNote = noteStr
-            self.detectedChord = finalChord
-            self.isArpeggioChord = finalIsArpeggio
-            if let chord = finalChord, chord != self.lastAnnouncedChord {
-                self.lastAnnouncedChord = chord
-                let prefix = finalIsArpeggio ? "Arpeggio chord: " : "Chord: "
-                AccessibilityAnnouncer.shared.announce("\(prefix)\(chord)", minInterval: 2.0)
-            }
-            self.chromaEnergy = self.lastChromaEnergy
-            if let note = noteStr, note != self.recentNotes.last {
-                self.recentNotes.append(note)
-                if self.recentNotes.count > 20 {
-                    self.recentNotes.removeFirst()
-                }
+        appendPoint(newPoint, now: now)
+        currentNote = noteStr
+        detectedChord = finalChord
+        isArpeggioChord = finalIsArpeggio
+        if let chord = finalChord, chord != lastAnnouncedChord {
+            lastAnnouncedChord = chord
+            let prefix = finalIsArpeggio ? "Arpeggio chord: " : "Chord: "
+            AccessibilityAnnouncer.shared.announce("\(prefix)\(chord)", minInterval: 2.0)
+        }
+        chromaEnergy = lastChromaEnergy
+        if let note = noteStr, note != recentNotes.last {
+            recentNotes.append(note)
+            if recentNotes.count > 20 {
+                recentNotes.removeFirst()
             }
         }
     }
@@ -378,7 +372,7 @@ final class PitchMonitorViewModel: ObservableObject {
                 Task.detached(priority: .userInitiated) { [weak self] in
                     let estimate = supervisor.estimate(samples)
                     await MainActor.run { [weak self] in
-                        guard let self else { return }
+                        guard let self, self.isListening else { return }
                         self.lastNeuralResult = estimate
                         self.neuralResultAgeFrames = 0
                         if let estimate = estimate {

--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -145,6 +145,8 @@ final class TunerViewModel: ObservableObject {
     }
 
     private func processAudioBuffer(_ samples: [Float]) {
+        guard isCapturing else { return }
+
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
         if rms < noiseGateRms {
             self.isInTune = false
@@ -169,77 +171,73 @@ final class TunerViewModel: ObservableObject {
         // Run neural supervision
         let neuralResult = maybeRunNeural(samples)
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+        if let result = result {
+            let arbitration = neuralArbitrator.arbitrate(
+                yinResult: result,
+                neuralResult: neuralResult
+            )
+            let finalHz = arbitration.frequencyHz
 
-            if let result = result {
-                let arbitration = self.neuralArbitrator.arbitrate(
-                    yinResult: result,
-                    neuralResult: neuralResult
-                )
-                let finalHz = arbitration.frequencyHz
+            previousFrequency = finalHz
 
-                self.previousFrequency = finalHz
+            if let noteInfo = TunerNoteMapper.shared.mapFrequency(hz: finalHz, a4Reference: a4Reference) {
+                let newNoteName = noteInfo.noteName
+                noteName = newNoteName
+                octave = Int(noteInfo.octave)
+                centsDeviation = noteInfo.centsDeviation
+                frequency = finalHz
 
-                if let noteInfo = TunerNoteMapper.shared.mapFrequency(hz: finalHz, a4Reference: self.a4Reference) {
-                    let newNoteName = noteInfo.noteName
-                    self.noteName = newNoteName
-                    self.octave = Int(noteInfo.octave)
-                    self.centsDeviation = noteInfo.centsDeviation
-                    self.frequency = finalHz
-
-                    // Announce note changes to VoiceOver
-                    let noteWithOctave = "\(newNoteName)\(noteInfo.octave)"
-                    if noteWithOctave != self.lastAnnouncedNote {
-                        self.lastAnnouncedNote = noteWithOctave
-                        AccessibilityAnnouncer.shared.announce(
-                            "Detected \(newNoteName) \(noteInfo.octave)"
-                        )
-                    }
-
-                    let stringResult = TunerNoteMapper.shared.findNearestString(
-                        noteInfo: noteInfo,
-                        tuning: self.currentTuning,
-                        a4Reference: self.a4Reference
-                    )
-                    self.stringMatch = stringResult.stringName
-                    let stringIdx = Int(stringResult.stringIndex)
-                    self.activeStringIndex = stringIdx
-
-                    let cents = stringResult.centsFromTarget
-                    let justTuned: Bool
-                    self.isInTune = abs(cents) <= 6
-                    if abs(cents) <= 6 {
-                        self.tuningStatus = "In tune!"
-                        self.settledFrames += 1
-                        if self.settledFrames >= Self.settledThreshold && !self.stringProgress[stringIdx] {
-                            self.stringProgress[stringIdx] = true
-                            justTuned = true
-                            self.advanceToNextUntuned()
-                        } else {
-                            justTuned = false
-                        }
-                    } else {
-                        justTuned = false
-                        self.settledFrames = 0
-                        if cents > 0 {
-                            self.tuningStatus = String(format: "%.0f cents sharp", cents)
-                        } else {
-                            self.tuningStatus = String(format: "%.0f cents flat", abs(cents))
-                        }
-                    }
-
-                    self.speakTunerState(
-                        note: newNoteName,
-                        cents: cents,
-                        stringTuned: justTuned,
-                        stringName: stringResult.stringName
+                // Announce note changes to VoiceOver
+                let noteWithOctave = "\(newNoteName)\(noteInfo.octave)"
+                if noteWithOctave != lastAnnouncedNote {
+                    lastAnnouncedNote = noteWithOctave
+                    AccessibilityAnnouncer.shared.announce(
+                        "Detected \(newNoteName) \(noteInfo.octave)"
                     )
                 }
-            } else {
-                self.settledFrames = 0
-                self.isInTune = false
+
+                let stringResult = TunerNoteMapper.shared.findNearestString(
+                    noteInfo: noteInfo,
+                    tuning: currentTuning,
+                    a4Reference: a4Reference
+                )
+                stringMatch = stringResult.stringName
+                let stringIdx = Int(stringResult.stringIndex)
+                activeStringIndex = stringIdx
+
+                let cents = stringResult.centsFromTarget
+                let justTuned: Bool
+                isInTune = abs(cents) <= 6
+                if abs(cents) <= 6 {
+                    tuningStatus = "In tune!"
+                    settledFrames += 1
+                    if settledFrames >= Self.settledThreshold && !stringProgress[stringIdx] {
+                        stringProgress[stringIdx] = true
+                        justTuned = true
+                        advanceToNextUntuned()
+                    } else {
+                        justTuned = false
+                    }
+                } else {
+                    justTuned = false
+                    settledFrames = 0
+                    if cents > 0 {
+                        tuningStatus = String(format: "%.0f cents sharp", cents)
+                    } else {
+                        tuningStatus = String(format: "%.0f cents flat", abs(cents))
+                    }
+                }
+
+                speakTunerState(
+                    note: newNoteName,
+                    cents: cents,
+                    stringTuned: justTuned,
+                    stringName: stringResult.stringName
+                )
             }
+        } else {
+            settledFrames = 0
+            isInTune = false
         }
     }
 
@@ -258,7 +256,7 @@ final class TunerViewModel: ObservableObject {
                 Task.detached(priority: .userInitiated) { [weak self] in
                     let estimate = supervisor.estimate(samples)
                     await MainActor.run { [weak self] in
-                        guard let self else { return }
+                        guard let self, self.isCapturing else { return }
                         if let estimate = estimate {
                             self.neuralArbitrator.onInferenceResult(result: estimate)
                             self.neuralStatus = .active


### PR DESCRIPTION
## Summary

- Remove redundant `DispatchQueue.main.async` in `processAudioBuffer` (already MainActor)
- Add `guard isCapturing else { return }` to prevent stale updates after stop
- Apply same fix to `PitchMonitorViewModel`

## Test plan

- [ ] iOS build succeeds
- [ ] Tuner starts/stops cleanly, no stale note flash after stop
- [ ] Pitch monitor starts/stops cleanly

Fixes #306

Made with [Cursor](https://cursor.com)