### PR TITLE
Fix: map unselected frets to MUTED in explorer inversion flow (fixes #304)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
@@ -153,7 +153,7 @@ internal fun ExplorerTabContent(
 
         val fretsList = uiState.selections.entries
             .sortedBy { it.key }
-            .map { it.value ?: 0 }
+            .map { it.value ?: ChordVoicing.MUTED }
 
         val shareCallback: (() -> Unit)? = if (
             onShareChord != null &&

--- a/iosApp/UkuleleCompanion/Views/ExplorerView.swift
+++ b/iosApp/UkuleleCompanion/Views/ExplorerView.swift
@@ -146,7 +146,7 @@ struct ExplorerView: View {
             if let maybeFret = fretboardVM.selections[s], let fret = maybeFret {
                 return Int32(fret)
             }
-            return 0
+            return -1
         }
     }
 


### PR DESCRIPTION
## Summary

- Android: change `it.value ?: 0` to `it.value ?: ChordVoicing.MUTED` in ExplorerTab
- iOS: change `return 0` to `return -1` in ExplorerView.currentFrets

Muted strings were incorrectly treated as open strings in inversion detection and slash notation.

## Test plan

- [ ] Android and iOS build
- [ ] Explorer: voicing with muted bass shows correct chord name (no spurious slash notation)
- [ ] Share chord diagram correctly shows muted strings as X

Fixes #304

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized internal representation of unselected and muted strings across iOS and Android for more consistent chord display behavior.
  * Enhanced handling of missing fret selections to ensure predictable results when sharing chords and working with chord inversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->