### PR TITLE
Fix: add TalkBack accessibility semantics to DrawerContent (fixes #303)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/DrawerContent.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/DrawerContent.kt
@@ -36,8 +36,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
 
@@ -48,8 +52,11 @@ internal fun DrawerContent(
     selectedSection: Int,
     onItemSelected: (Int) -> Unit,
 ) {
+    val navigationDrawerDescription = stringResource(R.string.cd_navigation_drawer)
     Column(
-        modifier = Modifier.verticalScroll(rememberScrollState()),
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .semantics { contentDescription = navigationDrawerDescription },
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -80,10 +87,16 @@ internal fun DrawerContent(
                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             }
             val expanded = expandedState.getOrPut(section.title) { true }
+            val expandedDescription = stringResource(R.string.cd_section_expanded)
+            val collapsedDescription = stringResource(R.string.cd_section_collapsed)
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { expandedState[section.title] = !expanded }
+                    .semantics {
+                        role = Role.Button
+                        stateDescription = if (expanded) expandedDescription else collapsedDescription
+                    }
                     .padding(horizontal = 28.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -309,9 +310,11 @@ internal fun CapoSelector(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.width(12.dp))
+        val decreaseCapoDescription = stringResource(R.string.cd_decrease_capo)
         IconButton(
             onClick = { onCapoChange((capoFret - 1).coerceAtLeast(0)) },
             enabled = capoFret > 0,
+            modifier = Modifier.semantics { contentDescription = decreaseCapoDescription },
         ) {
             Text(
                 text = "−",
@@ -329,9 +332,11 @@ internal fun CapoSelector(
             modifier = Modifier.width(32.dp),
             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
         )
+        val increaseCapoDescription = stringResource(R.string.cd_increase_capo)
         IconButton(
             onClick = { onCapoChange((capoFret + 1).coerceAtMost(lastFret)) },
             enabled = capoFret < lastFret,
+            modifier = Modifier.semantics { contentDescription = increaseCapoDescription },
         ) {
             Text(
                 text = "+",

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1175,4 +1175,9 @@
     <string name="batch_select_all">الكل</string>
     <string name="batch_cancel">إلغاء</string>
     <string name="batch_delete">حذف</string>
+    <string name="cd_navigation_drawer">درج التنقل</string>
+    <string name="cd_section_expanded">موسّع</string>
+    <string name="cd_section_collapsed">مطوي</string>
+    <string name="cd_decrease_capo">تقليل الكابو</string>
+    <string name="cd_increase_capo">زيادة الكابو</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1169,4 +1169,9 @@
     <string name="batch_select_all">Alle</string>
     <string name="batch_cancel">Abbrechen</string>
     <string name="batch_delete">Löschen</string>
+    <string name="cd_navigation_drawer">Navigationsleiste</string>
+    <string name="cd_section_expanded">Ausgeklappt</string>
+    <string name="cd_section_collapsed">Eingeklappt</string>
+    <string name="cd_decrease_capo">Capo verringern</string>
+    <string name="cd_increase_capo">Capo erhöhen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1181,4 +1181,9 @@
     <string name="batch_select_all">Todos</string>
     <string name="batch_cancel">Cancelar</string>
     <string name="batch_delete">Eliminar</string>
+    <string name="cd_navigation_drawer">Cajón de navegación</string>
+    <string name="cd_section_expanded">Expandido</string>
+    <string name="cd_section_collapsed">Contraído</string>
+    <string name="cd_decrease_capo">Disminuir cejilla</string>
+    <string name="cd_increase_capo">Aumentar cejilla</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1165,4 +1165,9 @@
     <string name="batch_select_all">Tout</string>
     <string name="batch_cancel">Annuler</string>
     <string name="batch_delete">Supprimer</string>
+    <string name="cd_navigation_drawer">Tiroir de navigation</string>
+    <string name="cd_section_expanded">Développé</string>
+    <string name="cd_section_collapsed">Réduit</string>
+    <string name="cd_decrease_capo">Diminuer le capo</string>
+    <string name="cd_increase_capo">Augmenter le capo</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1171,4 +1171,9 @@
     <string name="batch_select_all">सभी</string>
     <string name="batch_cancel">रद्द करें</string>
     <string name="batch_delete">हटाएं</string>
+    <string name="cd_navigation_drawer">नेविगेशन ड्रॉअर</string>
+    <string name="cd_section_expanded">विस्तारित</string>
+    <string name="cd_section_collapsed">संकुचित</string>
+    <string name="cd_decrease_capo">कैपो घटाएं</string>
+    <string name="cd_increase_capo">कैपो बढ़ाएं</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1168,4 +1168,9 @@
     <string name="batch_select_all">Semua</string>
     <string name="batch_cancel">Batal</string>
     <string name="batch_delete">Hapus</string>
+    <string name="cd_navigation_drawer">Laci navigasi</string>
+    <string name="cd_section_expanded">Diperluas</string>
+    <string name="cd_section_collapsed">Diciutkan</string>
+    <string name="cd_decrease_capo">Kurangi capo</string>
+    <string name="cd_increase_capo">Tambah capo</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1169,4 +1169,9 @@
     <string name="batch_select_all">Tutti</string>
     <string name="batch_cancel">Annulla</string>
     <string name="batch_delete">Elimina</string>
+    <string name="cd_navigation_drawer">Cassetto di navigazione</string>
+    <string name="cd_section_expanded">Espanso</string>
+    <string name="cd_section_collapsed">Compresso</string>
+    <string name="cd_decrease_capo">Diminuisci capo</string>
+    <string name="cd_increase_capo">Aumenta capo</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1170,4 +1170,9 @@
     <string name="batch_select_all">すべて</string>
     <string name="batch_cancel">キャンセル</string>
     <string name="batch_delete">削除</string>
+    <string name="cd_navigation_drawer">ナビゲーションドロワー</string>
+    <string name="cd_section_expanded">展開済み</string>
+    <string name="cd_section_collapsed">折りたたみ</string>
+    <string name="cd_decrease_capo">カポを下げる</string>
+    <string name="cd_increase_capo">カポを上げる</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1170,4 +1170,9 @@
     <string name="batch_select_all">전체</string>
     <string name="batch_cancel">취소</string>
     <string name="batch_delete">삭제</string>
+    <string name="cd_navigation_drawer">탐색 서랍</string>
+    <string name="cd_section_expanded">펼침</string>
+    <string name="cd_section_collapsed">접힘</string>
+    <string name="cd_decrease_capo">카포 감소</string>
+    <string name="cd_increase_capo">카포 증가</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1169,4 +1169,9 @@
     <string name="batch_select_all">Alles</string>
     <string name="batch_cancel">Annuleren</string>
     <string name="batch_delete">Verwijderen</string>
+    <string name="cd_navigation_drawer">Navigatielade</string>
+    <string name="cd_section_expanded">Uitgevouwen</string>
+    <string name="cd_section_collapsed">Ingeklapt</string>
+    <string name="cd_decrease_capo">Capo verlagen</string>
+    <string name="cd_increase_capo">Capo verhogen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1171,4 +1171,9 @@
     <string name="batch_select_all">Wszystkie</string>
     <string name="batch_cancel">Anuluj</string>
     <string name="batch_delete">Usuń</string>
+    <string name="cd_navigation_drawer">Panel nawigacji</string>
+    <string name="cd_section_expanded">Rozwinięte</string>
+    <string name="cd_section_collapsed">Zwinięte</string>
+    <string name="cd_decrease_capo">Zmniejsz capo</string>
+    <string name="cd_increase_capo">Zwiększ capo</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1167,4 +1167,9 @@
     <string name="batch_select_all">Todos</string>
     <string name="batch_cancel">Cancelar</string>
     <string name="batch_delete">Excluir</string>
+    <string name="cd_navigation_drawer">Gaveta de navegação</string>
+    <string name="cd_section_expanded">Expandido</string>
+    <string name="cd_section_collapsed">Recolhido</string>
+    <string name="cd_decrease_capo">Diminuir capo</string>
+    <string name="cd_increase_capo">Aumentar capo</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1173,4 +1173,9 @@
     <string name="batch_select_all">Все</string>
     <string name="batch_cancel">Отмена</string>
     <string name="batch_delete">Удалить</string>
+    <string name="cd_navigation_drawer">Панель навигации</string>
+    <string name="cd_section_expanded">Развёрнуто</string>
+    <string name="cd_section_collapsed">Свёрнуто</string>
+    <string name="cd_decrease_capo">Уменьшить капо</string>
+    <string name="cd_increase_capo">Увеличить капо</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1169,4 +1169,9 @@
     <string name="batch_select_all">Tümü</string>
     <string name="batch_cancel">İptal</string>
     <string name="batch_delete">Sil</string>
+    <string name="cd_navigation_drawer">Gezinme çekmecesi</string>
+    <string name="cd_section_expanded">Genişletildi</string>
+    <string name="cd_section_collapsed">Daraltıldı</string>
+    <string name="cd_decrease_capo">Kapoyu azalt</string>
+    <string name="cd_increase_capo">Kapoyu artır</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="cd_navigation_drawer">导航抽屉</string>
+    <string name="cd_section_expanded">已展开</string>
+    <string name="cd_section_collapsed">已折叠</string>
+    <string name="cd_decrease_capo">降低变调夹</string>
+    <string name="cd_increase_capo">升高变调夹</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,13 @@
     <string name="nav_glossary">Glossary</string>
     <string name="nav_help">Help</string>
 
+    <!-- ── Navigation Drawer Accessibility ───────────────────────────── -->
+    <string name="cd_navigation_drawer">Navigation drawer</string>
+    <string name="cd_section_expanded">Expanded</string>
+    <string name="cd_section_collapsed">Collapsed</string>
+    <string name="cd_decrease_capo">Decrease capo</string>
+    <string name="cd_increase_capo">Increase capo</string>
+
     <!-- ── Top Bar / Content Descriptions ───────────────────────────── -->
     <string name="cd_open_nav_menu">Open navigation menu</string>
     <string name="cd_settings">Settings</string>


### PR DESCRIPTION
## Summary

- Add navigation pane semantics to drawer root container
- Add expand/collapse state descriptions to section headers
- Add capo button content descriptions in ExplorerTab

## Test plan

- [ ] Android build succeeds
- [ ] TalkBack announces drawer as navigation region
- [ ] Section headers announce expanded/collapsed state
- [ ] Capo buttons announce "Decrease capo" / "Increase capo"

Fixes #303

Made with [Cursor](https://cursor.com)