### PR TITLE
Fix: extract hardcoded melody UI strings into stringResource (fixes #305)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyInputControls.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyInputControls.kt
@@ -356,7 +356,7 @@ private fun RecordInputContent(
                 ) {
                     state.lastAddedFeedback?.let { feedback ->
                         Text(
-                            text = "Added $feedback",
+                            text = stringResource(R.string.melody_added_feedback, feedback),
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.primary,
@@ -504,12 +504,13 @@ internal fun OctaveSelector(
                 contentDescription = stringResource(R.string.cd_decrease_octave),
             )
         }
+        val octaveDescription = stringResource(R.string.cd_octave_value, currentOctave)
         Text(
             text = currentOctave.toString(),
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.semantics {
-                contentDescription = "Octave $currentOctave"
+                contentDescription = octaveDescription
                 liveRegion = LiveRegionMode.Polite
             },
         )

--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNoteSequence.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNoteSequence.kt
@@ -132,17 +132,17 @@ private fun NoteBlock(
     }
 
     val durationLabel = when (note.duration) {
-        NoteDuration.WHOLE -> "whole"
-        NoteDuration.HALF -> "half"
-        NoteDuration.QUARTER -> "quarter"
-        NoteDuration.EIGHTH -> "eighth"
-        NoteDuration.SIXTEENTH -> "sixteenth"
+        NoteDuration.WHOLE -> stringResource(R.string.melody_duration_whole)
+        NoteDuration.HALF -> stringResource(R.string.melody_duration_half)
+        NoteDuration.QUARTER -> stringResource(R.string.melody_duration_quarter)
+        NoteDuration.EIGHTH -> stringResource(R.string.melody_duration_eighth)
+        NoteDuration.SIXTEENTH -> stringResource(R.string.melody_duration_sixteenth)
     }
 
     val noteDescription = if (note.pitchClass != null) {
-        "$noteName${note.octave} $durationLabel note, position ${index + 1}"
+        stringResource(R.string.cd_note_position, "$noteName${note.octave}", durationLabel, index + 1)
     } else {
-        "Rest, $durationLabel, position ${index + 1}"
+        stringResource(R.string.cd_rest_position, durationLabel, index + 1)
     }
 
     Column(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
@@ -23,7 +23,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.Melody
 import com.baijum.ukufretboard.viewmodel.MelodyViewModel
 
@@ -98,20 +100,22 @@ fun MelodyNotepadView(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            val linearModeDesc = stringResource(R.string.cd_linear_mode)
             FilterChip(
                 selected = !state.isStepSequencerMode,
                 onClick = { if (state.isStepSequencerMode) viewModel.toggleStepSequencerMode() },
-                label = { Text("Linear") },
+                label = { Text(stringResource(R.string.melody_mode_linear)) },
                 modifier = Modifier.semantics {
-                    contentDescription = "Linear mode, sequential note entry"
+                    contentDescription = linearModeDesc
                 },
             )
+            val stepSequencerModeDesc = stringResource(R.string.cd_step_sequencer_mode)
             FilterChip(
                 selected = state.isStepSequencerMode,
                 onClick = { if (!state.isStepSequencerMode) viewModel.toggleStepSequencerMode() },
-                label = { Text("Step Sequencer") },
+                label = { Text(stringResource(R.string.melody_mode_step_sequencer)) },
                 modifier = Modifier.semantics {
-                    contentDescription = "Step sequencer mode, grid-based entry"
+                    contentDescription = stepSequencerModeDesc
                 },
             )
         }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyStepSequencer.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyStepSequencer.kt
@@ -27,12 +27,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.viewmodel.MelodyUiState
 
@@ -44,11 +46,11 @@ internal fun StepSequencerGrid(
     onClearStep: (Int) -> Unit,
     onExpandSteps: () -> Unit,
 ) {
-    val gridLabel = "Melody step sequencer, ${state.steps.size} steps"
+    val gridLabel = stringResource(R.string.cd_step_sequencer_grid, state.steps.size)
 
     Column(modifier = Modifier.semantics { contentDescription = gridLabel }) {
         Text(
-            text = "Step Sequencer (${state.steps.size} steps)",
+            text = stringResource(R.string.melody_step_sequencer_title, state.steps.size),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
         )
@@ -64,9 +66,9 @@ internal fun StepSequencerGrid(
                 val isPlaying = state.isPlaying && state.playingIndex == index
                 val noteName = note?.pitchClass?.let { Notes.pitchClassToName(it) }
                 val stepDesc = if (noteName != null) {
-                    "Step ${index + 1}: $noteName${note.octave} ${note.duration.name.lowercase()}"
+                    stringResource(R.string.cd_step_note, index + 1, "$noteName${note.octave}", note.duration.name.lowercase())
                 } else {
-                    "Step ${index + 1}: empty"
+                    stringResource(R.string.cd_step_empty, index + 1)
                 }
 
                 var showPitchPicker by remember { mutableStateOf(false) }
@@ -139,9 +141,9 @@ internal fun StepSequencerGrid(
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             val expandLabel = if (state.steps.size >= MelodyUiState.STEP_COUNT_16) {
-                "8 steps"
+                stringResource(R.string.melody_steps_8)
             } else {
-                "16 steps"
+                stringResource(R.string.melody_steps_16)
             }
             OutlinedButton(onClick = onExpandSteps) {
                 Text(expandLabel)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -822,6 +822,22 @@
     <string name="cd_start_recording">تسجيل نوتات من اليوكيليلي</string>
     <string name="cd_stop_recording">إيقاف التسجيل</string>
     <string name="melody_rename_dialog_title">إعادة تسمية اللحن</string>
+    <string name="melody_added_feedback">تمت إضافة %s</string>
+    <string name="melody_mode_linear">خطي</string>
+    <string name="melody_mode_step_sequencer">مُتتابع خطوات</string>
+    <string name="melody_duration_whole">كاملة</string>
+    <string name="melody_duration_half">نصف</string>
+    <string name="melody_duration_quarter">ربع</string>
+    <string name="melody_duration_eighth">ثُمن</string>
+    <string name="melody_duration_sixteenth">ذات السادس عشر</string>
+    <string name="melody_step_sequencer_title">مُتتابع خطوات (%d خطوة)</string>
+    <string name="melody_steps_8">8 خطوات</string>
+    <string name="melody_steps_16">16 خطوة</string>
+    <string name="cd_linear_mode">الوضع الخطي، إدخال متتابع للنوتات</string>
+    <string name="cd_step_sequencer_mode">وضع المُتتابع، إدخال شبكي</string>
+    <string name="cd_step_sequencer_grid">مُتتابع خطوات اللحن، %d خطوة</string>
+    <string name="cd_step_note">خطوة %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">خطوة %d: فارغة</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">العودة إلى التقدمات اللحنية</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -817,6 +817,22 @@
     <string name="cd_start_recording">从尤克里里录制音符</string>
     <string name="cd_stop_recording">停止录音</string>
     <string name="melody_rename_dialog_title">重命名旋律</string>
+    <string name="melody_added_feedback">已添加 %s</string>
+    <string name="melody_mode_linear">线性</string>
+    <string name="melody_mode_step_sequencer">步进音序器</string>
+    <string name="melody_duration_whole">全音符</string>
+    <string name="melody_duration_half">二分音符</string>
+    <string name="melody_duration_quarter">四分音符</string>
+    <string name="melody_duration_eighth">八分音符</string>
+    <string name="melody_duration_sixteenth">十六分音符</string>
+    <string name="melody_step_sequencer_title">步进音序器（%d 步）</string>
+    <string name="melody_steps_8">8 步</string>
+    <string name="melody_steps_16">16 步</string>
+    <string name="cd_linear_mode">线性模式，逐个输入音符</string>
+    <string name="cd_step_sequencer_mode">步进音序器模式，网格式输入</string>
+    <string name="cd_step_sequencer_grid">旋律步进音序器，%d 步</string>
+    <string name="cd_step_note">第 %1$d 步：%2$s %3$s</string>
+    <string name="cd_step_empty">第 %d 步：空</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">返回和弦进行</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Noten von der Ukulele aufnehmen</string>
     <string name="cd_stop_recording">Aufnahme stoppen</string>
     <string name="melody_rename_dialog_title">Melodie umbenennen</string>
+    <string name="melody_added_feedback">%s hinzugefügt</string>
+    <string name="melody_mode_linear">Linear</string>
+    <string name="melody_mode_step_sequencer">Step-Sequenzer</string>
+    <string name="melody_duration_whole">ganz</string>
+    <string name="melody_duration_half">halb</string>
+    <string name="melody_duration_quarter">viertel</string>
+    <string name="melody_duration_eighth">achtel</string>
+    <string name="melody_duration_sixteenth">sechzehntel</string>
+    <string name="melody_step_sequencer_title">Step-Sequenzer (%d Schritte)</string>
+    <string name="melody_steps_8">8 Schritte</string>
+    <string name="melody_steps_16">16 Schritte</string>
+    <string name="cd_linear_mode">Linearer Modus, sequenzielle Noteneingabe</string>
+    <string name="cd_step_sequencer_mode">Step-Sequenzer-Modus, rasterbasierte Eingabe</string>
+    <string name="cd_step_sequencer_grid">Melodie-Step-Sequenzer, %d Schritte</string>
+    <string name="cd_step_note">Schritt %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Schritt %d: leer</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">Zurück zu Akkordfolgen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Grabar notas del ukulele</string>
     <string name="cd_stop_recording">Detener grabación</string>
     <string name="melody_rename_dialog_title">Renombrar melodía</string>
+    <string name="melody_added_feedback">%s añadido</string>
+    <string name="melody_mode_linear">Lineal</string>
+    <string name="melody_mode_step_sequencer">Secuenciador</string>
+    <string name="melody_duration_whole">redonda</string>
+    <string name="melody_duration_half">blanca</string>
+    <string name="melody_duration_quarter">negra</string>
+    <string name="melody_duration_eighth">corchea</string>
+    <string name="melody_duration_sixteenth">semicorchea</string>
+    <string name="melody_step_sequencer_title">Secuenciador (%d pasos)</string>
+    <string name="melody_steps_8">8 pasos</string>
+    <string name="melody_steps_16">16 pasos</string>
+    <string name="cd_linear_mode">Modo lineal, entrada secuencial de notas</string>
+    <string name="cd_step_sequencer_mode">Modo secuenciador, entrada en cuadrícula</string>
+    <string name="cd_step_sequencer_grid">Secuenciador de melodía, %d pasos</string>
+    <string name="cd_step_note">Paso %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Paso %d: vacío</string>
 
     <!-- ── Conducción de voces ───────────────────────────────────────── -->
     <string name="cd_back_progressions">Volver a progresiones</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Enregistrer des notes depuis le ukulélé</string>
     <string name="cd_stop_recording">Arrêter l\'enregistrement</string>
     <string name="melody_rename_dialog_title">Renommer la mélodie</string>
+    <string name="melody_added_feedback">%s ajouté</string>
+    <string name="melody_mode_linear">Linéaire</string>
+    <string name="melody_mode_step_sequencer">Séquenceur</string>
+    <string name="melody_duration_whole">ronde</string>
+    <string name="melody_duration_half">blanche</string>
+    <string name="melody_duration_quarter">noire</string>
+    <string name="melody_duration_eighth">croche</string>
+    <string name="melody_duration_sixteenth">double croche</string>
+    <string name="melody_step_sequencer_title">Séquenceur (%d pas)</string>
+    <string name="melody_steps_8">8 pas</string>
+    <string name="melody_steps_16">16 pas</string>
+    <string name="cd_linear_mode">Mode linéaire, saisie séquentielle des notes</string>
+    <string name="cd_step_sequencer_mode">Mode séquenceur, saisie en grille</string>
+    <string name="cd_step_sequencer_grid">Séquenceur de mélodie, %d pas</string>
+    <string name="cd_step_note">Pas %1$d : %2$s %3$s</string>
+    <string name="cd_step_empty">Pas %d : vide</string>
 
     <!-- ── Conduite des voix ─────────────────────────────────────────── -->
     <string name="cd_back_progressions">Retour aux progressions</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">यूकुलेले से नोट्स रिकॉर्ड करें</string>
     <string name="cd_stop_recording">रिकॉर्डिंग बंद करें</string>
     <string name="melody_rename_dialog_title">मेलोडी का नाम बदलें</string>
+    <string name="melody_added_feedback">%s जोड़ा गया</string>
+    <string name="melody_mode_linear">रैखिक</string>
+    <string name="melody_mode_step_sequencer">स्टेप सीक्वेंसर</string>
+    <string name="melody_duration_whole">पूर्ण</string>
+    <string name="melody_duration_half">आधी</string>
+    <string name="melody_duration_quarter">चौथाई</string>
+    <string name="melody_duration_eighth">आठवीं</string>
+    <string name="melody_duration_sixteenth">सोलहवीं</string>
+    <string name="melody_step_sequencer_title">स्टेप सीक्वेंसर (%d स्टेप)</string>
+    <string name="melody_steps_8">8 स्टेप</string>
+    <string name="melody_steps_16">16 स्टेप</string>
+    <string name="cd_linear_mode">रैखिक मोड, क्रमिक नोट प्रविष्टि</string>
+    <string name="cd_step_sequencer_mode">स्टेप सीक्वेंसर मोड, ग्रिड-आधारित प्रविष्टि</string>
+    <string name="cd_step_sequencer_grid">मेलोडी स्टेप सीक्वेंसर, %d स्टेप</string>
+    <string name="cd_step_note">स्टेप %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">स्टेप %d: खाली</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">प्रोग्रेशन पर वापस जाएँ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -817,6 +817,22 @@
     <string name="cd_start_recording">Rekam not dari ukulele</string>
     <string name="cd_stop_recording">Hentikan rekaman</string>
     <string name="melody_rename_dialog_title">Ubah Nama Melodi</string>
+    <string name="melody_added_feedback">%s ditambahkan</string>
+    <string name="melody_mode_linear">Linear</string>
+    <string name="melody_mode_step_sequencer">Step Sequencer</string>
+    <string name="melody_duration_whole">penuh</string>
+    <string name="melody_duration_half">setengah</string>
+    <string name="melody_duration_quarter">seperempat</string>
+    <string name="melody_duration_eighth">seperdelapan</string>
+    <string name="melody_duration_sixteenth">seperenam belas</string>
+    <string name="melody_step_sequencer_title">Step Sequencer (%d langkah)</string>
+    <string name="melody_steps_8">8 langkah</string>
+    <string name="melody_steps_16">16 langkah</string>
+    <string name="cd_linear_mode">Mode linear, input not berurutan</string>
+    <string name="cd_step_sequencer_mode">Mode step sequencer, input berbasis grid</string>
+    <string name="cd_step_sequencer_grid">Step sequencer melodi, %d langkah</string>
+    <string name="cd_step_note">Langkah %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Langkah %d: kosong</string>
 
     <!-- ── Voice Leading ──────────────────────────────────────────────── -->
     <string name="cd_back_progressions">Kembali ke progresi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Registra note dall\'ukulele</string>
     <string name="cd_stop_recording">Interrompi registrazione</string>
     <string name="melody_rename_dialog_title">Rinomina melodia</string>
+    <string name="melody_added_feedback">%s aggiunto</string>
+    <string name="melody_mode_linear">Lineare</string>
+    <string name="melody_mode_step_sequencer">Sequenziatore</string>
+    <string name="melody_duration_whole">semibreve</string>
+    <string name="melody_duration_half">minima</string>
+    <string name="melody_duration_quarter">semiminima</string>
+    <string name="melody_duration_eighth">croma</string>
+    <string name="melody_duration_sixteenth">semicroma</string>
+    <string name="melody_step_sequencer_title">Sequenziatore (%d passi)</string>
+    <string name="melody_steps_8">8 passi</string>
+    <string name="melody_steps_16">16 passi</string>
+    <string name="cd_linear_mode">Modalità lineare, inserimento sequenziale delle note</string>
+    <string name="cd_step_sequencer_mode">Modalità sequenziatore, inserimento a griglia</string>
+    <string name="cd_step_sequencer_grid">Sequenziatore melodia, %d passi</string>
+    <string name="cd_step_note">Passo %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Passo %d: vuoto</string>
 
     <!-- ── Condotta delle voci ────────────────────────────────────────── -->
     <string name="cd_back_progressions">Torna alle progressioni</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -817,6 +817,22 @@
     <string name="cd_start_recording">ウクレレからノートを録音</string>
     <string name="cd_stop_recording">録音を停止</string>
     <string name="melody_rename_dialog_title">メロディーの名前を変更</string>
+    <string name="melody_added_feedback">%s を追加</string>
+    <string name="melody_mode_linear">リニア</string>
+    <string name="melody_mode_step_sequencer">ステップシーケンサー</string>
+    <string name="melody_duration_whole">全音符</string>
+    <string name="melody_duration_half">2分音符</string>
+    <string name="melody_duration_quarter">4分音符</string>
+    <string name="melody_duration_eighth">8分音符</string>
+    <string name="melody_duration_sixteenth">16分音符</string>
+    <string name="melody_step_sequencer_title">ステップシーケンサー（%d ステップ）</string>
+    <string name="melody_steps_8">8 ステップ</string>
+    <string name="melody_steps_16">16 ステップ</string>
+    <string name="cd_linear_mode">リニアモード、順次音符入力</string>
+    <string name="cd_step_sequencer_mode">ステップシーケンサーモード、グリッド入力</string>
+    <string name="cd_step_sequencer_grid">メロディーステップシーケンサー、%d ステップ</string>
+    <string name="cd_step_note">ステップ %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">ステップ %d: 空</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">コード進行に戻る</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -817,6 +817,22 @@
     <string name="cd_start_recording">우쿨렐레에서 음표 녹음</string>
     <string name="cd_stop_recording">녹음 중지</string>
     <string name="melody_rename_dialog_title">멜로디 이름 바꾸기</string>
+    <string name="melody_added_feedback">%s 추가됨</string>
+    <string name="melody_mode_linear">순차</string>
+    <string name="melody_mode_step_sequencer">스텝 시퀀서</string>
+    <string name="melody_duration_whole">온음표</string>
+    <string name="melody_duration_half">2분음표</string>
+    <string name="melody_duration_quarter">4분음표</string>
+    <string name="melody_duration_eighth">8분음표</string>
+    <string name="melody_duration_sixteenth">16분음표</string>
+    <string name="melody_step_sequencer_title">스텝 시퀀서 (%d 스텝)</string>
+    <string name="melody_steps_8">8 스텝</string>
+    <string name="melody_steps_16">16 스텝</string>
+    <string name="cd_linear_mode">순차 모드, 순서대로 음표 입력</string>
+    <string name="cd_step_sequencer_mode">스텝 시퀀서 모드, 격자 기반 입력</string>
+    <string name="cd_step_sequencer_grid">멜로디 스텝 시퀀서, %d 스텝</string>
+    <string name="cd_step_note">스텝 %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">스텝 %d: 비어 있음</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">코드 진행으로 돌아가기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Noten opnemen van ukulele</string>
     <string name="cd_stop_recording">Opname stoppen</string>
     <string name="melody_rename_dialog_title">Melodie hernoemen</string>
+    <string name="melody_added_feedback">%s toegevoegd</string>
+    <string name="melody_mode_linear">Lineair</string>
+    <string name="melody_mode_step_sequencer">Stappensequencer</string>
+    <string name="melody_duration_whole">heel</string>
+    <string name="melody_duration_half">half</string>
+    <string name="melody_duration_quarter">kwart</string>
+    <string name="melody_duration_eighth">achtste</string>
+    <string name="melody_duration_sixteenth">zestiende</string>
+    <string name="melody_step_sequencer_title">Stappensequencer (%d stappen)</string>
+    <string name="melody_steps_8">8 stappen</string>
+    <string name="melody_steps_16">16 stappen</string>
+    <string name="cd_linear_mode">Lineaire modus, opeenvolgende nootinvoer</string>
+    <string name="cd_step_sequencer_mode">Stappensequencermodus, rasterinvoer</string>
+    <string name="cd_step_sequencer_grid">Melodie-stappensequencer, %d stappen</string>
+    <string name="cd_step_note">Stap %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Stap %d: leeg</string>
 
     <!-- ── Stemvoering ────────────────────────────────────────────────── -->
     <string name="cd_back_progressions">Terug naar progressies</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -820,6 +820,22 @@
     <string name="cd_start_recording">Nagrywaj nuty z ukulele</string>
     <string name="cd_stop_recording">Zatrzymaj nagrywanie</string>
     <string name="melody_rename_dialog_title">Zmień nazwę melodii</string>
+    <string name="melody_added_feedback">Dodano %s</string>
+    <string name="melody_mode_linear">Liniowy</string>
+    <string name="melody_mode_step_sequencer">Sekwencer krokowy</string>
+    <string name="melody_duration_whole">cała</string>
+    <string name="melody_duration_half">półnuta</string>
+    <string name="melody_duration_quarter">ćwierćnuta</string>
+    <string name="melody_duration_eighth">ósemka</string>
+    <string name="melody_duration_sixteenth">szesnastka</string>
+    <string name="melody_step_sequencer_title">Sekwencer krokowy (%d kroków)</string>
+    <string name="melody_steps_8">8 kroków</string>
+    <string name="melody_steps_16">16 kroków</string>
+    <string name="cd_linear_mode">Tryb liniowy, sekwencyjne wprowadzanie nut</string>
+    <string name="cd_step_sequencer_mode">Tryb sekwencera krokowego, wprowadzanie w siatce</string>
+    <string name="cd_step_sequencer_grid">Sekwencer melodii, %d kroków</string>
+    <string name="cd_step_note">Krok %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Krok %d: pusty</string>
 
     <!-- ── Prowadzenie głosów ─────────────────────────────────────────── -->
     <string name="cd_back_progressions">Wróć do progresji</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Gravar notas do ukulele</string>
     <string name="cd_stop_recording">Parar gravação</string>
     <string name="melody_rename_dialog_title">Renomear Melodia</string>
+    <string name="melody_added_feedback">%s adicionado</string>
+    <string name="melody_mode_linear">Linear</string>
+    <string name="melody_mode_step_sequencer">Sequenciador</string>
+    <string name="melody_duration_whole">semibreve</string>
+    <string name="melody_duration_half">mínima</string>
+    <string name="melody_duration_quarter">semínima</string>
+    <string name="melody_duration_eighth">colcheia</string>
+    <string name="melody_duration_sixteenth">semicolcheia</string>
+    <string name="melody_step_sequencer_title">Sequenciador (%d passos)</string>
+    <string name="melody_steps_8">8 passos</string>
+    <string name="melody_steps_16">16 passos</string>
+    <string name="cd_linear_mode">Modo linear, entrada sequencial de notas</string>
+    <string name="cd_step_sequencer_mode">Modo sequenciador, entrada em grade</string>
+    <string name="cd_step_sequencer_grid">Sequenciador de melodia, %d passos</string>
+    <string name="cd_step_note">Passo %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Passo %d: vazio</string>
 
     <!-- ── Condução de vozes ─────────────────────────────────────────── -->
     <string name="cd_back_progressions">Voltar às progressões</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -820,6 +820,22 @@
     <string name="cd_start_recording">Записать ноты с укулеле</string>
     <string name="cd_stop_recording">Остановить запись</string>
     <string name="melody_rename_dialog_title">Переименовать мелодию</string>
+    <string name="melody_added_feedback">Добавлено: %s</string>
+    <string name="melody_mode_linear">Линейный</string>
+    <string name="melody_mode_step_sequencer">Секвенсор</string>
+    <string name="melody_duration_whole">целая</string>
+    <string name="melody_duration_half">половинная</string>
+    <string name="melody_duration_quarter">четвертная</string>
+    <string name="melody_duration_eighth">восьмая</string>
+    <string name="melody_duration_sixteenth">шестнадцатая</string>
+    <string name="melody_step_sequencer_title">Секвенсор (%d шагов)</string>
+    <string name="melody_steps_8">8 шагов</string>
+    <string name="melody_steps_16">16 шагов</string>
+    <string name="cd_linear_mode">Линейный режим, последовательный ввод нот</string>
+    <string name="cd_step_sequencer_mode">Режим секвенсора, ввод по сетке</string>
+    <string name="cd_step_sequencer_grid">Секвенсор мелодии, %d шагов</string>
+    <string name="cd_step_note">Шаг %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Шаг %d: пусто</string>
 
     <!-- ── Voice Leading ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">Назад к прогрессиям</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -818,6 +818,22 @@
     <string name="cd_start_recording">Ukuleleden notaları kaydet</string>
     <string name="cd_stop_recording">Kaydı durdur</string>
     <string name="melody_rename_dialog_title">Melodiyi Yeniden Adlandır</string>
+    <string name="melody_added_feedback">%s eklendi</string>
+    <string name="melody_mode_linear">Doğrusal</string>
+    <string name="melody_mode_step_sequencer">Adım Sıralayıcı</string>
+    <string name="melody_duration_whole">tam</string>
+    <string name="melody_duration_half">yarım</string>
+    <string name="melody_duration_quarter">dörtlük</string>
+    <string name="melody_duration_eighth">sekizlik</string>
+    <string name="melody_duration_sixteenth">on altılık</string>
+    <string name="melody_step_sequencer_title">Adım Sıralayıcı (%d adım)</string>
+    <string name="melody_steps_8">8 adım</string>
+    <string name="melody_steps_16">16 adım</string>
+    <string name="cd_linear_mode">Doğrusal mod, sıralı nota girişi</string>
+    <string name="cd_step_sequencer_mode">Adım sıralayıcı modu, ızgara tabanlı giriş</string>
+    <string name="cd_step_sequencer_grid">Melodi adım sıralayıcı, %d adım</string>
+    <string name="cd_step_note">Adım %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Adım %d: boş</string>
 
     <!-- ── Ses Yönlendirme ────────────────────────────────────────────── -->
     <string name="cd_back_progressions">İlerlemelere dön</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -4,4 +4,20 @@
     <string name="cd_section_collapsed">已折叠</string>
     <string name="cd_decrease_capo">降低变调夹</string>
     <string name="cd_increase_capo">升高变调夹</string>
+    <string name="melody_added_feedback">已添加 %s</string>
+    <string name="melody_mode_linear">线性</string>
+    <string name="melody_mode_step_sequencer">步进音序器</string>
+    <string name="melody_duration_whole">全音符</string>
+    <string name="melody_duration_half">二分音符</string>
+    <string name="melody_duration_quarter">四分音符</string>
+    <string name="melody_duration_eighth">八分音符</string>
+    <string name="melody_duration_sixteenth">十六分音符</string>
+    <string name="melody_step_sequencer_title">步进音序器（%d 步）</string>
+    <string name="melody_steps_8">8 步</string>
+    <string name="melody_steps_16">16 步</string>
+    <string name="cd_linear_mode">线性模式，逐个输入音符</string>
+    <string name="cd_step_sequencer_mode">步进音序器模式，网格式输入</string>
+    <string name="cd_step_sequencer_grid">旋律步进音序器，%d 步</string>
+    <string name="cd_step_note">第 %1$d 步：%2$s %3$s</string>
+    <string name="cd_step_empty">第 %d 步：空</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -916,6 +916,22 @@
     <string name="cd_start_recording">Record notes from ukulele</string>
     <string name="cd_stop_recording">Stop recording</string>
     <string name="melody_rename_dialog_title">Rename Melody</string>
+    <string name="melody_added_feedback">Added %s</string>
+    <string name="melody_mode_linear">Linear</string>
+    <string name="melody_mode_step_sequencer">Step Sequencer</string>
+    <string name="melody_duration_whole">whole</string>
+    <string name="melody_duration_half">half</string>
+    <string name="melody_duration_quarter">quarter</string>
+    <string name="melody_duration_eighth">eighth</string>
+    <string name="melody_duration_sixteenth">sixteenth</string>
+    <string name="melody_step_sequencer_title">Step Sequencer (%d steps)</string>
+    <string name="melody_steps_8">8 steps</string>
+    <string name="melody_steps_16">16 steps</string>
+    <string name="cd_linear_mode">Linear mode, sequential note entry</string>
+    <string name="cd_step_sequencer_mode">Step sequencer mode, grid-based entry</string>
+    <string name="cd_step_sequencer_grid">Melody step sequencer, %d steps</string>
+    <string name="cd_step_note">Step %1$d: %2$s %3$s</string>
+    <string name="cd_step_empty">Step %d: empty</string>
 
     <string name="cd_add_known_chord">Add %s to known chords</string>
 


### PR DESCRIPTION
## Summary

- Extract 6 hardcoded user-facing strings from melody UI package into string resources
- Replace with `stringResource(R.string.xxx)` calls
- Add translations for all 15 locales
- Lint passes clean (no MissingTranslation errors)

## Test plan

- [ ] Android build and lint pass
- [ ] Melody notepad screen displays correctly
- [ ] Accessibility labels are readable by TalkBack

Fixes #305

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Melody Notepad UI translations for 16+ languages: Arabic, Chinese, French, German, Hindi, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Russian, Spanish, and Turkish.
  * Improved accessibility with localized content descriptions for melody input controls, note duration labels, and step sequencer grid interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->