### PR TITLE
Fix: use ordinalityOfUnit for currentDayOfYear() on iOS

### DIFF
--- a/shared/src/iosMain/kotlin/com/baijum/ukufretboard/platform/PlatformUtils.ios.kt
+++ b/shared/src/iosMain/kotlin/com/baijum/ukufretboard/platform/PlatformUtils.ios.kt
@@ -1,7 +1,7 @@
 package com.baijum.ukufretboard.platform
 
 import platform.Foundation.NSCalendar
-import platform.Foundation.NSCalendarUnitDayOfYear
+import platform.Foundation.NSCalendarUnitDay
 import platform.Foundation.NSCalendarUnitYear
 import platform.Foundation.NSDate
 import platform.Foundation.NSUUID
@@ -18,8 +18,7 @@ actual fun currentYear(): Int {
     return components.year.toInt()
 }
 
-actual fun currentDayOfYear(): Int {
-    val calendar = NSCalendar.currentCalendar
-    val components = calendar.components(NSCalendarUnitDayOfYear, fromDate = NSDate())
-    return components.day.toInt()
-}
+actual fun currentDayOfYear(): Int =
+    NSCalendar.currentCalendar
+        .ordinalityOfUnit(NSCalendarUnitDay, inUnit = NSCalendarUnitYear, forDate = NSDate())
+        .toInt()


### PR DESCRIPTION
## Summary
- Replaces the broken `NSCalendar.components` + `components.day` call with `ordinalityOfUnit(NSCalendarUnitDay, inUnit: NSCalendarUnitYear)` which correctly returns the 1-based day-of-year.
- The old code requested `NSCalendarUnitDayOfYear` but read `components.day` (day-of-month), which was unpopulated and returned -1, causing daily challenges to use the same RNG seed all year on iOS.

Fixes #324

Made with [Cursor](https://cursor.com)