### PR TITLE
Fix: escape metadata and content lines in ChordPro export

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordProExporter.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordProExporter.kt
@@ -20,6 +20,10 @@ object ChordProExporter {
     /** Maps a captured section type to its ChordPro directive base name. */
     private fun sectionDirective(type: String): String = type.lowercase()
 
+    /** Strips `{`, `}`, and newlines from a metadata value to prevent directive injection. */
+    private fun sanitizeMeta(value: String): String =
+        value.replace("{", "").replace("}", "").replace("\n", " ").replace("\r", "")
+
     /**
      * Converts a [ChordSheet] to a ChordPro-formatted string.
      *
@@ -27,15 +31,15 @@ object ChordProExporter {
      * @return The ChordPro-formatted text.
      */
     fun export(sheet: ChordSheet): String = buildString {
-        appendLine("{title: ${sheet.title}}")
+        appendLine("{title: ${sanitizeMeta(sheet.title)}}")
         if (sheet.subtitle.isNotEmpty()) {
-            appendLine("{subtitle: ${sheet.subtitle}}")
+            appendLine("{subtitle: ${sanitizeMeta(sheet.subtitle)}}")
         }
         if (sheet.artist.isNotEmpty()) {
-            appendLine("{artist: ${sheet.artist}}")
+            appendLine("{artist: ${sanitizeMeta(sheet.artist)}}")
         }
         if (sheet.key.isNotEmpty()) {
-            appendLine("{key: ${sheet.key}}")
+            appendLine("{key: ${sanitizeMeta(sheet.key)}}")
         }
         if (sheet.capo > 0) {
             appendLine("{capo: ${sheet.capo}}")
@@ -60,7 +64,14 @@ object ChordProExporter {
                     appendLine("{start_of_$type}")
                 }
             } else {
-                appendLine(line)
+                val trimmed = line.trimStart()
+                if (trimmed.startsWith("#")) {
+                    appendLine("{comment: $line}")
+                } else if (trimmed.startsWith("{")) {
+                    appendLine("\\$line")
+                } else {
+                    appendLine(line)
+                }
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordProParser.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordProParser.kt
@@ -87,6 +87,11 @@ object ChordProParser {
 
             if (trimmed.startsWith("#")) return@forEach
 
+            if (trimmed.startsWith("\\{")) {
+                contentLines.add(line.replaceFirst("\\", ""))
+                return@forEach
+            }
+
             val match = DIRECTIVE.find(trimmed)
             if (match != null && trimmed.startsWith("{")) {
                 val directive = match.groupValues[1].lowercase()

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
@@ -204,6 +204,62 @@ class ChordProExporterTest {
         assertTrue(result.contains("{end_of_verse}"))
     }
 
+    // --- export: metadata escaping ---
+
+    @Test
+    fun exportSanitizesBracesInTitle() {
+        val result = ChordProExporter.export(sheet(title = "Hey} {capo: 7"))
+        assertTrue(result.contains("{title: Hey capo: 7}"), "Result: $result")
+        assertFalse(result.contains("{capo: 7}"), "Brace injection should be stripped: $result")
+    }
+
+    @Test
+    fun exportSanitizesNewlinesInArtist() {
+        val result = ChordProExporter.export(sheet(artist = "Line1\nLine2"))
+        assertTrue(result.contains("{artist: Line1 Line2}"), "Newline should become space: $result")
+    }
+
+    // --- export: content line escaping ---
+
+    @Test
+    fun exportEscapesHashPrefixedContent() {
+        val result = ChordProExporter.export(sheet(content = "#1 Hit Song"))
+        assertTrue(result.contains("{comment: #1 Hit Song}"), "Hash line should be wrapped: $result")
+    }
+
+    @Test
+    fun exportEscapesBracePrefixedContent() {
+        val result = ChordProExporter.export(sheet(content = "{custom directive}"))
+        assertTrue(result.contains("\\{custom directive}"), "Brace line should be escaped: $result")
+    }
+
+    // --- round-trip: edge cases ---
+
+    @Test
+    fun roundTripPreservesHashPrefixedLyrics() {
+        val original = sheet(title = "Test", content = "#1 Hit\nNormal line")
+        val exported = ChordProExporter.export(original)
+        val reimported = ChordProParser.parse(exported)
+        assertTrue(reimported.content.contains("#1 Hit"), "Content: ${reimported.content}")
+        assertTrue(reimported.content.contains("Normal line"))
+    }
+
+    @Test
+    fun roundTripPreservesBracePrefixedContent() {
+        val original = sheet(title = "Test", content = "{looks like directive}\nNormal")
+        val exported = ChordProExporter.export(original)
+        val reimported = ChordProParser.parse(exported)
+        assertTrue(reimported.content.contains("{looks like directive}"), "Content: ${reimported.content}")
+    }
+
+    @Test
+    fun roundTripSanitizesTitleWithBraces() {
+        val original = sheet(title = "Hey} {capo: 7")
+        val exported = ChordProExporter.export(original)
+        val reimported = ChordProParser.parse(exported)
+        assertEquals("Hey capo: 7", reimported.title)
+    }
+
     // --- suggestedFilename ---
 
     @Test


### PR DESCRIPTION
## Summary
- Sanitizes `{`, `}`, and newlines from metadata values (title, subtitle, artist, key) to prevent directive injection on re-import.
- Wraps `#`-prefixed content lines in `{comment:}` directives so they survive round-trip instead of being silently dropped as comments.
- Backslash-escapes content lines starting with `{` to prevent them being parsed as unknown directives and silently discarded.
- Parser now recognizes `\{`-prefixed lines and strips the escape.

Fixes #323

Made with [Cursor](https://cursor.com)