### PR TITLE
Fix: normalize timestamps for all collections in BackupCodec

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
@@ -131,6 +131,11 @@ object BackupCodec {
             "setlists" to arrayOf("createdAt", "updatedAt"),
             "customStrumPatterns" to arrayOf("createdAt"),
             "customFingerpickingPatterns" to arrayOf("createdAt"),
+            "chordSheets" to arrayOf("createdAt", "updatedAt", "lastViewedAt"),
+            "melodies" to arrayOf("createdAt"),
+            "customProgressions" to arrayOf("createdAt"),
+            "favorites" to arrayOf("addedAt"),
+            "favoriteFolders" to arrayOf("createdAt"),
         )
         val objectFields = mapOf(
             "practiceTimer" to arrayOf("lastSessionTime"),

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/sync/BackupCodecTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/sync/BackupCodecTest.kt
@@ -433,6 +433,95 @@ class BackupCodecTest {
     }
 
     @Test
+    fun normalizeTimestampsForChordSheets() {
+        val jsonWithFractional = """
+        {
+            "version": 3,
+            "exportedAt": 1717430400000,
+            "chordSheets": [
+                {
+                    "id": "cs-1",
+                    "title": "Song",
+                    "content": "",
+                    "createdAt": 1718180000123.456,
+                    "updatedAt": 1718180000123.789,
+                    "lastViewedAt": 1718180000123.0,
+                    "viewCount": 0,
+                    "totalViewTimeMs": 0
+                }
+            ]
+        }
+        """.trimIndent()
+
+        val decoded = BackupCodec.decode(jsonWithFractional)
+        assertEquals(1718180000123L, decoded.chordSheets[0].createdAt)
+        assertEquals(1718180000123L, decoded.chordSheets[0].updatedAt)
+        assertEquals(1718180000123L, decoded.chordSheets[0].lastViewedAt)
+    }
+
+    @Test
+    fun normalizeTimestampsForMelodiesAndProgressions() {
+        val jsonWithSeconds = """
+        {
+            "version": 3,
+            "exportedAt": 1717430400000,
+            "melodies": [
+                {
+                    "id": "m-1",
+                    "name": "Scale",
+                    "notes": [],
+                    "bpm": 120,
+                    "createdAt": 1718180000
+                }
+            ],
+            "customProgressions": [
+                {
+                    "id": "cp-1",
+                    "name": "I-IV-V",
+                    "description": "",
+                    "scaleType": "MAJOR",
+                    "degrees": [],
+                    "createdAt": 1718180000
+                }
+            ]
+        }
+        """.trimIndent()
+
+        val decoded = BackupCodec.decode(jsonWithSeconds)
+        assertEquals(1718180000000L, decoded.melodies[0].createdAt)
+        assertEquals(1718180000000L, decoded.customProgressions[0].createdAt)
+    }
+
+    @Test
+    fun normalizeTimestampsForFavoritesAndFolders() {
+        val jsonWithFractional = """
+        {
+            "version": 3,
+            "exportedAt": 1717430400000,
+            "favorites": [
+                {
+                    "rootPitchClass": 0,
+                    "chordSymbol": "",
+                    "frets": [0, 0, 0, 3],
+                    "addedAt": 1718180000123.456
+                }
+            ],
+            "favoriteFolders": [
+                {
+                    "id": "f1",
+                    "name": "Jazz",
+                    "createdAt": 1718180000
+                }
+            ]
+        }
+        """.trimIndent()
+
+        val decoded = BackupCodec.decode(jsonWithFractional)
+        assertEquals(1718180000123L, decoded.favorites[0].addedAt)
+        assertEquals(1718180000000L, decoded.favoriteFolders[0].createdAt)
+    }
+
+    @Test
     fun encodeProducesPrettyPrintedJson() {
         val data = BackupData(exportedAt = 12345L)
         val encoded = BackupCodec.encode(data)


### PR DESCRIPTION
## Summary
- Adds `chordSheets` (createdAt, updatedAt, lastViewedAt), `melodies` (createdAt), `customProgressions` (createdAt), `favorites` (addedAt), and `favoriteFolders` (createdAt) to the `normalizeKmpTimestamps` arrayFields map.
- Legacy iOS backups with fractional-Double timestamps in these collections caused `decodeFromString` to throw (Long can't parse fractional JSON numbers), failing the entire restore. Epoch-seconds values silently corrupted to January 1970 dates.
- Added tests with fractional and epoch-seconds timestamps for all newly covered collections.

Fixes #315

Made with [Cursor](https://cursor.com)