### PR TITLE
Fix: annotate BackupCodec.decode with @Throws and fix Swift caller

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -136,7 +136,7 @@ final class BackupRestoreManager: ObservableObject {
 
         let backup: BackupData
         do {
-            backup = try catchKotlinException { BackupCodec.shared.decode(jsonString: jsonString) }
+            backup = try BackupCodec.shared.decode(jsonString: jsonString)
         } catch {
             throw BackupError.invalidJSON
         }
@@ -695,16 +695,6 @@ final class BackupRestoreManager: ObservableObject {
     private static let themeFromKMP: [String: String] = {
         Dictionary(uniqueKeysWithValues: themeToKMP.map { ($0.value, $0.key) })
     }()
-}
-
-// MARK: - Kotlin exception bridging
-
-private func catchKotlinException<T>(_ block: () -> T) throws -> T {
-    do {
-        return block()
-    } catch let error as NSError {
-        throw error
-    }
 }
 
 struct BackupDocument: FileDocument {

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
@@ -43,6 +43,7 @@ object BackupCodec {
      * - Old iOS format (identified by `"timestamp"` field in epoch seconds)
      * - KMP-format backups with fractional or seconds-unit timestamps
      */
+    @Throws(Exception::class)
     fun decode(jsonString: String): BackupData {
         val afterLegacy = normalizeIosFormat(jsonString)
         val normalized = normalizeKmpTimestamps(afterLegacy)


### PR DESCRIPTION
## Summary
- Adds `@Throws(Exception::class)` to `BackupCodec.decode()` so Kotlin exceptions surface as Swift `throws` instead of terminating the process.
- Removes the no-op `catchKotlinException` wrapper (its closure type was non-throwing, making the `catch` dead code).
- The Swift restore path now uses real `try/catch` against the KMP API.

Fixes #314

Made with [Cursor](https://cursor.com)