### PR TITLE
Fix: move blocking AudioRecord.read() to Dispatchers.IO

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/audio/AudioCaptureEngine.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/audio/AudioCaptureEngine.kt
@@ -135,7 +135,7 @@ object AudioCaptureEngine {
 
         captureJob = scope.launch {
             try {
-                withContext(Dispatchers.Default) {
+                withContext(Dispatchers.IO) {
                     // Read from the recorder in hop-sized chunks.
                     val shortBuf = ShortArray(HOP_SIZE)
 


### PR DESCRIPTION
## Summary
- Changes `withContext(Dispatchers.Default)` to `withContext(Dispatchers.IO)` for the blocking `AudioRecord.read()` loop in `AudioCaptureEngine`.
- `Dispatchers.IO` is designed for blocking I/O and has an elastic thread pool, preventing starvation of `Dispatchers.Default` on low-core devices.

Fixes #325

Made with [Cursor](https://cursor.com)