### PR TITLE
Fix: make tuner auto-start a one-shot per tab entry

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
@@ -150,11 +150,9 @@ private fun TunerContent(
     val haptic = LocalHapticFeedback.current
     val reduceMotion = LocalReduceMotion.current
 
-    // --- Auto-start: begin listening when entering the tab ----------------
-    if (tunerSettings.autoStart && !state.isListening) {
-        LaunchedEffect(Unit) {
-            viewModel.startTuning()
-        }
+    // --- Auto-start: one-shot on tab entry when enabled --------------------
+    LaunchedEffect(tunerSettings.autoStart) {
+        if (tunerSettings.autoStart) viewModel.startTuning()
     }
 
     // --- Haptic feedback on string tuned ----------------------------------


### PR DESCRIPTION
## Summary
- Replaces the conditional `if (autoStart && !isListening) { LaunchedEffect(Unit) }` pattern with `LaunchedEffect(tunerSettings.autoStart)` that fires once when the tab is entered.
- Prevents the mic from restarting immediately after every stop (user tap, audio focus loss), and eliminates the audio-focus steal loop.

Fixes #318

Made with [Cursor](https://cursor.com)