### PR TITLE
Fix: stop microphone capture when app goes to background

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/PitchMonitorTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PitchMonitorTab.kt
@@ -138,9 +138,19 @@ fun PitchMonitorTab(
     val context = LocalContext.current
     viewModel.setApplicationContext(context)
 
-    // Stop capture when navigating away.
-    DisposableEffect(Unit) {
-        onDispose { viewModel.stopListening() }
+    // Stop capture when navigating away or when the app goes to background.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) {
+                viewModel.stopListening()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            viewModel.stopListening()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     RequireMicPermission {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/TunerTab.kt
@@ -117,9 +117,19 @@ fun TunerTab(
     }
     viewModel.setApplicationContext(context)
 
-    // Stop capture when leaving the tab.
-    DisposableEffect(Unit) {
-        onDispose { viewModel.stopTuning() }
+    // Stop capture when leaving the tab or when the app goes to background.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) {
+                viewModel.stopTuning()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            viewModel.stopTuning()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     RequireMicPermission {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
@@ -50,8 +50,18 @@ fun MelodyNotepadView(
     var showMenu by remember { mutableStateOf(false) }
     var bpmSliderValue by remember(state.bpm) { mutableFloatStateOf(state.bpm.toFloat()) }
 
-    DisposableEffect(Unit) {
-        onDispose { viewModel.stopRecording() }
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP) {
+                viewModel.stopRecording()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            viewModel.stopRecording()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
 
     Column(


### PR DESCRIPTION
## Summary
- Adds `LifecycleEventObserver` to TunerTab, PitchMonitorTab, and MelodyNotepadView that stops audio capture on `ON_STOP`.
- Previously, capture only stopped on composable disposal (tab switch) or ViewModel clearing, not when the user pressed Home or locked the screen.
- Prevents continued microphone recording and CPU-intensive DSP/ONNX processing while the app is in the background.

Fixes #317

Made with [Cursor](https://cursor.com)