### PR TITLE
Fix: remove invalid .defaultToSpeaker option from .playback audio category

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -219,7 +219,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
             print("AudioCaptureEngine: failed to deactivate audio session: \(error)")
         }
         do {
-            try session.setCategory(.playback, mode: .default, options: [.defaultToSpeaker])
+            try session.setCategory(.playback, mode: .default)
             try session.setActive(true)
         } catch {
             print("AudioCaptureEngine: failed to restore playback session: \(error)")

--- a/iosApp/UkuleleCompanion/UkuleleCompanionApp.swift
+++ b/iosApp/UkuleleCompanion/UkuleleCompanionApp.swift
@@ -42,7 +42,7 @@ struct UkuleleCompanionApp: App {
         #else
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(.playback, mode: .default, options: [.defaultToSpeaker])
+            try session.setCategory(.playback, mode: .default)
             try session.setPreferredSampleRate(44100)
             try session.setActive(true)
         } catch {


### PR DESCRIPTION
## Summary
- Removes `.defaultToSpeaker` from `.setCategory(.playback, ...)` calls in both `UkuleleCompanionApp.configureAudioSession()` and `AudioCaptureEngine.deactivateRecordingSession()`.
- `.defaultToSpeaker` is only valid with `.playAndRecord`; combining it with `.playback` silently throws, leaving the session in `.soloAmbient` where audio is silenced by the Ring/Silent switch.

Fixes #319

Made with [Cursor](https://cursor.com)