### PR TITLE
Fix: guard against zero-length audio buffer in iOS AudioCaptureEngine

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
+++ b/iosApp/UkuleleCompanion/Audio/AudioCaptureEngine.swift
@@ -150,6 +150,7 @@ final class AudioCaptureEngine: ObservableObject, @unchecked Sendable {
         guard let channelData = buffer.floatChannelData else { return }
         let samples = channelData[0]
         let count = Int(buffer.frameLength)
+        guard count > 0 else { return }
 
         bufferLock.lock()
         defer { bufferLock.unlock() }


### PR DESCRIPTION
## Summary
- Adds `guard count > 0 else { return }` at the top of `processBuffer` to prevent out-of-bounds reads when AVAudioEngine delivers a zero-frame buffer during route changes.

Fixes #320

Made with [Cursor](https://cursor.com)