### PR TITLE
Fix: prevent PlayAlongViewModel from stacking duplicate timers

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -67,6 +67,7 @@ final class PlayAlongViewModel: ObservableObject {
             errorMessage = "No chords in this progression. Please select a progression first."
             return
         }
+        guard !isPlaying else { return }
         errorMessage = nil
         self.degrees = degrees
         self.bpm = bpm
@@ -122,6 +123,7 @@ final class PlayAlongViewModel: ObservableObject {
         audioEngine.start()
         isPlaying = true
 
+        timer?.invalidate()
         let interval = 60.0 / bpm
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- Adds `guard !isPlaying else { return }` at the top of `start()` to reject double-taps during the async permission window.
- Adds `timer?.invalidate()` before reassigning in `beginSession()` to prevent orphaned timers firing at 2x rate.

Fixes #322

Made with [Cursor](https://cursor.com)