### PR TITLE
Fix: move audio analysis off the main thread on iOS

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -104,6 +104,9 @@ final class MelodyViewModel: ObservableObject {
     private var playbackTask: Task<Void, Never>?
     private let audioEngine = AudioCaptureEngine()
     private nonisolated(unsafe) let frameGate = FrameGate()
+    private nonisolated(unsafe) let audioProcessingQueue = DispatchQueue(
+        label: "com.baijum.ukufretboard.melody.dsp", qos: .userInitiated
+    )
     private var stableCount = 0
     private var lastDetectedPitchClass: Int? = nil
 
@@ -309,7 +312,7 @@ final class MelodyViewModel: ObservableObject {
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
             guard self.frameGate.tryEnter() else { return }
-            Task { @MainActor in
+            self.audioProcessingQueue.async {
                 let floatArray = KotlinFloatArray(size: Int32(samples.count))
                 for i in 0..<samples.count {
                     floatArray.set(index: Int32(i), value: samples[i])
@@ -322,48 +325,47 @@ final class MelodyViewModel: ObservableObject {
                     previousFrequency: nil
                 )
 
-                guard let result, result.confidence > 0.8 else {
-                    self.detectedNote = nil
-                    self.stableCount = 0
-                    self.lastDetectedPitchClass = nil
-                    self.stabilizationProgress = 0
-                    self.frameGate.exit()
-                    return
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    defer { self.frameGate.exit() }
+
+                    guard let result, result.confidence > 0.8 else {
+                        self.detectedNote = nil
+                        self.stableCount = 0
+                        self.lastDetectedPitchClass = nil
+                        self.stabilizationProgress = 0
+                        return
+                    }
+
+                    let noteInfo = TunerNoteMapper.shared.mapFrequency(
+                        hz: result.frequencyHz,
+                        a4Reference: 440.0
+                    )
+
+                    guard let noteInfo else { return }
+
+                    let pc = Int(noteInfo.pitchClass)
+                    let oct = Int(noteInfo.octave)
+
+                    self.detectedNote = noteInfo.noteName + "\(oct)"
+
+                    if pc == self.lastDetectedPitchClass {
+                        self.stableCount += 1
+                    } else {
+                        self.lastDetectedPitchClass = pc
+                        self.stableCount = 1
+                    }
+
+                    self.stabilizationProgress = Float(self.stableCount) / Float(Self.stabilizationThreshold)
+
+                    if self.stableCount >= Self.stabilizationThreshold {
+                        self.addNote(pitchClass: pc, octave: oct)
+                        self.stableCount = 0
+                        self.lastDetectedPitchClass = nil
+                        self.detectedNote = nil
+                        self.stabilizationProgress = 0
+                    }
                 }
-
-                let noteInfo = TunerNoteMapper.shared.mapFrequency(
-                    hz: result.frequencyHz,
-                    a4Reference: 440.0
-                )
-
-                guard let noteInfo else {
-                    self.frameGate.exit()
-                    return
-                }
-
-                let pc = Int(noteInfo.pitchClass)
-                let oct = Int(noteInfo.octave)
-
-                self.detectedNote = noteInfo.noteName + "\(oct)"
-
-                if pc == self.lastDetectedPitchClass {
-                    self.stableCount += 1
-                } else {
-                    self.lastDetectedPitchClass = pc
-                    self.stableCount = 1
-                }
-
-                self.stabilizationProgress = Float(self.stableCount) / Float(Self.stabilizationThreshold)
-
-                if self.stableCount >= Self.stabilizationThreshold {
-                    self.addNote(pitchClass: pc, octave: oct)
-                    self.stableCount = 0
-                    self.lastDetectedPitchClass = nil
-                    self.detectedNote = nil
-                    self.stabilizationProgress = 0
-                }
-
-                self.frameGate.exit()
             }
         }
 

--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -73,14 +73,38 @@ final class PitchMonitorViewModel: ObservableObject {
     private var lastArpeggioChordMs: Int64 = 0
     private static let arpeggioHoldFrames = 2
 
+    private nonisolated(unsafe) let audioProcessingQueue = DispatchQueue(
+        label: "com.baijum.ukufretboard.pitchmonitor.dsp", qos: .userInitiated
+    )
+
     init() {
         neuralSupervisor = nil
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
             guard self.frameGate.tryEnter() else { return }
-            Task { @MainActor in
-                self.processBuffer(samples)
-                self.frameGate.exit()
+            self.audioProcessingQueue.async {
+                let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
+                for i in 0..<samples.count {
+                    kotlinArray.set(index: Int32(i), value: samples[i])
+                }
+                let yinResult = PitchDetector.shared.detect(
+                    samples: kotlinArray,
+                    sampleRate: 44100,
+                    threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
+                    previousFrequency: nil
+                )
+                let chordResult = AudioChordDetector.shared.detect(
+                    samples: kotlinArray,
+                    sampleRate: 44100,
+                    threshold: 0.28,
+                    preferredRootPitchClass: nil,
+                    preferredRootWeight: 1.15
+                )
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.processBuffer(samples, yinResult: yinResult, chordResult: chordResult)
+                    self.frameGate.exit()
+                }
             }
         }
         Task {
@@ -154,15 +178,13 @@ final class PitchMonitorViewModel: ObservableObject {
         isListening = true
     }
 
-    private func processBuffer(_ samples: [Float]) {
+    private func processBuffer(
+        _ samples: [Float],
+        yinResult: PitchResult?,
+        chordResult: AudioChordDetector.ChordDetectionResult
+    ) {
         guard isListening else { return }
 
-        let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
-        for i in 0..<samples.count {
-            kotlinArray.set(index: Int32(i), value: samples[i])
-        }
-
-        // RMS for onset detection
         var sumSq: Float = 0
         for s in samples { sumSq += s * s }
         let currentRms = sqrt(sumSq / Float(samples.count))
@@ -181,7 +203,6 @@ final class PitchMonitorViewModel: ObservableObject {
             return
         }
 
-        // Noise gate
         if currentRms < noiseGateRms {
             previousFrequency = nil
             recentFrequencies.removeAll()
@@ -192,19 +213,8 @@ final class PitchMonitorViewModel: ObservableObject {
             return
         }
 
-        // Pitch detection
-        let prevFreq = previousFrequency.map { KotlinDouble(value: $0) }
-        let yinResult = PitchDetector.shared.detect(
-            samples: kotlinArray,
-            sampleRate: 44100,
-            threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
-            previousFrequency: prevFreq
-        )
-
-        // Neural supervision
         let neuralResult = maybeRunNeural(samples)
 
-        // Arbitrate
         var finalHz: Double?
         if let yin = yinResult {
             if let neural = neuralResult {
@@ -241,15 +251,7 @@ final class PitchMonitorViewModel: ObservableObject {
             arpeggioDetector.addNote(timestampMs: Int64(now), pitchClass: pitchClass)
         }
 
-        // Chord detection (throttled)
         if chordFrameCounter % Self.chordDetectionInterval == 0 {
-            let chordResult = AudioChordDetector.shared.detect(
-                samples: kotlinArray,
-                sampleRate: 44100,
-                threshold: 0.28,
-                preferredRootPitchClass: nil,
-                preferredRootWeight: 1.15
-            )
             let rawChordName: String? = {
                 if let found = chordResult.detection as? ChordDetector.DetectionResultChordFound {
                     return found.result.name

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -20,6 +20,9 @@ final class PlayAlongViewModel: ObservableObject {
 
     private let audioEngine = AudioCaptureEngine()
     private nonisolated(unsafe) let frameGate = FrameGate()
+    private nonisolated(unsafe) let audioProcessingQueue = DispatchQueue(
+        label: "com.baijum.ukufretboard.playalong.dsp", qos: .userInitiated
+    )
     let tonePlayer = TonePlayer()
     private let scorer = PlayAlongScorer()
 
@@ -47,9 +50,23 @@ final class PlayAlongViewModel: ObservableObject {
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
             guard self.frameGate.tryEnter() else { return }
-            Task { @MainActor in
-                self.processAudioBuffer(samples)
-                self.frameGate.exit()
+            self.audioProcessingQueue.async {
+                let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
+                for i in 0..<samples.count {
+                    kotlinArray.set(index: Int32(i), value: samples[i])
+                }
+                let chordResult = AudioChordDetector.shared.detect(
+                    samples: kotlinArray,
+                    sampleRate: 44100,
+                    threshold: 0.28,
+                    preferredRootPitchClass: nil,
+                    preferredRootWeight: 1.15
+                )
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.processAudioBuffer(samples, chordResult: chordResult)
+                    self.frameGate.exit()
+                }
             }
         }
     }
@@ -166,33 +183,19 @@ final class PlayAlongViewModel: ObservableObject {
 
     // MARK: - Audio Processing
 
-    private func processAudioBuffer(_ samples: [Float]) {
-        let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
-        for i in 0..<samples.count {
-            kotlinArray.set(index: Int32(i), value: samples[i])
-        }
-
-        // Noise gate
+    private func processAudioBuffer(
+        _ samples: [Float],
+        chordResult: AudioChordDetector.ChordDetectionResult
+    ) {
         var sumSq: Float = 0
         for s in samples { sumSq += s * s }
         let rms = sqrt(sumSq / Float(samples.count))
         if rms < 0.005 {
-            DispatchQueue.main.async { [weak self] in
-                self?.detectedChord = nil
-            }
+            detectedChord = nil
             return
         }
 
-        // Throttled chord detection
         if chordFrameCounter % Self.chordDetectionInterval == 0 {
-            let chordResult = AudioChordDetector.shared.detect(
-                samples: kotlinArray,
-                sampleRate: 44100,
-                threshold: 0.28,
-                preferredRootPitchClass: nil,
-                preferredRootWeight: 1.15
-            )
-
             let rawChordName: String? = {
                 if let found = chordResult.detection as? ChordDetector.DetectionResultChordFound {
                     return found.result.name

--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -79,6 +79,10 @@ final class TunerViewModel: ObservableObject {
         return .red
     }
 
+    private nonisolated(unsafe) let audioProcessingQueue = DispatchQueue(
+        label: "com.baijum.ukufretboard.tuner.dsp", qos: .userInitiated
+    )
+
     init() {
         neuralSupervisor = nil
         audioEngine.onBuffer = { [weak self] samples in
@@ -89,9 +93,22 @@ final class TunerViewModel: ObservableObject {
                 return true
             }
             guard shouldProcess else { return }
-            Task { @MainActor in
-                self.processAudioBuffer(samples)
-                self.processingLock.withLock { $0 = false }
+            self.audioProcessingQueue.async {
+                let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
+                for i in 0..<samples.count {
+                    kotlinArray.set(index: Int32(i), value: samples[i])
+                }
+                let result = PitchDetector.shared.detect(
+                    samples: kotlinArray,
+                    sampleRate: 44100,
+                    threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
+                    previousFrequency: nil
+                )
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    self.applyPitchResult(result, samples: samples)
+                    self.processingLock.withLock { $0 = false }
+                }
             }
         }
         Task {
@@ -144,7 +161,7 @@ final class TunerViewModel: ObservableObject {
         previousFrequency = nil
     }
 
-    private func processAudioBuffer(_ samples: [Float]) {
+    private func applyPitchResult(_ yinResult: PitchResult?, samples: [Float]) {
         guard isCapturing else { return }
 
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
@@ -153,22 +170,8 @@ final class TunerViewModel: ObservableObject {
             return
         }
 
-        // Convert [Float] to KotlinFloatArray for KMP interop
-        let kotlinArray = KotlinFloatArray(size: Int32(samples.count))
-        for i in 0..<samples.count {
-            kotlinArray.set(index: Int32(i), value: samples[i])
-        }
+        let result = yinResult
 
-        let prevFreq = previousFrequency.map { KotlinDouble(value: $0) }
-
-        let result = PitchDetector.shared.detect(
-            samples: kotlinArray,
-            sampleRate: 44100,
-            threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
-            previousFrequency: prevFreq
-        )
-
-        // Run neural supervision
         let neuralResult = maybeRunNeural(samples)
 
         if let result = result {


### PR DESCRIPTION
## Summary
- Adds a dedicated serial `DispatchQueue` to TunerViewModel, PitchMonitorViewModel, PlayAlongViewModel, and MelodyViewModel for audio processing.
- `KotlinFloatArray` conversion (4096 per-element ObjC-bridge calls) and `PitchDetector.detect()` / `AudioChordDetector.detect()` now run off `@MainActor`.
- UI state updates still happen on `@MainActor` via `Task { @MainActor in ... }` after detection completes.
- Eliminates UI stuttering during tuner/pitch monitor use on older devices.

Fixes #321

Made with [Cursor](https://cursor.com)