### PR TITLE
Fix: restore previousFrequency continuity hint for YIN pitch detection on iOS

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AVFoundation
 import os
-import shared
+@preconcurrency import shared
 
 struct PitchPoint {
     let timestampMs: Int64
@@ -32,6 +32,9 @@ final class PitchMonitorViewModel: ObservableObject {
     // Frame-dropping (backpressure) — checked on audio thread, not MainActor
     private nonisolated(unsafe) let frameGate = FrameGate()
     private nonisolated(unsafe) let neuralInferenceLock = OSAllocatedUnfairLock(initialState: false)
+
+    // Thread-safe previous frequency for YIN continuity (read from DSP queue, written from MainActor)
+    private nonisolated(unsafe) let lastFrequencyLock = OSAllocatedUnfairLock<Double?>(initialState: nil)
 
     // Neural state
     private var neuralFrameCounter: Int = 0
@@ -87,11 +90,12 @@ final class PitchMonitorViewModel: ObservableObject {
                 for i in 0..<samples.count {
                     kotlinArray.set(index: Int32(i), value: samples[i])
                 }
+                let prevFreq = self.lastFrequencyLock.withLock { $0 }.map { KotlinDouble(value: $0) }
                 let yinResult = PitchDetector.shared.detect(
                     samples: kotlinArray,
                     sampleRate: 44100,
                     threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
-                    previousFrequency: nil
+                    previousFrequency: prevFreq
                 )
                 let chordResult = AudioChordDetector.shared.detect(
                     samples: kotlinArray,
@@ -152,6 +156,7 @@ final class PitchMonitorViewModel: ObservableObject {
     private func startCapture() {
         recentFrequencies.removeAll()
         previousFrequency = nil
+        lastFrequencyLock.withLock { $0 = nil }
         previousRms = 0
         blankingFramesRemaining = 0
         chordFrameCounter = 0
@@ -181,7 +186,7 @@ final class PitchMonitorViewModel: ObservableObject {
     private func processBuffer(
         _ samples: [Float],
         yinResult: PitchResult?,
-        chordResult: AudioChordDetector.ChordDetectionResult
+        chordResult: AudioChordDetector.AudioChordResult
     ) {
         guard isListening else { return }
 
@@ -205,6 +210,7 @@ final class PitchMonitorViewModel: ObservableObject {
 
         if currentRms < noiseGateRms {
             previousFrequency = nil
+            lastFrequencyLock.withLock { $0 = nil }
             recentFrequencies.removeAll()
             let newPoint = PitchPoint(timestampMs: now, midiNote: nil)
             appendPoint(newPoint, now: now)
@@ -229,6 +235,7 @@ final class PitchMonitorViewModel: ObservableObject {
 
         if let hz = finalHz {
             previousFrequency = hz
+            lastFrequencyLock.withLock { $0 = hz }
             recentFrequencies.append(hz)
             if recentFrequencies.count > Self.smoothingWindow {
                 recentFrequencies.removeFirst()
@@ -240,6 +247,7 @@ final class PitchMonitorViewModel: ObservableObject {
             }
         } else {
             previousFrequency = nil
+            lastFrequencyLock.withLock { $0 = nil }
             recentFrequencies.removeAll()
         }
 

--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AVFoundation
 import os
-import shared
+@preconcurrency import shared
 
 /// Orchestrates Play Along: metronome timing, mic capture, chord detection, and scoring.
 @MainActor
@@ -187,7 +187,7 @@ final class PlayAlongViewModel: ObservableObject {
 
     private func processAudioBuffer(
         _ samples: [Float],
-        chordResult: AudioChordDetector.ChordDetectionResult
+        chordResult: AudioChordDetector.AudioChordResult
     ) {
         var sumSq: Float = 0
         for s in samples { sumSq += s * s }

--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -3,7 +3,7 @@ import Combine
 import Foundation
 import os
 import SwiftUI
-import shared
+@preconcurrency import shared
 
 enum NeuralRuntimeStatus {
     case loading, active, fallback
@@ -48,6 +48,9 @@ final class TunerViewModel: ObservableObject {
     // Frame-dropping (backpressure) — checked on audio thread, not MainActor
     private nonisolated(unsafe) let processingLock = OSAllocatedUnfairLock(initialState: false)
     private nonisolated(unsafe) let neuralInferenceLock = OSAllocatedUnfairLock(initialState: false)
+
+    // Thread-safe previous frequency for YIN continuity (read from DSP queue, written from MainActor)
+    private nonisolated(unsafe) let lastFrequencyLock = OSAllocatedUnfairLock<Double?>(initialState: nil)
 
     // Neural pitch supervision
     private var neuralSupervisor: NeuralPitchSupervisor?
@@ -98,11 +101,12 @@ final class TunerViewModel: ObservableObject {
                 for i in 0..<samples.count {
                     kotlinArray.set(index: Int32(i), value: samples[i])
                 }
+                let prevFreq = self.lastFrequencyLock.withLock { $0 }.map { KotlinDouble(value: $0) }
                 let result = PitchDetector.shared.detect(
                     samples: kotlinArray,
                     sampleRate: 44100,
                     threshold: PitchDetector.shared.DEFAULT_THRESHOLD,
-                    previousFrequency: nil
+                    previousFrequency: prevFreq
                 )
                 Task { @MainActor [weak self] in
                     guard let self else { return }
@@ -159,6 +163,7 @@ final class TunerViewModel: ObservableObject {
         audioEngine.start()
         isCapturing = true
         previousFrequency = nil
+        lastFrequencyLock.withLock { $0 = nil }
     }
 
     private func applyPitchResult(_ yinResult: PitchResult?, samples: [Float]) {
@@ -182,6 +187,7 @@ final class TunerViewModel: ObservableObject {
             let finalHz = arbitration.frequencyHz
 
             previousFrequency = finalHz
+            lastFrequencyLock.withLock { $0 = finalHz }
 
             if let noteInfo = TunerNoteMapper.shared.mapFrequency(hz: finalHz, a4Reference: a4Reference) {
                 let newNoteName = noteInfo.noteName
@@ -334,6 +340,7 @@ final class TunerViewModel: ObservableObject {
         stringMatch = nil
         tuningStatus = ""
         previousFrequency = nil
+        lastFrequencyLock.withLock { $0 = nil }
         activeStringIndex = nil
         settledFrames = 0
         isInTune = false


### PR DESCRIPTION
## Summary

- Restore the `previousFrequency` parameter to `PitchDetector.detect()` calls in `TunerViewModel` and `PitchMonitorViewModel` by introducing a thread-safe `OSAllocatedUnfairLock<Double?>` readable from the DSP queue
- Fix pre-existing build errors: rename `AudioChordDetector.ChordDetectionResult` → `AudioChordResult` (matching actual KMP export) and add `@preconcurrency import shared` for Swift 6 sendability

## Test plan

- [ ] Open the Tuner on iOS, pluck a string and let it decay — needle should stay stable on the detected note without octave flicker
- [ ] Open Pitch Monitor, verify pitch tracking remains smooth during sustained notes
- [ ] Verify Android is unaffected (no changes to Android code)
- [ ] CI passes (iOS build + shared module tests)

Fixes #339

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved thread-safety in frequency tracking and audio processing pipeline for enhanced reliability and stability in pitch detection and chord recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->