### PR TITLE
Fix: VoiceLeadingView plays full chord voicing instead of single note

### DIFF
--- a/iosApp/UkuleleCompanion/Views/VoiceLeadingView.swift
+++ b/iosApp/UkuleleCompanion/Views/VoiceLeadingView.swift
@@ -12,11 +12,6 @@ struct VoiceLeadingView: View {
     private let leftHanded: Bool
     private let tuning: [shared.UkuleleString]
 
-    private static let sampleNames = [
-        "uke_c", "uke_csharp", "uke_d", "uke_dsharp",
-        "uke_e", "uke_f", "uke_fsharp", "uke_g",
-        "uke_gsharp", "uke_a", "uke_asharp", "uke_b",
-    ]
 
     init(progression: Progression, keyRoot: Int32) {
         self.progression = progression
@@ -342,12 +337,11 @@ struct VoiceLeadingView: View {
 
     private func playVoicing(_ voicing: ChordVoicing) {
         let frets = voicing.fretInts
-        for (i, fret) in frets.enumerated() {
-            guard fret >= 0 else { continue }
-            let pc = (tuning[i].openPitchClass + Int32(fret)) % 12
-            tonePlayer.play(Self.sampleNames[Int(pc)])
-            return
+        let pitchClasses = frets.enumerated().compactMap { i, fret -> Int32? in
+            guard fret >= 0 else { return nil }
+            return (tuning[i].openPitchClass + Int32(fret)) % 12
         }
+        tonePlayer.playChord(pitchClasses: pitchClasses, strumDelayMs: 40)
     }
 
     private func playAllVoicings() {


### PR DESCRIPTION
## Summary

- Fix `playVoicing()` to play all non-muted strings as a strummed chord instead of only the first non-muted string (which was often not even the chord root)
- Use `TonePlayer.playChord(pitchClasses:strumDelayMs:)` matching the pattern from FavoritesView and Android's `ToneGenerator.playChord`
- Remove the now-unused `sampleNames` array

## Test plan

- [ ] Open any progression → Voice Leading on iOS
- [ ] Tap the play button under a chord diagram — should hear a full strummed chord, not a single note
- [ ] Tap "Play All" — should hear a sequence of strummed chords
- [ ] Verify Android is unaffected (no changes)
- [ ] CI passes

Fixes #340

Made with [Cursor](https://cursor.com)