### PR TITLE
Fix: Theory Quiz records answer under the question's actual category

### DIFF
--- a/iosApp/UkuleleCompanion/Views/TheoryQuizView.swift
+++ b/iosApp/UkuleleCompanion/Views/TheoryQuizView.swift
@@ -167,8 +167,7 @@ struct TheoryQuizView: View {
                         } else {
                             streak = 0
                         }
-                        let cat = useAllCategories ? selectedCategory : selectedCategory
-                        learnVM.recordQuizAnswer(category: cat, correct: correct)
+                        learnVM.recordQuizAnswer(category: question.category, correct: correct)
                     }
                 } label: {
                     HStack {
@@ -278,7 +277,7 @@ struct TheoryQuizView: View {
                         blitzScore += 1
                         blitzTimeMs = min(blitzTimeMs + 3_000, Self.blitzDurationMs)
                     }
-                    learnVM.recordQuizAnswer(category: selectedCategory, correct: correct)
+                    learnVM.recordQuizAnswer(category: question.category, correct: correct)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
                         nextQuestion()
                     }


### PR DESCRIPTION
## Summary

- In "All categories" mode, both standard and blitz quiz recorded every answer against `selectedCategory` (the last-tapped chip, defaulting to `.intervals`) instead of the question's own category
- Replace the no-op ternary (`useAllCategories ? selectedCategory : selectedCategory`) and the hardcoded `selectedCategory` in blitz mode with `question.category`
- This matches the Android implementation which correctly passes `currentQuestion!!.category`

## Test plan

- [ ] Open Theory Quiz → select "All" mode
- [ ] Answer several questions across different categories
- [ ] Check per-category stats — they should now reflect the actual category of each question
- [ ] Also test in Blitz mode with "All" selected
- [ ] CI passes

Fixes #341

Made with [Cursor](https://cursor.com)