### PR TITLE
Fix: Circle of Fifths tap zones centered on key labels

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/CircleOfFifthsView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/CircleOfFifthsView.kt
@@ -134,7 +134,7 @@ fun CircleOfFifthsView(
                                 // Rotate so 0° is at top (subtract 90°)
                                 angle += PI / 2
                                 if (angle < 0) angle += 2 * PI
-                                val segmentIndex = ((angle / (2 * PI)) * 12).toInt() % 12
+                                val segmentIndex = (((angle + PI / 12) / (2 * PI)) * 12).toInt() % 12
                                 selectedKey = if (dist >= innerRadius) {
                                     // Outer ring — major key
                                     circleOrder[segmentIndex]

--- a/iosApp/UkuleleCompanion/Views/CircleOfFifthsView.swift
+++ b/iosApp/UkuleleCompanion/Views/CircleOfFifthsView.swift
@@ -58,9 +58,9 @@ struct CircleOfFifthsView: View {
                     context.fill(path, with: .color(.accentColor.opacity(0.2)))
                 }
 
-                // Draw segment lines
+                // Draw segment lines (offset by 15° so they fall between labels)
                 for i in 0..<12 {
-                    let angle = Angle.degrees(Double(i) * 30 - 90)
+                    let angle = Angle.degrees(Double(i) * 30 - 90 + 15)
                     var line = Path()
                     let x1 = c.x + cos(angle.radians) * innerRadius * 0.85
                     let y1 = c.y + sin(angle.radians) * innerRadius * 0.85
@@ -140,10 +140,12 @@ struct CircleOfFifthsView: View {
                         .onEnded { value in
                             let dx = value.location.x - center.x
                             let dy = value.location.y - center.y
+                            let dist = sqrt(dx * dx + dy * dy)
+                            guard dist <= outerRadius else { return }
                             let angle = atan2(dy, dx)
                             var degrees = angle * 180 / .pi + 90
                             if degrees < 0 { degrees += 360 }
-                            let segment = Int(degrees / 30) % 12
+                            let segment = Int((degrees + 15) / 30) % 12
                             selectedKeyIndex = segment
                         }
                 )


### PR DESCRIPTION
## Summary

- Add half-segment offset to tap-to-key calculation on both platforms so tap zones align with the visual wedges (key labels sit at multiples of 30°, tap zones must span ±15° around them)
- Android: add `PI/12` offset before flooring
- iOS: add `+15°` offset, add distance guard to ignore taps outside the circle, and offset segment divider lines by 15° so they fall between labels (matching Android)

## Test plan

- [ ] On both platforms: tap just left of the "C" label (at 12 o'clock) — should select C, not F
- [ ] Tap near the edges of each wedge — the correct key should be highlighted
- [ ] On iOS: tap outside the circle boundary — nothing should be selected
- [ ] On iOS: verify segment divider lines now fall between labels, not through them
- [ ] CI passes (both Android and iOS)

Fixes #342

Made with [Cursor](https://cursor.com)