### PR TITLE
Fix: Favorites Create/Rename folder alerts use proper View structs

### DIFF
--- a/iosApp/UkuleleCompanion/Views/FavoritesView.swift
+++ b/iosApp/UkuleleCompanion/Views/FavoritesView.swift
@@ -146,7 +146,7 @@ struct FavoritesView: View {
             }
         }
         .alert("New Folder", isPresented: $showCreateFolder) {
-            CreateFolderAlert { name in
+            CreateFolderAlertContent { name in
                 viewModel.createFolder(name: name)
             }
         }
@@ -155,7 +155,7 @@ struct FavoritesView: View {
             set: { if !$0 { renamingFolder = nil } }
         )) {
             if let folder = renamingFolder {
-                RenameFolderAlert(currentName: folder.name) { newName in
+                RenameFolderAlertContent(currentName: folder.name) { newName in
                     viewModel.renameFolder(id: folder.id, name: newName)
                     renamingFolder = nil
                 }
@@ -388,18 +388,29 @@ struct FavoriteFolderSheet: View {
     }
 }
 
-@MainActor @ViewBuilder
-private func CreateFolderAlert(onCreate: @escaping (String) -> Void) -> some View {
-    @State var name = ""
-    TextField("Folder name", text: $name)
-    Button("Create") { if !name.isEmpty { onCreate(name) } }
-    Button("Cancel", role: .cancel) {}
+private struct CreateFolderAlertContent: View {
+    @State private var name = ""
+    let onCreate: (String) -> Void
+
+    var body: some View {
+        TextField("Folder name", text: $name)
+        Button("Create") { if !name.isEmpty { onCreate(name) } }
+        Button("Cancel", role: .cancel) {}
+    }
 }
 
-@MainActor @ViewBuilder
-private func RenameFolderAlert(currentName: String, onRename: @escaping (String) -> Void) -> some View {
-    @State var name = currentName
-    TextField("Folder name", text: $name)
-    Button("Rename") { if !name.isEmpty { onRename(name) } }
-    Button("Cancel", role: .cancel) {}
+private struct RenameFolderAlertContent: View {
+    @State private var name: String
+    let onRename: (String) -> Void
+
+    init(currentName: String, onRename: @escaping (String) -> Void) {
+        _name = State(initialValue: currentName)
+        self.onRename = onRename
+    }
+
+    var body: some View {
+        TextField("Folder name", text: $name)
+        Button("Rename") { if !name.isEmpty { onRename(name) } }
+        Button("Cancel", role: .cancel) {}
+    }
 }

--- a/iosApp/UkuleleCompanion/Views/FavoritesView.swift
+++ b/iosApp/UkuleleCompanion/Views/FavoritesView.swift
@@ -394,7 +394,11 @@ private struct CreateFolderAlertContent: View {
 
     var body: some View {
         TextField("Folder name", text: $name)
-        Button("Create") { if !name.isEmpty { onCreate(name) } }
+            .accessibilityHint("Enter a name for the new folder")
+        Button("Create") {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { onCreate(trimmed) }
+        }
         Button("Cancel", role: .cancel) {}
     }
 }
@@ -410,7 +414,11 @@ private struct RenameFolderAlertContent: View {
 
     var body: some View {
         TextField("Folder name", text: $name)
-        Button("Rename") { if !name.isEmpty { onRename(name) } }
+            .accessibilityHint("Edit the folder name")
+        Button("Rename") {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { onRename(trimmed) }
+        }
         Button("Cancel", role: .cancel) {}
     }
 }


### PR DESCRIPTION
## Summary

- Replace `CreateFolderAlert` and `RenameFolderAlert` free functions (which declared `@State` in a non-View context) with proper `View` structs: `CreateFolderAlertContent` and `RenameFolderAlertContent`
- `@State` is now properly installed in the SwiftUI view graph, so TextField bindings work correctly
- The rename alert uses `_name = State(initialValue: currentName)` to seed the field with the existing folder name

## Test plan

- [ ] Favorites → tap "+" folder chip → "New Folder" alert → type "Jazz" → tap Create → folder appears
- [ ] Long-press a folder chip → Rename → change name → tap Rename → folder name updates
- [ ] Verify Cancel buttons dismiss without side effects
- [ ] VoiceOver navigation works on the alert elements
- [ ] CI passes

Fixes #343

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to dialog handling with no impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->