### PR TITLE
Fix: iOS melody recording never detects a note

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -109,6 +109,9 @@ final class MelodyViewModel: ObservableObject {
     )
     private var stableCount = 0
     private var lastDetectedPitchClass: Int? = nil
+    private var lastDetectedOctave: Int? = nil
+    private var awaitingSilence = false
+    private var previousFrequency: KotlinDouble? = nil
 
     init(repository: MelodyRepository = MelodyRepository()) {
         self.repository = repository
@@ -308,6 +311,9 @@ final class MelodyViewModel: ObservableObject {
     private func beginCapture() {
         stableCount = 0
         lastDetectedPitchClass = nil
+        lastDetectedOctave = nil
+        awaitingSilence = false
+        previousFrequency = nil
 
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
@@ -318,24 +324,31 @@ final class MelodyViewModel: ObservableObject {
                     floatArray.set(index: Int32(i), value: samples[i])
                 }
 
+                let prevFreq = self.previousFrequency
+
                 let result = PitchDetector.shared.detect(
                     samples: floatArray,
                     sampleRate: Int32(AudioCaptureEngine.sampleRate),
                     threshold: 0.15,
-                    previousFrequency: nil
+                    previousFrequency: prevFreq
                 )
 
                 Task { @MainActor [weak self] in
                     guard let self else { return }
                     defer { self.frameGate.exit() }
 
-                    guard let result, result.confidence > 0.8 else {
+                    guard let result else {
                         self.detectedNote = nil
                         self.stableCount = 0
                         self.lastDetectedPitchClass = nil
+                        self.lastDetectedOctave = nil
                         self.stabilizationProgress = 0
+                        self.previousFrequency = nil
+                        self.awaitingSilence = false
                         return
                     }
+
+                    self.previousFrequency = KotlinDouble(value: result.frequencyHz)
 
                     let noteInfo = TunerNoteMapper.shared.mapFrequency(
                         hz: result.frequencyHz,
@@ -349,21 +362,27 @@ final class MelodyViewModel: ObservableObject {
 
                     self.detectedNote = noteInfo.noteName + "\(oct)"
 
-                    if pc == self.lastDetectedPitchClass {
+                    if pc == self.lastDetectedPitchClass && oct == self.lastDetectedOctave {
                         self.stableCount += 1
                     } else {
                         self.lastDetectedPitchClass = pc
+                        self.lastDetectedOctave = oct
                         self.stableCount = 1
                     }
 
                     self.stabilizationProgress = Float(self.stableCount) / Float(Self.stabilizationThreshold)
 
                     if self.stableCount >= Self.stabilizationThreshold {
-                        self.addNote(pitchClass: pc, octave: oct)
+                        if !self.awaitingSilence {
+                            self.addNote(pitchClass: pc, octave: oct)
+                            self.awaitingSilence = true
+                        }
                         self.stableCount = 0
                         self.lastDetectedPitchClass = nil
+                        self.lastDetectedOctave = nil
                         self.detectedNote = nil
                         self.stabilizationProgress = 0
+                        self.previousFrequency = nil
                     }
                 }
             }
@@ -381,6 +400,9 @@ final class MelodyViewModel: ObservableObject {
         detectedNote = nil
         stableCount = 0
         lastDetectedPitchClass = nil
+        lastDetectedOctave = nil
+        awaitingSilence = false
+        previousFrequency = nil
     }
 
     func save(name: String) {

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -111,7 +111,7 @@ final class MelodyViewModel: ObservableObject {
     private var lastDetectedPitchClass: Int? = nil
     private var lastDetectedOctave: Int? = nil
     private var awaitingSilence = false
-    private var previousFrequency: KotlinDouble? = nil
+    private nonisolated(unsafe) var previousFrequency: KotlinDouble? = nil
 
     init(repository: MelodyRepository = MelodyRepository()) {
         self.repository = repository


### PR DESCRIPTION
## Summary

- Remove the inverted YIN confidence gate (`result.confidence > 0.8`) that made melody mic recording a complete no-op on iOS — YIN confidence is "lower = better" and `PitchDetector.detect()` cannot return values above 0.30, so the guard was unsatisfiable
- Add `awaitingSilence` retrigger guard to prevent a sustained note from being recorded repeatedly (~every 3 frames / 70ms)
- Fix stability check to require both `pitchClass` **and** `octave` to be stable, preventing wrong-octave notes during decay
- Pass `previousFrequency` continuity hint to `PitchDetector` to suppress octave jumps between frames

All four changes bring iOS `MelodyViewModel.beginCapture` to parity with Android's `processRecordingBufferInner`.

Fixes #349

## Test plan

- [ ] On iOS, open Melody Notepad, tap record, pluck a string — note should be detected, stabilization ring should fill, note should be added
- [ ] Sustain a note — it should be recorded only once (not repeatedly)
- [ ] Pluck different strings — correct pitch class and octave should be recorded
- [ ] Verify Android melody recording still works unchanged (no shared code modified)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced melody recording with improved pitch and octave detection accuracy
  * Refined note stability detection for more reliable audio recognition during recording sessions
  * Optimized detection state management for smoother recording experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->