### PR TITLE
Fix: iOS tuner clears YIN continuity hint and display on silence

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -36,6 +36,8 @@ final class TunerViewModel: ObservableObject {
     private var previousFrequency: Double?
     private var settledFrames: Int = 0
     private static let settledThreshold = 8
+    private var lostSignalFrames: Int = 0
+    private static let lostSignalHoldFrames = 17
 
     // TTS
     private let synthesizer = AVSpeechSynthesizer()
@@ -171,7 +173,19 @@ final class TunerViewModel: ObservableObject {
 
         let rms = sqrt(samples.reduce(0) { $0 + $1 * $1 } / Float(max(samples.count, 1)))
         if rms < noiseGateRms {
-            self.isInTune = false
+            lostSignalFrames = 0
+            previousFrequency = nil
+            lastFrequencyLock.withLock { $0 = nil }
+            settledFrames = 0
+            isInTune = false
+            noteName = "--"
+            octave = nil
+            centsDeviation = 0
+            frequency = nil
+            stringMatch = nil
+            tuningStatus = ""
+            activeStringIndex = nil
+            neuralArbitrator.reset()
             return
         }
 
@@ -180,6 +194,8 @@ final class TunerViewModel: ObservableObject {
         let neuralResult = maybeRunNeural(samples)
 
         if let result = result {
+            lostSignalFrames = 0
+
             let arbitration = neuralArbitrator.arbitrate(
                 yinResult: result,
                 neuralResult: neuralResult
@@ -245,8 +261,23 @@ final class TunerViewModel: ObservableObject {
                 )
             }
         } else {
+            lostSignalFrames += 1
+            if lostSignalFrames < Self.lostSignalHoldFrames && noteName != "--" {
+                return
+            }
+            lostSignalFrames = 0
+            previousFrequency = nil
+            lastFrequencyLock.withLock { $0 = nil }
             settledFrames = 0
             isInTune = false
+            noteName = "--"
+            octave = nil
+            centsDeviation = 0
+            frequency = nil
+            stringMatch = nil
+            tuningStatus = ""
+            activeStringIndex = nil
+            neuralArbitrator.reset()
         }
     }
 
@@ -343,6 +374,7 @@ final class TunerViewModel: ObservableObject {
         lastFrequencyLock.withLock { $0 = nil }
         activeStringIndex = nil
         settledFrames = 0
+        lostSignalFrames = 0
         isInTune = false
         neuralArbitrator.reset()
     }


### PR DESCRIPTION
## Summary

- Clear `previousFrequency` and `lastFrequencyLock` (the YIN continuity hint) when the tuner goes silent or sustains pitch detection failure, preventing a stale hint from seeding a self-reinforcing octave error on the next pluck
- Reset the display (note name, cents, frequency, string match) to idle state during silence instead of freezing on the last detected note forever
- Add a ~400ms grace window (`lostSignalHoldFrames`) in the no-pitch branch so brief decay gaps don't flicker the display, matching Android's `LOST_SIGNAL_HOLD_MS` behavior

Both bail-out paths in `applyPitchResult` now match Android's `TunerViewModel.processBuffer` behavior. The iOS `PitchMonitorViewModel` already handled this correctly — only the tuner diverged.

Fixes #350

## Test plan

- [ ] On iOS, open tuner, pluck G3 string, let it ring, then mute — display should return to "--" idle state (not freeze on "G3")
- [ ] Pluck A4 after silence — tuner should show A4 correctly (not octave-locked to A3)
- [ ] Brief pauses during string decay should not flicker the display (grace window)
- [ ] Verify Android tuner still works unchanged (no shared code modified)

Made with [Cursor](https://cursor.com)