### PR TITLE
Fix: iOS melody save upserts by ID instead of always inserting

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -406,15 +406,15 @@ final class MelodyViewModel: ObservableObject {
     }
 
     func save(name: String) {
-        let id = UUID().uuidString
-        let melody = MelodyData(
-            id: id,
-            name: name,
-            notes: notes,
-            bpm: bpm,
-            createdAt: Date().timeIntervalSince1970 * 1000
-        )
-        savedMelodies.insert(melody, at: 0)
+        let id = loadedMelodyId ?? UUID().uuidString
+        let createdAt = savedMelodies.first(where: { $0.id == id })?.createdAt
+            ?? Date().timeIntervalSince1970 * 1000
+        let melody = MelodyData(id: id, name: name, notes: notes, bpm: bpm, createdAt: createdAt)
+        if let idx = savedMelodies.firstIndex(where: { $0.id == id }) {
+            savedMelodies[idx] = melody
+        } else {
+            savedMelodies.insert(melody, at: 0)
+        }
         loadedMelodyName = name
         loadedMelodyId = id
         hasUnsavedChanges = false


### PR DESCRIPTION
## Summary
- Fix `MelodyViewModel.save(name:)` to reuse `loadedMelodyId` when saving a loaded melody, updating in place rather than inserting a duplicate with a new UUID
- Preserve the original `createdAt` timestamp on update, matching Android's `saveMelody` behavior and the existing `SongbookViewModel.save(song:)` upsert pattern

Fixes #353

## Test plan
- [ ] Create a new melody, save as "Test" — list shows 1 entry
- [ ] Load "Test", add notes, tap Save — list still shows 1 entry (updated in place)
- [ ] Verify createdAt timestamp is preserved after re-save
- [ ] Clear all and save as "New" — list now shows 2 entries (new melody inserted)
- [ ] iOS build succeeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed melody saving to preserve original melody identifiers and creation timestamps when updating existing melodies.
* Improved saved melodies list handling to update existing entries in place rather than creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->