### PR TITLE
Fix: iOS Play Along clears chord state on silence and uses real confidence

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PlayAlongViewModel.swift
@@ -32,6 +32,7 @@ final class PlayAlongViewModel: ObservableObject {
     private var chordHoldCount: Int = 0
     private var displayedChord: String?
     private var chordMissCount: Int = 0
+    private var detectionConfidence: Float = 0
     private static let chordDetectionInterval = 2
     private static let chordHoldFrames = 2
     private static let chordMissTolerance = 3
@@ -103,6 +104,7 @@ final class PlayAlongViewModel: ObservableObject {
         chordHoldCount = 0
         displayedChord = nil
         chordMissCount = 0
+        detectionConfidence = 0
 
         requestMicAndBegin()
     }
@@ -165,7 +167,7 @@ final class PlayAlongViewModel: ObservableObject {
         scorer.recordBeat(
             expectedChord: expectedChord,
             detectedChord: displayedChord,
-            confidence: displayedChord != nil ? 0.8 : 0.0
+            confidence: detectionConfidence
         )
 
         let normalized = displayedChord.map { Self.normalizeForComparison($0) }
@@ -194,6 +196,11 @@ final class PlayAlongViewModel: ObservableObject {
         let rms = sqrt(sumSq / Float(samples.count))
         if rms < 0.005 {
             detectedChord = nil
+            displayedChord = nil
+            lastChordName = nil
+            chordHoldCount = 0
+            chordMissCount = 0
+            detectionConfidence = 0
             return
         }
 
@@ -216,10 +223,12 @@ final class PlayAlongViewModel: ObservableObject {
 
             if chordHoldCount >= Self.chordHoldFrames {
                 displayedChord = rawChordName
+                detectionConfidence = chordResult.confidence
             } else if rawChordName == nil && chordMissCount > Self.chordMissTolerance {
                 displayedChord = nil
                 lastChordName = nil
                 chordHoldCount = 0
+                detectionConfidence = 0
             }
         }
         chordFrameCounter += 1


### PR DESCRIPTION
## Summary
- Clear the full chord state machine (`displayedChord`, `lastChordName`, `chordHoldCount`, `chordMissCount`, `detectionConfidence`) in the silence branch so the scorer sees misses instead of crediting a stale chord
- Replace the hardcoded `0.8` confidence with the real `AudioChordDetector` confidence value, matching Android's `detectionConfidence` pattern

Fixes #354

## Test plan
- [ ] Start Play Along on a C–G–Am–F progression, strum a clean C, then mute strings
- [ ] Verify the score records misses during silence (not correct C hits)
- [ ] Verify `isChordCorrect` does not show the success state during silence
- [ ] Resume strumming and confirm detection and scoring resume normally
- [ ] iOS build succeeds

Made with [Cursor](https://cursor.com)