### PR TITLE
docs: audit documentation for accuracy and remove obsolete content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Ukulele Companion is a **free, fully offline** multiplatform app (Android + iOS)
 | **Android** | Kotlin 2.4.0, Jetpack Compose (BOM 2026.05.01), Material 3, Single Activity, MVVM, StateFlow |
 | **iOS** | Swift 6, SwiftUI, MVVM, `@StateObject`/`@Published`, iOS 16.0+, static `shared.framework` via Gradle |
 | **Audio ML** | ONNX Runtime 1.26.0 on both platforms (Android AAR, iOS xcframework via C API) |
-| **Build** | Gradle 9.4.1, AGP 9.2.1, Kotlin DSL, version catalog (`libs.versions.toml`) |
+| **Build** | Gradle 9.5.1, AGP 9.2.1, Kotlin DSL, version catalog (`libs.versions.toml`) |
 
 ## Package Structure
 
@@ -42,16 +42,16 @@ Ukulele Companion is a **free, fully offline** multiplatform app (Android + iOS)
 | `audio/` | `ToneGenerator`, `MetronomeEngine`, `AudioCaptureEngine` (44.1kHz PCM) |
 | `data/` | Repositories (SharedPreferences-backed), backup/restore manager |
 | `domain/` | `NeuralPitchSupervisor`, `ChordImageSharer`, `AchievementChecker` |
-| `ui/` | 55 Compose screens/components via `ModalNavigationDrawer` (no NavHost) |
-| `viewmodel/` | 13 ViewModels exposing `StateFlow` |
+| `ui/` | 76 Compose screens/components via `ModalNavigationDrawer` (no NavHost) |
+| `viewmodel/` | 14 ViewModels exposing `StateFlow` |
 
 ### iOS app (`iosApp/UkuleleCompanion/`)
 
 | Directory | Contents |
 |-----------|----------|
 | `Audio/` | `AudioCaptureEngine`, `TonePlayer`, `NeuralPitchSupervisor` (ONNX C API) |
-| `Views/` | 48 SwiftUI views across Play, Create, Learn, Reference tabs |
-| `ViewModels/` | 15 ViewModels using `@Published` |
+| `Views/` | 50 SwiftUI views across Play, Create, Learn, Reference tabs |
+| `ViewModels/` | 17 ViewModels using `@Published` |
 | `Helpers/` | `AccessibilityHelper`, `BackupRestoreManager` |
 
 ## Key Patterns
@@ -92,7 +92,7 @@ Skills in `.cursor/skills/` provide step-by-step workflows for common tasks:
 
 | Skill | When to use |
 |-------|-------------|
-| `add-translations` | Adding new user-facing strings to all 15 supported locales (Android `strings.xml` + iOS `Localizable.xcstrings`) |
+| `add-translations` | Adding new user-facing strings to all 16 supported locales (Android `strings.xml` + iOS `Localizable.xcstrings`) |
 | `android-release` | Build and upload an Android release based on an existing git tag |
 | `ios-release` | Build an iOS release based on an existing git tag |
 | `github-release` | Create a GitHub release with a version tag and auto-generated release notes |

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -7,7 +7,7 @@
 - **Source:** [Freesound.org — Pack #8545](https://freesound.org/people/stomachache/packs/8545/)
 - **License:** [Creative Commons Attribution 3.0 Unported (CC BY 3.0)](https://creativecommons.org/licenses/by/3.0/)
 - **Description:** Single ukulele notes recorded close-miked with Sony PCM-D50.
-- **Files used:** All 12 chromatic notes (C through B) from the pack, converted to OGG preview format.
+- **Files used:** All 12 chromatic notes (C through B) from the pack, converted to WAV format.
 
 Per the CC BY 3.0 license, the original sounds were created by Freesound user
 "stomachache" and are used with attribution as required.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 <td width="50%" valign="top">
 
 ### 🎸 Interactive Fretboard Explorer
-Tap fret positions on a visual ukulele fretboard (standard GCEA tuning, frets 0–12) and the app instantly detects and displays the chord. Supports 20 chord types across triads, sevenths, suspended, and extended chords. Shows alternate notational symbols ("Also written as") so you can recognize chords written in different styles.
+Tap fret positions on a visual ukulele fretboard (standard GCEA tuning, frets 0–12) and the app instantly detects and displays the chord. Supports 19 chord types across triads, sevenths, suspended, and extended chords. Shows alternate notational symbols ("Also written as") so you can recognize chords written in different styles.
 
 ### 📚 Chord Library
 Browse playable voicings for any chord. Select a root note, category (Triad, Seventh, Suspended, Extended), and chord type to see algorithmically generated voicings displayed as mini fretboard diagrams.
@@ -58,7 +58,7 @@ A reference guide with 14 strumming and 10 fingerpicking patterns — from begin
 Common chord progressions for any key across seven modes (Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, Locrian). Each chord chip shows its harmonic function (Tonic, Subdominant, Dominant) with colour coding. Includes Pop, Classic Rock, 50s, Folk, Jazz ii-V-I, Reggae, and more. Create custom progressions with diatonic chord suggestions from the selected scale, duplicate presets, copy to clipboard, and use tap tempo for practice.
 
 ### 🎼 Scale Overlay
-Highlight notes from any of 38 scales (Major, Natural/Harmonic/Melodic Minor, Pentatonic, Blues, modes, Bebop, Diminished, and more) directly on the fretboard. Filter by fret position and see the diatonic chords for each scale.
+Highlight notes from any of 37 scales (Major, Natural/Harmonic/Melodic Minor, Pentatonic, Blues, modes, Bebop, Diminished, and more) directly on the fretboard. Filter by fret position and see the diatonic chords for each scale.
 
 </td>
 <td width="50%" valign="top">
@@ -159,15 +159,15 @@ Ukulele Companion is designed to be usable by everyone, including blind and visu
 
 | Component | Android | iOS |
 |-----------|---------|-----|
-| Language | Kotlin 2.3 | Swift + Kotlin (via KMP) |
+| Language | Kotlin 2.4 | Swift + Kotlin (via KMP) |
 | UI | Jetpack Compose + Material 3 | SwiftUI |
 | Architecture | ViewModel + StateFlow | ObservableObject + @Published |
 | Shared Logic | Kotlin Multiplatform (`:shared` module) | Same KMP module via framework |
-| Audio | SoundPool with OGG samples | AVFoundation with WAV samples |
+| Audio | SoundPool with WAV samples | AVFoundation with WAV samples |
 | Persistence | SharedPreferences + DataStore | UserDefaults |
 | Serialization | Kotlinx Serialization | Codable + JSONSerialization |
 | Neural Inference | ONNX Runtime Android | ONNX Runtime C API (xcframework) |
-| Build | Gradle 9.4, AGP 9.1, Kotlin DSL | Xcode, min iOS 16.0 |
+| Build | Gradle 9.5, AGP 9.2, Kotlin DSL | Xcode, min iOS 16.0 |
 | Min SDK | 26 (Android 8.0) | iOS 16.0 |
 | Target SDK | 35 | — |
 | Localization | Android resources (16 locales) | Localizable.xcstrings (16 locales) |

--- a/docs/manual/android/01-getting-started.md
+++ b/docs/manual/android/01-getting-started.md
@@ -65,7 +65,6 @@ The four groups are:
 | **Progress** | Dashboard with learning stats and practice timer |
 | **Daily Challenge** | Three fresh challenges every day |
 | **Practice Routine** | Guided practice session builder |
-
 | **Chord Transitions** | Animated finger movement between chords |
 | **Play Along** | Real-time play-along with chord detection |
 | **Achievements** | Milestone gallery and progress tracking |
@@ -89,5 +88,5 @@ Tap the **gear icon** in the top-right corner of the app bar to open the Setting
 
 - The app works entirely offline — no internet connection is needed.
 - Your favorites, songs, and settings are saved locally on your device.
-- Long-press on chord voicings in the library to save them as favorites.
+- Tap the heart icon on chord voicings in the library to save them as favorites.
 - Check the **Help** screen (at the bottom of the drawer) for quick descriptions of every feature.

--- a/docs/manual/android/02-explorer.md
+++ b/docs/manual/android/02-explorer.md
@@ -26,10 +26,10 @@ When no frets are selected, the area below the fretboard shows a **"Try these be
 
 Tap any fret cell on the fretboard to place or remove a finger. The fretboard displays frets 0 through 12 across four strings (G, C, E, A in standard tuning).
 
-As you tap frets, the app analyzes the selected notes and shows the detected chord name above the fretboard. The app recognizes 20 chord types across four categories:
+As you tap frets, the app analyzes the selected notes and shows the detected chord name above the fretboard. The app recognizes 19 chord types across four categories:
 
 - **Triads** — Major, Minor, Diminished, Augmented
-- **Seventh** — Dom7, Min7, Maj7, Aug7, Dim7, Minor Major 7th
+- **Seventh** — Dom7, Min7, Maj7, Aug7, Dim7, Half-diminished 7th, Minor Major 7th
 - **Suspended** — Sus2, Sus4, 7sus4
 - **Extended** — 6, Min6, 9, Min9, Add9
 

--- a/docs/manual/android/06-favorites.md
+++ b/docs/manual/android/06-favorites.md
@@ -10,9 +10,9 @@ To save a voicing to your favorites:
 
 1. Go to the **Chords** section.
 2. Find a voicing you like.
-3. **Long-press** the voicing diagram — a heart icon confirms it has been saved.
+3. Tap the **heart icon** on the voicing card — a filled heart confirms it has been saved. Tap again to remove it.
 
-You can also tap the **heart icon** on any voicing in the library to toggle it as a favorite.
+(Long-pressing a voicing diagram in the library opens the **share** action rather than saving it.)
 
 ## Viewing Favorites
 
@@ -25,8 +25,7 @@ Open the **Favorites** section from the navigation drawer. Your saved voicings a
 
 Favorites can be organized into folders using the **filter chips** at the top of the screen:
 
-- **All** — shows every saved voicing (default).
-- **Unfiled** — shows voicings not assigned to any folder.
+- **All** — shows every saved voicing with a count (default).
 - **Your folders** — each folder you create appears as a chip with the count of voicings inside.
 
 ### Creating a Folder
@@ -37,18 +36,19 @@ Favorites can be organized into folders using the **filter chips** at the top of
 
 The new folder appears as a chip in the filter row.
 
-### Moving Voicings to a Folder
+### Assigning Voicings to Folders
 
-1. Tap the **folder icon** (small + icon) on any voicing.
-2. A dialog appears listing all your folders plus "Unfiled".
-3. Tap a folder name to move the voicing there.
+1. Tap the **folder icon** on any voicing.
+2. A bottom sheet titled "Save to Folders" (or "Manage Folders") appears listing all your folders, each with a checkbox.
+3. Tick or untick the checkboxes to add or remove the voicing from folders. A voicing can belong to more than one folder. You can also create a new folder from this sheet, or remove the voicing from favorites entirely.
 
 ### Deleting a Folder
 
-Tap the **delete icon** on a folder chip. The folder is removed, and all voicings inside it are moved back to "Unfiled". The voicings themselves are not deleted.
+Tap the **delete icon** on a folder chip. The folder is removed and any voicings it contained are simply unassigned from it. The voicings themselves remain in your favorites.
 
 ## Tips
 
 - Use folders to group voicings by song, practice session, or chord type.
+- A voicing can live in several folders at once — tick as many as you like in the folder sheet.
 - The "All" chip always shows your complete collection regardless of folder assignments.
-- Removing a voicing from favorites (via the heart icon) deletes it entirely, while moving it to "Unfiled" keeps it saved.
+- Removing a voicing from favorites (via the heart icon) deletes it entirely, while removing it from a folder keeps it saved.

--- a/docs/manual/android/08-settings.md
+++ b/docs/manual/android/08-settings.md
@@ -13,7 +13,7 @@ Control how the app plays back chords and notes.
 | **Sound enabled** | Toggle all sound playback on or off. |
 | **Volume** | Adjust the playback volume from 0% to 100%. |
 | **Note Duration** | How long each note rings out (300–1200 ms). |
-| **Strum Delay** | The delay between strings when strumming a chord (20–150 ms). A shorter delay sounds like a quick strum; a longer delay sounds like a slow arpeggio. |
+| **Strum Delay** | The delay between strings when strumming a chord (0–150 ms). A shorter delay sounds like a quick strum; a longer delay sounds like a slow arpeggio. |
 | **Strum Direction** | Choose between strumming down (low to high) or up (high to low). |
 | **Play on Tap** | When enabled, plays the note immediately when you tap a fret on the Explorer fretboard. |
 | **Noise filtering** | Controls how much background noise is filtered for the Tuner, Pitch Monitor, and Melody Notepad (0–100%, default 75%). Higher values filter more noise; lower values pick up quieter sounds. Increase in noisy environments or decrease in a quiet room for maximum sensitivity. |
@@ -43,7 +43,7 @@ Choose from four theme options:
 
 ## Tuning
 
-Select the tuning for your ukulele. The app adjusts the fretboard, chord detection, and playback accordingly.
+Select the tuning for your ukulele. The app adjusts the fretboard, chord detection, and playback accordingly. Eight presets are available:
 
 | Tuning | Strings | Description |
 |--------|---------|------------|
@@ -51,6 +51,10 @@ Select the tuning for your ukulele. The app adjusts the fretboard, chord detecti
 | **Low-G** | G3-C4-E4-A4 | Same notes but with the G string tuned an octave lower, extending the bass range. |
 | **Baritone (DGBE)** | D3-G3-B4-E4 | Baritone ukulele tuning, matching the top four strings of a guitar. |
 | **D-Tuning (ADF#B)** | A4-D4-F#4-B4 | A traditional alternative tuning, one whole step above standard. |
+| **Slack Key (GCEG)** | G4-C4-E4-G4 | An open-G tuning for slack-key style playing. |
+| **Open A (AC#EA)** | A4-C#4-E4-A4 | An open-A tuning. |
+| **Low A (GCEa)** | G4-C4-E4-A3 | Standard notes with a low A on the bottom string. |
+| **Half-Step Down** | F#4-B3-D#4-G#4 | Standard tuning lowered by a semitone. |
 
 ## Fretboard
 

--- a/docs/manual/android/09-learning.md
+++ b/docs/manual/android/09-learning.md
@@ -79,7 +79,8 @@ Earn badges by reaching milestones as you use the app.
 - **Practice** — streaks and consistency (e.g., "Getting Started" for a 3-day streak, "Monthly Master" for 30 days).
 - **Learning** — lesson and quiz milestones (e.g., "First Steps" for completing your first lesson, "Scholar" for all lessons).
 - **Ear Training** — interval and chord ear training accuracy.
-- **Collection** — favorites and song milestones.
+- **Chords** — chord-learning milestones.
+- **Songs** — songbook milestones.
 
 ### Viewing Achievements
 

--- a/docs/manual/android/10-play-along.md
+++ b/docs/manual/android/10-play-along.md
@@ -11,7 +11,7 @@ Play Along lets you practise a chord progression with real-time feedback from yo
 ### Setup
 
 1. **Choose a key** — tap a note chip (C, C#, D, ... B).
-2. **Choose a scale** — Major or Minor.
+2. **Choose a scale** — Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, or Locrian.
 3. **Select a progression** — tap a progression card. Each card shows the name, description, and the resolved chord names in your chosen key (e.g., "C → G → Am → F").
 
 ### Playing
@@ -39,7 +39,7 @@ Play Along requires microphone access for chord detection. The first time you us
 Each beat is scored based on whether the detected chord matches the expected chord. At the end of a session (or when you stop), the score card shows:
 
 - **Accuracy** — percentage of beats with correct chord detection.
-- **Grade** — a letter grade from S (95%+) to F (below 40%).
+- **Grade** — a letter grade based on accuracy: S (90%+), A (80%+), B (70%+), C (60%+), D (50%+), and F (below 50%).
 - **Best Streak** — the longest consecutive run of correct beats.
 
 

--- a/docs/manual/android/13-metronome.md
+++ b/docs/manual/android/13-metronome.md
@@ -16,7 +16,7 @@ You can change the BPM while the metronome is playing — the new tempo takes ef
 
 ## Time Signature
 
-Select from 2/4, 3/4, 4/4, 5/4, 6/4, or 7/4 using the filter chips. The default is 4/4. Changing the time signature updates the number of beat indicators and resets the accent pattern.
+Select from 2/4, 3/4, 4/4, 5/4, 6/4, 7/4, 6/8, or 12/8 using the filter chips. The default is 4/4. Changing the time signature updates the number of beat indicators and resets the accent pattern. The compound meters (6/8 and 12/8) use a triplet subdivision automatically, so the subdivision selector is locked while one is active.
 
 ## Accent Pattern
 

--- a/docs/manual/android/14-melody-notepad.md
+++ b/docs/manual/android/14-melody-notepad.md
@@ -27,7 +27,7 @@ Notes appear in the sequence display at the top as colored blocks showing the no
 
 Toggle from Linear to **Step Sequencer** mode using the mode switch at the top.
 
-1. The sequencer shows a grid of **8 steps** by default. Tap **Expand** to switch to 16 steps, or **Shrink** to return to 8.
+1. The sequencer shows a grid of **8 steps** by default. Tap the **16 steps** button to switch to a 16-step grid; it then becomes an **8 steps** button to return to 8.
 2. Tap any step in the grid to open a **pitch picker**. Select a note name and octave to assign it to that step.
 3. Long-press a step to **clear** it (reset it to silence).
 4. Tap **Play** to loop the sequence continuously at the current BPM. The active step is highlighted as it plays.

--- a/docs/manual/ios/01-getting-started.md
+++ b/docs/manual/ios/01-getting-started.md
@@ -2,7 +2,7 @@
 
 ## Installing the App
 
-Ukulele Companion is available on the [App Store](https://apps.apple.com/app/id6760328302). Install it on any iPhone or iPad running iOS 17.0 or later. No account or login is required — just install and open.
+Ukulele Companion is available on the [App Store](https://apps.apple.com/app/id6760328302). Install it on any iPhone or iPad running iOS 16.0 or later. No account or login is required — just install and open.
 
 ## First Launch
 
@@ -15,15 +15,15 @@ When you open the app for the first time, a short **onboarding wizard** walks yo
 5. **Navigation** — how to use the tab bar and what each section contains.
 6. **Quick Setup** — choose your tuning (High-G, Low-G, Baritone, etc.), left-handed mode, and color theme. These choices take effect immediately and can be changed later in Settings.
 
-Tap **Get Started** on the last page to enter the app. You can also tap **Skip** on any earlier page to go straight to the Explorer.
+Tap **Get Started** on the last page to enter the app. You can also tap **Skip** on any earlier page to go straight in.
 
-The wizard only appears once. After that, the app opens directly to the Explorer.
+The wizard only appears once. After that, the app opens directly to the **Play** tab.
 
 ## Navigating the App
 
-The app uses a **tab bar** at the bottom of the screen with four tabs. Tap a tab to see its list of screens, then tap any row to open it.
+The app uses a **tab bar** at the bottom of the screen. Tap a tab to see its list of screens, then tap any row to open it. By default there are four tabs — **Play**, **Create**, **Learn**, and **Reference** — and the Learn and Reference tabs can each be hidden in Settings.
 
-The four tabs are:
+The tabs are:
 
 ### Play
 
@@ -32,47 +32,50 @@ The four tabs are:
 | **Explorer** | Interactive fretboard with chord detection |
 | **Tuner** | Chromatic tuner using the microphone |
 | **Pitch Monitor** | Real-time pitch visualisation graph |
-| **Chords** | Browse the chord library by root and type |
-| **Favorites** | Your saved chord voicings |
 | **Metronome** | Practice metronome with time signatures and accents |
+| **Chord Library** | Browse chord voicings by root and type |
+| **Favorites** | Your saved chord voicings |
 
 ### Create
 
 | Section | What It Does |
 |---------|-------------|
-| **Songs** | Personal songbook with chord sheets, ChordPro import/export |
 | **Start a Song** | Guided songwriting flow — pick a key, build a progression, write lyrics, transpose, and save |
+| **Chord Progressions** | Common chord progressions in any key |
+| **Strumming Patterns** | Strumming and fingerpicking pattern reference |
+| **Songbook** | Personal songbook with chord sheets, ChordPro import/export |
+| **Setlists** | Ordered collections of songs for gigs and practice |
 | **Melody Notepad** | Melody composer with linear and step sequencer modes |
-| **Patterns** | Strumming and fingerpicking pattern reference |
-| **Progressions** | Common chord progressions in any key |
 
 ### Learn
 
+The Learn tab groups its screens into sections (Practice, Training, Knowledge, and Progress):
+
 | Section | What It Does |
 |---------|-------------|
-| **Learn Theory** | Structured theory lessons |
-| **Theory Quiz** | Test your music theory knowledge |
-| **Interval Trainer** | Ear training for intervals |
-| **Note Quiz** | Fretboard note identification quiz |
-| **Chord Ear Training** | Identify chord types by ear |
-| **Scale Practice** | Guided scale exercises on the fretboard |
-| **Progress** | Dashboard with learning stats and practice timer |
 | **Daily Challenge** | Three fresh challenges every day |
 | **Practice Routine** | Guided practice session builder |
-| **Chord Transitions** | Animated finger movement between chords |
+| **Chord Transitions** | Guided two-chord changing drill |
 | **Play Along** | Real-time play-along with chord detection |
+| **Interval Trainer** | Ear training for intervals |
+| **Chord Ear Training** | Identify chord types by ear |
+| **Note Quiz** | Fretboard note identification quiz |
+| **Scale Practice** | Guided scale exercises on the fretboard |
+| **Theory Lessons** | Structured theory lessons |
+| **Theory Quiz** | Test your music theory knowledge |
+| **Learning Progress** | Dashboard with learning stats and practice timer |
 | **Achievements** | Milestone gallery and progress tracking |
 
 ### Reference
 
 | Section | What It Does |
 |---------|-------------|
-| **Capo Guide** | Educational capo reference |
-| **Circle of Fifths** | Visual key relationship chart |
-| **Chord Substitutions** | Guide to chord substitutions |
-| **Chords in Scale** | Diatonic chords for any scale |
-| **Fretboard Notes** | Visual note map of the fretboard |
 | **Glossary** | Searchable music theory dictionary |
+| **Capo Guide** | Educational capo reference |
+| **Fretboard Note Map** | Visual note map of the fretboard |
+| **Chord Substitutions** | Guide to chord substitutions |
+| **Scale Chords** | Diatonic chords for any scale |
+| **Circle of Fifths** | Visual key relationship chart |
 
 ## Opening Settings
 
@@ -82,5 +85,5 @@ Tap the **gear icon** in the toolbar of any tab to open the Settings panel as a 
 
 - The app works entirely offline — no internet connection is needed.
 - Your favorites, songs, and settings are saved locally on your device.
-- Long-press on chord voicings in the library to save them as favorites.
+- Tap the heart icon on a chord voicing in the Chord Library to save it to your favorites.
 - Check the **Help** screen (accessible from Settings) for quick descriptions of every feature.

--- a/docs/manual/ios/02-explorer.md
+++ b/docs/manual/ios/02-explorer.md
@@ -4,21 +4,9 @@ The Explorer is the main screen of Ukulele Companion. It shows an interactive fr
 
 ![Explorer fretboard](screenshots/explorer-fretboard.png)
 
-## Tips for First-Time Users
+## Suggested Chords
 
-The first time you visit the Explorer, a **tips card** appears at the top of the screen with a brief explanation of the three key features:
-
-- **Tap any fret** to select a note — the app detects which chord you are building.
-- **Tap Scales** to overlay scale patterns on the fretboard.
-- **Use the capo slider** to simulate a capo and transpose your chords.
-
-Tap **Got it** to dismiss the card permanently.
-
-![Explorer with tips card](screenshots/explorer-fretboard.png)
-
-## Suggested Beginner Chords
-
-When no frets are selected, the area below the fretboard shows a **"Try these beginner chords"** section with four common ukulele chords: **C**, **Am**, **F**, and **G7**. Tap any chip to load the chord onto the fretboard instantly. This is a quick way to hear what the chords sound like and see the fingering. Tap **Reset** to clear the fretboard and see the suggestions again.
+When no frets are selected, the area below the fretboard shows a **"Try These"** section with a row of common ukulele chords: **C**, **Am**, **F**, **G7**, **Em**, and **D**. Tap any chip to load the chord onto the fretboard instantly. This is a quick way to hear what the chords sound like and see the fingering. Tap **Reset** (in the action bar above) to clear the fretboard and see the suggestions again.
 
 ![Beginner chord suggestions](screenshots/explorer-beginner-chords.png)
 
@@ -26,10 +14,10 @@ When no frets are selected, the area below the fretboard shows a **"Try these be
 
 Tap any fret cell on the fretboard to place or remove a finger. The fretboard displays frets 0 through 12 across four strings (G, C, E, A in standard tuning).
 
-As you tap frets, the app analyzes the selected notes and shows the detected chord name above the fretboard. The app recognizes 20 chord types across four categories:
+As you tap frets, the app analyzes the selected notes and shows the detected chord name above the fretboard. The app recognizes 19 chord types across four categories:
 
 - **Triads** — Major, Minor, Diminished, Augmented
-- **Seventh** — Dom7, Min7, Maj7, Aug7, Dim7, Minor Major 7th
+- **Seventh** — Dom7, Min7, Maj7, Aug7, Dim7, Half-Diminished (m7♭5), Minor Major 7th
 - **Suspended** — Sus2, Sus4, 7sus4
 - **Extended** — 6, Min6, 9, Min9, Add9
 
@@ -42,12 +30,10 @@ When a chord is detected, the area below the fretboard shows detailed informatio
 - **Chord name** — with slash notation for inversions (e.g., C/E).
 - **Quality** — e.g., "Major", "Minor 7th (1st Inv)".
 - **Also written as** — alternate notational symbols used in different musical traditions. For example, detecting "Cdim" also shows "C°", and "Cmaj7" also shows "CM7, CΔ7, C^7". This helps you recognize the same chord written in different styles across books, apps, and sheet music.
-- **Alternate interpretations** — when the same set of notes can form a different chord (e.g., Am7 and C6 share the same notes).
+- **Also** chips — when the same set of notes can form a different chord (e.g., Am7 and C6 share the same notes), the alternates appear as chips. Tap one to look it up in the Chord Library.
 - **Intervals, Formula, Fingering, Difficulty, Inversion** — detailed music theory breakdown.
 
-## Transpose
-
-Below the detected chord, you will see **+** and **-** buttons to transpose the chord up or down by semitones. The app also shows the equivalent capo position for reference.
+Below the chord name, a **Play** button strums the chord and a **Share** button exports it as an image. Tapping the chord name itself opens the voicing in the Chord Library.
 
 ## Scale Overlay
 
@@ -55,9 +41,10 @@ The scale overlay highlights notes from a selected scale directly on the fretboa
 
 To use the scale overlay:
 
-1. Tap the **Scales** button below the fretboard.
-2. Select a **root note** (e.g., C, G, D).
-3. Select a **scale type** (Major, Natural Minor, Harmonic Minor, Melodic Minor, Pentatonic Major, Pentatonic Minor, Blues, Dorian, Mixolydian, or Lydian).
+1. Tap the **Scales** button (in the action bar above the capo slider) to reveal the scale panel.
+2. Turn on the **Scale Overlay** toggle.
+3. Select a **root note** (e.g., C, G, D).
+4. Select a **scale type**. A wide range of scales is available — including Major, Natural Minor, Harmonic Minor, Melodic Minor, the pentatonic and blues scales, the church modes (Dorian, Phrygian, Lydian, Mixolydian, Locrian), and many more.
 
 Scale notes are highlighted on the fretboard, with the root note shown in a distinct color.
 
@@ -76,9 +63,9 @@ Tap a position chip to filter, and tap **All** to go back to showing every note.
 
 When a scale overlay is active, the fretboard automatically uses the correct note spelling for that key. For example, in the key of F major, the note between A and B is shown as "Bb" (flat), while in the key of G major, the note between F and G is shown as "F#" (sharp). This follows standard music theory conventions.
 
-### Chords in This Scale
+### Chords in Scale
 
-Below the position chips, the app lists the **chords that naturally occur** in the selected scale. Tap any chord chip to jump to its voicings in the Chord Library.
+Below the position chips, the app lists the **chords that naturally occur** in the selected scale (the diatonic triads), each labelled with its Roman-numeral scale degree. This gives you a quick reference for which chords fit the key you are exploring.
 
 ## Did You Know?
 

--- a/docs/manual/ios/03-chords.md
+++ b/docs/manual/ios/03-chords.md
@@ -1,61 +1,65 @@
-# Chords
+# Chord Library
 
-The Chords section is a comprehensive chord library. Browse voicings for any chord by selecting a root note and chord type.
+The Chord Library is a comprehensive collection of chord voicings. Browse voicings for any chord by selecting a root note and chord type.
 
 ![Chord library](screenshots/chords-library.png)
 
 ## Browsing Chords
 
-1. **Select a root note** — tap one of the 12 note buttons at the top (C, C#, D, etc.). If you prefer flat names, you can switch this in [Settings](08-settings.md).
-2. **Select a category** — choose from Triad, Seventh, Suspended, or Extended.
-3. **Select a chord type** — for example, Major, Minor, Dom7, Min7, etc.
+The filter controls are grouped under a collapsible **Filters** header (tap it to expand or collapse). With the filters expanded:
+
+1. **Select a root note** — tap one of the 12 note buttons (C, C#, D, etc.). If you prefer flat names, you can switch this in [Settings](08-settings.md).
+2. **Transpose** — optional **+** and **−** buttons shift the selected root up or down by semitones.
+3. **Select a category** — choose from Triad, Seventh, Suspended, or Extended.
+4. **Select a chord type** — for example, Major, Minor, Dom7, Min7, etc.
 
 The app displays all available voicings as mini fretboard diagrams in a grid.
+
+You can also use the **search bar** at the top to find a chord directly by name (for example, "Cm7" or "C/E").
 
 ## Voicing Diagrams
 
 Each voicing card shows:
 
-- **Chord name** — displayed in bold at the top-right corner (e.g., "C", "Am").
-- **Fret diagram** — a mini fretboard showing finger positions, open strings, and muted strings.
-- **Note names** — the notes for each string shown below the diagram (e.g., G C E C).
-- **Fret numbers** — the fret number for each string aligned below the note names (e.g., 0 0 0 3).
-- **Inversion label** — Root, 1st Inv, 2nd Inv, etc.
-- **Favorite icon** — a heart at the top-left to save/remove from favorites.
-- **Share icon** — a share button at the bottom-right to export the voicing as an image.
+- **Chord name** — displayed at the top of the card (e.g., "C", "Am").
+- **Fret diagram** — a vertical mini fretboard showing finger positions, open strings, and muted strings, with a position marker (e.g., "3fr") when the voicing is higher up the neck.
+- **Favorite button** — a heart at the bottom-left to save or manage the voicing in your favorites.
+- **Share button** — a share icon at the bottom-right to export the voicing as an image.
 
-**Tap** a voicing to load it onto the Explorer fretboard, where you can see it in full size.
+**Tap** a voicing diagram to load it onto the Explorer fretboard (and hear it played).
 
 ## Inversion Filters
 
-Above the voicing grid, filter chips let you narrow voicings by inversion type:
+When a chord type is selected, an **Inversions** row appears above the voicing grid with filter chips:
 
 - **All** — shows every voicing with a count (e.g., "All (15)").
-- **Root**, **1st Inv**, **2nd Inv**, **3rd Inv** — each shows how many voicings match.
+- **Root**, **1st Inv**, **2nd Inv**, **3rd Inv** — each shows how many voicings match. Only inversions that have voicings are listed.
 
-Additional action buttons:
+When more than one voicing is shown, a **Play all** button in the Inversions row plays the filtered voicings in sequence.
 
-- **Capo** — opens the capo calculator to find equivalent voicings with a capo.
-- **Viz** — opens the capo visualizer.
-- **Compare** — groups voicings by inversion for side-by-side comparison.
+## Capo Tools
+
+**Long-press** any voicing card to open its context menu, which offers:
+
+- **Share as Image** — export the voicing as an image.
+- **Capo Positions** — open the capo calculator to find equivalent voicings with a capo.
+- **Capo Visualizer** — open the capo visualizer for that voicing.
 
 ## Saving Favorites
 
-Tap the **heart icon** on any voicing card to save it to your Favorites. A filled heart indicates a saved voicing. Tap again to remove it.
+Tap the **heart icon** on any voicing card to open the favorites sheet. From there you can save the voicing, add it to one or more folders, or remove it. A filled red heart indicates a saved voicing.
 
 See [Favorites](06-favorites.md) for more about managing your saved voicings.
 
 ## Accessibility
 
 - **Per-string exploration** — When using VoiceOver, chord diagrams provide per-string details (note, fret, and role such as bass note or common tone) accessible through the VoiceOver rotor's custom content.
-- **Share hint** — Long-pressing a chord diagram to share is announced with an accessibility hint so VoiceOver users know the action is available.
+- **Share hint** — The chord diagram announces a hint that it can be long-pressed to share as an image.
 
 ## Sharing Voicings
 
-Tap the **share icon** on any voicing card to export it as an image you can send to others. You can also **long-press** a chord diagram to share it directly.
+Tap the **share icon** on any voicing card to export it as an image you can send to others. You can also **long-press** a chord diagram and choose **Share as Image** from its context menu.
 
 ## Playing Voicings
 
-Tap the **play button** on any voicing to hear it played back. The app strums the notes with the sound settings you have configured (volume, strum delay, note duration).
-
-You can also play all voicings in sequence by using the play controls at the top of the voicing grid.
+Tapping a voicing diagram loads it onto the Explorer fretboard and plays it back, strummed with the sound settings you have configured (volume, strum delay, note duration). When a chord type shows more than one voicing, use **Play all** in the Inversions row to hear them in sequence.

--- a/docs/manual/ios/04-patterns.md
+++ b/docs/manual/ios/04-patterns.md
@@ -11,30 +11,28 @@ The **Strumming** tab shows a list of preset strumming patterns, from beginner t
 - **Name** — e.g., "Island Strum", "Calypso", "6/8 Ballad".
 - **Time signature badge** — shows the time signature the pattern is designed for (e.g., 4/4, 3/4, 6/8).
 - **Difficulty badge** — Beginner, Intermediate, or Advanced.
-- **Play button** — tap the play icon to hear the pattern played on open strings. The currently active beat highlights as it plays. Tap the stop icon to stop playback. Only one pattern plays at a time.
-- **Duplicate button** — tap the copy icon to duplicate any pattern (preset or custom) into your custom patterns. The copy appears in "My Patterns" with " (Copy)" appended to the name.
-- **Visual beat arrows** — down arrows, up arrows, chuck, and miss/pause indicators showing the rhythmic pattern. The active beat is highlighted during playback.
-- **Notation** — a text representation of the pattern (e.g., "D - D U - U D U").
-- **Description** — a brief explanation of the pattern and when to use it.
+- **Visual beat arrows** — down arrows, up arrows, chuck (X), and miss/pause indicators showing the rhythmic pattern. The active beat is highlighted during playback.
+- **Counting** — a text representation of the rhythm count.
 - **Genre tags** — musical styles the pattern suits (e.g., Hawaiian, Pop, Folk).
-- **BPM slider** — adjust the playback tempo. Defaults to the midpoint of the pattern's suggested range.
+- **Play button** — tap the play icon to hear the pattern played on open strings. The currently active beat highlights as it plays. Tap the stop icon to stop playback. Only one pattern plays at a time.
+- **BPM slider** — adjust the playback tempo (40–220 BPM).
+
+Tap a card to expand it and reveal the pattern's **description** and **notation** (e.g., "D - D U - U D U"). To copy a preset into your own patterns, **long-press** the card and choose **Duplicate** — the copy appears in "My Patterns" with " (Copy)" appended to the name.
 
 ### Managing Custom Patterns
 
-Tap the **+ button** (floating action button) in the bottom-right corner to create your own strumming pattern:
+Tap the **+ button** in the top-right of the toolbar to create your own strumming pattern. The editor is a form:
 
 1. Enter a **pattern name**.
-2. Select a **time signature** (2/2, 2/4, 3/4, 4/4, 5/4, 7/4, 6/8, 7/8, 9/8, 11/8, or 12/8). The beat count adjusts automatically to match the selected time signature.
-3. Use the **+/−** buttons to add or remove beats (2–16). Beat slots wrap to multiple lines when the count is high.
-4. Tap each **beat slot** to cycle through directions: Down, Up, Chuck, Miss, and Pause.
-5. Tap the **accent row** below to toggle emphasis on individual beats (accented beats are shown louder/bolder).
-6. Tap **Save** to add it to your custom patterns.
+2. Select a **time signature** — 4/4, 3/4, or 6/8.
+3. In the **Beats** section, tap **Add Beat** to append beats. Each beat row has a **direction** picker (Down, Up, Chuck, Miss, or Pause) and an **Accent** toggle. Swipe a beat row to delete it.
+4. Tap **Save** to add it to your custom patterns.
 
-Your custom patterns appear in a **"My Patterns"** section at the top of the list. Custom patterns have additional actions:
+Your custom patterns appear in a **"My Patterns"** section at the top of the list. Custom patterns have additional actions, available as buttons on the card or from its long-press menu:
 
 - **Edit** — tap the pencil icon to open the pattern in the editor with all fields pre-populated for modification.
 - **Duplicate** — tap the copy icon to create a copy you can then edit independently.
-- **Delete** — tap the trash icon. A confirmation dialog appears before the pattern is permanently removed.
+- **Delete** — tap the trash icon. A confirmation appears before the pattern is permanently removed.
 
 ## Fingerpicking Patterns
 
@@ -45,25 +43,20 @@ The **Fingerpicking** tab shows reference patterns for fingerstyle playing, incl
 - **Name** — e.g., "Arpeggio Up", "Travis Pick", "6/8 Arpeggio", "Clawhammer".
 - **Time signature badge** — shows the time signature (e.g., 4/4, 3/4, 6/8).
 - **Difficulty badge** — Beginner or Intermediate.
+- **Finger step display** — indicators showing which finger (Thumb, Index, Middle, Ring) plucks which string (G, C, E, A) at each step. The active step is highlighted during playback.
 - **Play button** — tap to hear each note plucked in sequence on the open strings. The active step highlights during playback.
-- **Duplicate button** — copy any pattern into your custom patterns.
-- **Finger step display** — color-coded indicators showing which finger (Thumb, Index, Middle, Ring) plucks which string (G, C, E, A) at each step. The active step is highlighted during playback.
-- **Notation** — a text representation of the fingerpicking sequence (e.g., "T(G) T(C) I(E) M(A)").
-- **Description** — guidance on technique and musical context.
 - **BPM slider** — adjust the playback tempo.
 
-The finger indicators use distinct colors for each finger, making it easy to follow the picking pattern visually. Emphasized steps are shown in a bolder weight.
+Tap a card to expand it for the pattern's **description** and **notation** (e.g., "T(G) T(C) I(E) M(A)"). To copy a preset, **long-press** the card and choose **Duplicate**.
 
 ### Creating Custom Fingerpicking Patterns
 
-Tap the **+ button** on the Fingerpicking tab to create your own pattern:
+Tap the **+ button** in the toolbar on the Fingerpicking tab to create your own pattern. The editor is a form:
 
 1. Enter a **pattern name**.
-2. Select a **time signature** from the available options. The step count adjusts automatically to match the selected time signature (clamped to 2–8).
-3. Adjust the number of steps (2–8) with the **+/−** buttons.
-4. Tap a step to select it, then choose the **finger** and **string** from the chip rows below.
-5. Tap the **accent row** to toggle emphasis on individual steps.
-6. Tap **Save** to add it to your custom patterns.
+2. Select a **time signature** — 4/4, 3/4, or 6/8.
+3. In the **Steps** section, tap **Add Step** to append steps. Each step row has a **finger** picker (T, I, M, R), a **string** picker (G, C, E, A), and an **Accent** toggle. Swipe a step row to delete it.
+4. Tap **Save** to add it to your custom patterns.
 
 Custom fingerpicking patterns support the same **edit**, **duplicate**, and **delete** actions as custom strumming patterns.
 
@@ -73,5 +66,5 @@ Custom fingerpicking patterns support the same **edit**, **duplicate**, and **de
 - Use the **play button** to hear each pattern — listening is much more effective than reading notation alone.
 - Adjust the **BPM slider** to start slow and gradually increase speed as you get comfortable.
 - Playback uses the open strings of your selected tuning, so it matches whatever tuning you have configured in Settings.
-- Use **duplicate** to copy a preset pattern, then **edit** it to create your own variation.
+- Long-press a preset to **Duplicate** it into "My Patterns", then **edit** the copy to create your own variation.
 - The time signature badge helps you match patterns to songs — most pop/rock is 4/4, waltzes are 3/4, and ballads like "House of the Rising Sun" are 6/8.

--- a/docs/manual/ios/05-progressions.md
+++ b/docs/manual/ios/05-progressions.md
@@ -9,53 +9,43 @@ The Progressions section shows common chord progressions for any key across seve
 1. **Select a key** — choose a root note at the top.
 2. **Choose a mode** — select from Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, or Locrian. Each mode generates progressions using its own set of diatonic chords.
 
-The app displays a list of common progressions for that key and mode: Pop (I-V-vi-IV), Classic Rock (I-IV-V), 50s (I-vi-IV-V), Folk, Jazz ii-V-I, Reggae, and more. Custom progressions appear under "My Progressions" above the "Presets" section.
+The app displays a list of common progressions for that key and mode: Pop (I-V-vi-IV), Classic Rock (I-IV-V), 50s (I-vi-IV-V), Folk, Jazz ii-V-I, Reggae, and more. Any progressions you create appear under a "Custom" section above the "Presets" section.
 
 ## Progression Cards
 
 Each progression card shows all of its information inline:
 
-- **Name** — the progression name (e.g., "Pop", "Jazz ii-V-I"). Custom progressions also have a delete button in the title row.
-- **Roman numeral degrees** — the scale degrees used (e.g., I – V – vi – IV).
-- **Chord chips with harmonic function** — the actual chord names in your selected key, each labelled with its harmonic function: **Tonic** (primary colour), **Subdominant** (tertiary colour), or **Dominant** (red). Tap any chip to jump to its voicings in the Chord Library.
+- **Title row** — the progression name (e.g., "Pop", "Jazz ii-V-I") with **Share** and **Copy** icons. Custom progressions also show **Edit** (pencil) and **Delete** (trash) icons here.
 - **Description** — a short summary of where and how the progression is commonly used.
+- **Chord chips** — each chip shows the Roman-numeral degree (e.g., I, V, vi, IV), the actual chord name in your selected key, and the chord's harmonic function: **Tonic**, **Subdominant**, or **Dominant** (each shown in a distinct colour). The chip for the current chord is highlighted during playback.
+- **Playback bar** — a Play button, BPM control, a Beats-per-chord selector, and a loop toggle.
 
 ### Actions on Each Card
 
-Actions are organised in two rows at the bottom of the card:
-
-**Row 1 — primary actions:**
-
-- **Play** — hear the progression played back with the current sound settings.
-- **Practice** — enter practice mode where chords advance automatically on the beat.
-- **Duplicate** — create a copy as a new custom progression with "(Copy)" appended to the name.
-- **Edit** — open the progression in the editor to rename it, add or remove chords, or change the mode. Available on custom progressions only (presets cannot be modified).
-
-**Row 2 — secondary actions:**
-
-- **Share** — export the progression as text to share with others.
-- **Copy** — copy the progression to the clipboard with a single tap.
-- **Capo** — view capo positions that let you play the progression using simpler chord shapes.
+- **Play** (in the playback bar) — hear the progression played back with the current sound settings.
+- **Beats per chord** (in the playback bar) — choose 1, 2, 4, or 8 beats before advancing.
+- **Loop** (in the playback bar) — repeat the progression continuously.
 - **Voice Leading** — view smooth voice-leading suggestions between the chords.
-
-## BPM and Tap Tempo
-
-The progression playback bar includes a BPM slider to control the playback speed. Next to the slider is a **Tap Tempo** button — tap it rhythmically to set the BPM by feel. The app calculates the tempo from the intervals between your taps. After 3 seconds of inactivity, the taps reset so you can start fresh.
+- **Practice** — open practice mode where chords advance automatically on the beat.
+- **Capo** — view capo positions that let you play the progression using simpler chord shapes.
+- **Share** / **Copy** (title-row icons) — export the progression as text, or copy it to the clipboard.
+- **Edit** / **Delete** (title-row icons, custom progressions only) — modify or remove a custom progression.
+- **Duplicate** — long-press the card and choose **Duplicate** to create a copy as a new custom progression with "(Copy)" appended to the name.
 
 ## Custom Progressions
 
-You can create your own custom progressions by tapping the **New Progression** button. Custom progressions can be edited, duplicated, and deleted.
+You can create your own custom progressions by tapping the **+** button in the toolbar. Custom progressions can be edited, duplicated, and deleted.
 
 When creating or editing a custom progression, diatonic chord chips for the selected scale are displayed as suggestions. These chips show the chords that naturally fit the key, making it easy to build harmonically coherent progressions without memorising music theory.
 
-- **Edit** lets you change the name, chord sequence, or mode of an existing custom progression.
-- **Duplicate** creates a new independent copy you can modify separately.
+- **Edit** (pencil icon) lets you change the name, chord sequence, or mode of an existing custom progression.
+- **Duplicate** (long-press menu) creates a new independent copy you can modify separately.
 - **Delete** (trash icon on the card title row) permanently removes the custom progression after a confirmation dialog.
 
 ## Tips
 
 - Use progressions as a starting point for songwriting or practice sessions.
 - The harmonic function labels help you understand why certain chord movements sound pleasing — Tonic feels like home, Dominant creates tension, and Subdominant provides motion.
-- Tap chord chips to quickly look up voicings you are not familiar with.
+- Use the **Practice** button to run a progression in time and rehearse the chord changes.
 - Try the same progression in different keys to understand how transposition works.
-- Use tap tempo when following along with a song to match its speed.
+- Use the **Capo** view to find simpler shapes for awkward keys.

--- a/docs/manual/ios/06-favorites.md
+++ b/docs/manual/ios/06-favorites.md
@@ -8,25 +8,29 @@ The Favorites section stores your saved chord voicings for quick access. You can
 
 To save a voicing to your favorites:
 
-1. Go to the **Chords** section.
+1. Go to the **Chord Library** section.
 2. Find a voicing you like.
-3. **Long-press** the voicing diagram — a heart icon confirms it has been saved.
+3. Tap the **heart icon** on the voicing card to open the favorites sheet, then tap **Save** (optionally choosing one or more folders first).
 
-You can also tap the **heart icon** on any voicing in the library to toggle it as a favorite.
+A filled red heart on a voicing card means it is saved.
 
 ## Viewing Favorites
 
-Open the **Favorites** section from the Play tab. Your saved voicings appear in a grid, showing the chord name and a mini fretboard diagram for each.
+Open the **Favorites** section from the Play tab. Your saved voicings appear in a grid, showing the chord name and a mini fretboard diagram for each. When you have no favorites yet, the screen shows a short prompt explaining how to add them.
 
-- **Tap** a voicing to load it onto the Explorer fretboard.
-- Tap the **heart icon** on a voicing to remove it from favorites.
+Each favorite card has a few controls:
+
+- **Tap the diagram** to hear the chord played back.
+- **Folder icon** — open the favorites sheet to move the voicing between folders.
+- **Speaker icon** — play the chord.
+- **Share icon** — export the voicing as an image.
+- **Heart icon** — remove the voicing from favorites.
 
 ## Organizing with Folders
 
 Favorites can be organized into folders using the **filter chips** at the top of the screen:
 
-- **All** — shows every saved voicing (default).
-- **Unfiled** — shows voicings not assigned to any folder.
+- **All** — shows every saved voicing (default), with a count.
 - **Your folders** — each folder you create appears as a chip with the count of voicings inside.
 
 ### Creating a Folder
@@ -35,20 +39,24 @@ Favorites can be organized into folders using the **filter chips** at the top of
 2. Enter a folder name in the dialog.
 3. Tap **Create**.
 
-The new folder appears as a chip in the filter row.
+The new folder appears as a chip in the filter row. (You can also create a folder from the favorites sheet while saving a voicing.)
 
 ### Moving Voicings to a Folder
 
-1. Tap the **folder icon** (small + icon) on any voicing.
-2. A dialog appears listing all your folders plus "Unfiled".
-3. Tap a folder name to move the voicing there.
+1. Tap the **folder icon** on any favorite card.
+2. A sheet appears listing all your folders with checkmarks.
+3. Tap folders to select or deselect them, then tap **Save**. A voicing can belong to more than one folder.
 
-### Deleting a Folder
+### Managing a Folder
 
-Tap the **delete icon** on a folder chip. The folder is removed, and all voicings inside it are moved back to "Unfiled". The voicings themselves are not deleted.
+Tap a folder chip to open its menu, which offers **View**, **Rename**, and **Delete**. Deleting a folder removes the folder only — the voicings inside remain in your favorites.
+
+### Reordering Within a Folder
+
+When viewing a single folder, tap the reorder button in the toolbar to drag voicings into the order you prefer.
 
 ## Tips
 
 - Use folders to group voicings by song, practice session, or chord type.
 - The "All" chip always shows your complete collection regardless of folder assignments.
-- Removing a voicing from favorites (via the heart icon) deletes it entirely, while moving it to "Unfiled" keeps it saved.
+- Removing a voicing with the heart icon deletes it from favorites entirely; removing it from a folder (by deselecting the folder in the sheet) keeps it saved.

--- a/docs/manual/ios/07-songs.md
+++ b/docs/manual/ios/07-songs.md
@@ -45,7 +45,7 @@ You can import chord sheets from files on your device or by pasting ChordPro tex
 
 1. Tap the **import button** in the toolbar and choose **Import from file**.
 2. Select a file from your device. The app supports:
-   - **ChordPro files** (`.chopro`, `.cho`, `.chordpro`) — parsed automatically with title, artist, subtitle, and chord directives.
+   - **ChordPro files** (`.cho`, `.chordpro`, `.chopro`, `.crd`, `.pro`) — parsed automatically with title, artist, subtitle, and chord directives.
    - **Plain text files** — imported as-is with the filename used as the title.
 3. The imported song is added to your collection immediately.
 

--- a/docs/manual/ios/08-settings.md
+++ b/docs/manual/ios/08-settings.md
@@ -10,13 +10,13 @@ Control how the app plays back chords and notes.
 
 | Setting | Description |
 |---------|------------|
-| **Sound enabled** | Toggle all sound playback on or off. |
+| **Sound Enabled** | Toggle all sound playback on or off. |
 | **Volume** | Adjust the playback volume from 0% to 100%. |
 | **Note Duration** | How long each note rings out (300–1200 ms). |
-| **Strum Delay** | The delay between strings when strumming a chord (20–150 ms). A shorter delay sounds like a quick strum; a longer delay sounds like a slow arpeggio. |
-| **Strum Direction** | Choose between strumming down (low to high) or up (high to low). |
+| **Strum Delay** | The delay between strings when strumming a chord (0–150 ms). A shorter delay sounds like a quick strum; a longer delay sounds like a slow arpeggio. |
 | **Play on Tap** | When enabled, plays the note immediately when you tap a fret on the Explorer fretboard. |
-| **Noise filtering** | Controls how much background noise is filtered for the Tuner, Pitch Monitor, and Melody Notepad (0–100%, default 75%). Higher values filter more noise; lower values pick up quieter sounds. Increase in noisy environments or decrease in a quiet room for maximum sensitivity. |
+| **Strum Down** | When on, chords strum from the lowest string to the highest; turn it off to strum the other way. |
+| **Noise Gate** | Controls how much background noise is filtered for the Tuner, Pitch Monitor, and Melody Notepad (0–100%, default 75%). Higher values filter more noise; lower values pick up quieter sounds. Increase in noisy environments or decrease in a quiet room for maximum sensitivity. |
 
 ## Display
 
@@ -33,30 +33,45 @@ Choose from four theme options:
 | **System** | Follows your device's system-wide light/dark mode setting. |
 | **High Contrast** | An accessibility-focused theme with stronger color contrast, making text and UI elements easier to read. Adapts to your system light/dark preference. |
 
-### Navigation Sections
-
 | Setting | Description |
 |---------|------------|
-| **Show explorer tips** | When enabled, a rotating "Did you know?" card appears on the Explorer tab. |
-| **Show Learn section** | When enabled, the Learn tab (Theory, Quizzes, Ear Training, etc.) is visible in the tab bar. Disable to simplify navigation for experienced players. |
-| **Show Reference section** | When enabled, the Reference tab (Capo Guide, Circle of Fifths, Glossary, etc.) is visible in the tab bar. |
+| **Show Tips** | When enabled, a rotating "Did You Know?" card appears on the Explorer. |
+| **Show Learn Tab** | When enabled, the Learn tab (Theory, Quizzes, Ear Training, etc.) is visible in the tab bar. Disable to simplify navigation for experienced players. |
+| **Show Reference Tab** | When enabled, the Reference tab (Capo Guide, Circle of Fifths, Glossary, etc.) is visible in the tab bar. |
+
+The Settings panel also has a **Language** section for choosing the app's language.
 
 ## Tuning
 
-Select the tuning for your ukulele. The app adjusts the fretboard, chord detection, and playback accordingly.
+Pick a tuning **Preset** for your ukulele. The app adjusts the fretboard, chord detection, and playback accordingly. Eight presets are available:
 
 | Tuning | Strings | Description |
 |--------|---------|------------|
-| **High-G (Standard)** | G4-C4-E4-A4 | The most common soprano/concert/tenor tuning with a re-entrant high G string. |
-| **Low-G** | G3-C4-E4-A4 | Same notes but with the G string tuned an octave lower, extending the bass range. |
-| **Baritone (DGBE)** | D3-G3-B4-E4 | Baritone ukulele tuning, matching the top four strings of a guitar. |
-| **D-Tuning (ADF#B)** | A4-D4-F#4-B4 | A traditional alternative tuning, one whole step above standard. |
+| **High-G (Standard)** | G C E A (re-entrant) | The most common soprano/concert/tenor tuning with a re-entrant high G string. |
+| **Low-G** | G C E A (low G) | Same notes but with the G string tuned an octave lower, extending the bass range. |
+| **Baritone (DGBE)** | D G B E | Baritone ukulele tuning, matching the top four strings of a guitar. |
+| **D-Tuning (ADF#B)** | A D F# B | A traditional alternative tuning, one whole step above standard. |
+| **Slack Key (GCEG)** | G C E G | An open-G tuning for slack-key style playing. |
+| **Open A (AC#EA)** | A C# E A | An open-A tuning. |
+| **Low A (GCEa)** | G C E a | Standard notes with a low A on the bottom string. |
+| **Half-Step Down** | F# B D# G# | Standard tuning lowered by a semitone. |
+
+## Tuner
+
+The Tuner section has its own options: **Auto-Start** (begin listening when the tuner opens), **Precision Mode**, **Auto-Advance** (move to the next string automatically), **Spoken Feedback**, and an **A4 Reference** slider (415–465 Hz) for adjusting the reference pitch.
 
 ## Fretboard
 
 | Setting | Description |
 |---------|------------|
 | **Left-Handed** | Mirrors the fretboard so the nut appears on the right side, matching a left-handed player's perspective. |
+| **Show Note Names** | Toggles note-name labels on the fretboard. |
+| **Allow Muted Strings** | Allows generated voicings to include muted strings. |
+| **Last Fret** | Sets how many frets the fretboard shows (12–22). |
+
+## Backup & Restore
+
+Export all your data — favorites, songs, melodies, progressions, custom patterns, setlists, learning progress, and settings — to a JSON file, and restore it later. Restoring merges the backup with your current data without overwriting existing items.
 
 ![Settings — more sections](screenshots/settings-panel-more.png)
 

--- a/docs/manual/ios/09-learning.md
+++ b/docs/manual/ios/09-learning.md
@@ -28,6 +28,7 @@ Below the practice timer, the dashboard shows stats for each training activity:
 - **Interval Trainer** — accuracy and attempts.
 - **Note Quiz** — score, accuracy, and best streak.
 - **Chord Ear Training** — accuracy and attempts.
+- **Scale Practice** — totals, accuracy, and best streak.
 
 ## Daily Challenge
 
@@ -37,9 +38,9 @@ Three fresh challenges are generated every day to keep your practice varied and 
 
 Each challenge card shows:
 
-- A **numbered badge** (1, 2, 3).
+- An **icon** indicating the challenge type, with the challenge **title** and type label.
 - The **challenge description** (e.g., "Learn C", "Theory Quiz: 10 Questions", "Practice: Happy Birthday").
-- A **Go** button that navigates directly to the relevant section of the app.
+- A **Mark Complete** button to check the challenge off once you have done it.
 
 Below the challenges, a **Tip of the Day** provides a quick piece of practice advice.
 
@@ -54,9 +55,9 @@ The Practice Routine builder creates a structured, guided session tailored to yo
 ### Setting Up
 
 1. **Duration** — drag the slider to set your available time (5–60 minutes).
-2. **Skill Level** — choose Beginner, Intermediate, or Advanced.
+2. **Level** — choose Beginner, Intermediate, or Advanced.
 3. **Focus Areas** — select which skills to include: Chords, Scales, Ear Training, Theory, Songs.
-4. Tap **Start Practice Routine**.
+4. Tap **Generate Routine**, then **Start Routine**.
 
 ### Following the Routine
 
@@ -66,7 +67,7 @@ The app generates a sequence of steps:
 - **Focused exercises** — exercises matched to your focus areas and skill level, each with a suggested duration.
 - **Cool-down** — a relaxing finish.
 
-Each step shows a description, time allocation, and a **Go** button to navigate to the relevant feature. Mark steps complete as you finish them. A progress bar tracks your overall routine completion.
+Each step shows a numbered badge, title, and time allocation. Tap a step to expand its description, then tap **Done** to mark it complete and advance to the next one. A progress indicator tracks your overall routine completion.
 
 ## Achievements
 
@@ -76,14 +77,15 @@ Earn badges by reaching milestones as you use the app.
 
 ### Achievement Categories
 
-- **Practice** — streaks and consistency (e.g., "Getting Started" for a 3-day streak, "Monthly Master" for 30 days).
-- **Learning** — lesson and quiz milestones (e.g., "First Steps" for completing your first lesson, "Scholar" for all lessons).
-- **Ear Training** — interval and chord ear training accuracy.
-- **Collection** — favorites and song milestones.
+- **Practice** — practice streaks, consistency, and scale-practice milestones.
+- **Learning** — lesson and quiz milestones.
+- **Ear Training** — interval and chord ear-training accuracy.
+- **Songs** — songbook milestones.
+- **Chords** — chord and favorites milestones.
 
 ### Viewing Achievements
 
-The gallery shows a progress bar (e.g., "1 / 21 unlocked") and lists all achievements. Filter by category using the chips at the top. Locked achievements are shown dimmed with their unlock criteria visible, so you always know what to work towards.
+The gallery shows how many achievements you have unlocked out of a total of 21, and lists all of them. Filter by category using the chips at the top. Locked achievements are shown dimmed with their unlock criteria visible, so you always know what to work towards.
 
 ## Tips
 

--- a/docs/manual/ios/10-play-along.md
+++ b/docs/manual/ios/10-play-along.md
@@ -1,6 +1,6 @@
 # Play Along & Chord Training
 
-These features use real-time audio and animation to help you practise chord changes and playing accuracy.
+These features use real-time audio and timed prompts to help you practise chord changes and playing accuracy.
 
 ## Play Along
 
@@ -10,25 +10,25 @@ Play Along lets you practise a chord progression with real-time feedback from yo
 
 ### Setup
 
-1. **Choose a key** — tap a note chip (C, C#, D, ... B).
-2. **Choose a scale** — Major or Minor.
-3. **Select a progression** — tap a progression card. Each card shows the name, description, and the resolved chord names in your chosen key (e.g., "C → G → Am → F").
+1. **Key** — pick a root note (C, C#, D, ... B) from the Key picker.
+2. **Scale** — choose Major or Minor.
+3. **Progression** — pick a progression from the Progression picker. After you choose one, its chords (resolved into your chosen key) appear as a row of chips below.
 
 ### Playing
 
-After selecting a progression, the play-along screen appears with:
+After selecting a progression, the play-along screen shows:
 
-- **Chord timeline** — a horizontal row of all chords in the progression. The current chord is highlighted.
-- **Current chord display** — a large card showing the chord you should be playing right now.
-- **Live detection feedback** — when the microphone is active, the app shows what chord it hears and whether it matches the expected chord (green check for correct, red X for incorrect).
+- **Chord strip** — a row of all chords in the progression. The current chord is highlighted while playing.
+- **Current chord display** — a large label showing the chord you should be playing right now.
+- **Beat indicators** — dots that fill in as each beat of the current chord passes.
+- **Live detection feedback** — when the microphone is active, the app shows what chord it hears ("Heard: …") and whether it matches the expected chord (green check for correct, red X for incorrect).
 - **Score card** — accuracy percentage, letter grade (S/A/B/C/D/F), and best streak.
 
 ### Controls
 
-- **BPM slider** — adjust the tempo from 40 to 180 BPM.
-- **Tap Tempo** — tap rhythmically to set the BPM by feel.
-- **Beats per chord** — choose 2, 4, or 8 beats before the progression advances to the next chord.
-- **Play/Stop button** — starts or stops the session. When playing, the metronome keeps time and the progression advances automatically.
+- **BPM slider** — adjust the tempo from 40 to 200 BPM.
+- **Beats/Chord** — choose 2, 4, or 8 beats before the progression advances to the next chord.
+- **Play/Stop button** — starts or stops the session. When playing, the progression advances automatically in time.
 
 ### Microphone Permission
 
@@ -45,35 +45,29 @@ Each beat is scored based on whether the detected chord matches the expected cho
 
 ## Chord Transitions
 
-The Chord Transition Trainer helps you practise switching between two chords with an animated fretboard visualisation.
+The Chord Transition Trainer helps you drill switching between two chords in time, so you can build muscle memory for a change that gives you trouble.
 
 ![Chord Transitions](screenshots/chord-transitions.png)
 
 ### Setup
 
-1. **Chord A** — select the root note and chord type for the starting chord.
-2. **Chord B** — select the root note and chord type for the target chord.
+1. **Chord 1** — select the root note and chord quality for the starting chord.
+2. **Chord 2** — select the root note and chord quality for the target chord.
 
-The app displays both chord diagrams side by side so you can see the finger positions.
-
-### Animation
-
-Below the diagrams, an animated fretboard shows how your fingers move from Chord A to Chord B:
-
-- Fingers that **stay** in place are shown as stationary dots.
-- Fingers that **slide** along a string are animated smoothly.
-- Fingers that **lift** off are shown moving away.
-- Fingers that **place** onto a new position are shown arriving.
+The app shows both chord diagrams (stacked with an arrow between them) so you can see the finger positions. Tap a diagram to hear that chord.
 
 ### Controls
 
-- **BPM slider** — controls the animation speed.
-- **Tap Tempo** — set the speed by tapping.
-- **Beats** — choose 1, 2, 4, or 8 beats per transition cycle.
-- **Play button** — starts the repeating animation.
-- **Reset button** — resets the animation to the start.
+- **BPM slider** — sets the tempo of the drill (40–200 BPM).
+- **Tap** — set the tempo by tapping rhythmically.
+- **Beats per chord** — choose 1, 2, 4, or 8 beats before switching chords.
+- **Play chord on transition** — when on, the chord is strummed each time it changes.
+- **Start button** — begins the timed drill.
+- **Reset button** — clears the transition count and timer.
 
-A text description of each finger movement is shown alongside the animation (e.g., "Index: slide from fret 1 to fret 2", "Ring: lift off").
+### During the Drill
+
+While the drill runs, the app shows the **current chord** in large text with **beat indicators** that fill as each beat passes, prompting you when to switch. Below, a stats row tracks your **transition count**, **elapsed time**, and **switches per minute** so you can measure your progress.
 
 ## Tips
 

--- a/docs/manual/ios/11-tuner.md
+++ b/docs/manual/ios/11-tuner.md
@@ -14,10 +14,11 @@ The Tuner is a chromatic tuner that listens to your ukulele through the micropho
 
 ## Tuner Display
 
-- **Note name** — large, color-coded text showing the detected pitch. Green means in tune, yellow means close, and red means the string needs significant adjustment.
-- **Needle meter** — a semicircular gauge showing the deviation in cents (-50 to +50). Center is perfectly in tune.
-- **Cents display** — a numeric readout (e.g., "+5 ¢") for precise tuning.
-- **Guidance text** — "Tune up", "Tune down", or "In tune" to tell you which direction to adjust.
+- **Tuning label** — shows the selected tuning and its open-string notes (and the A4 reference if you have changed it from 440 Hz).
+- **Note name** — large, color-coded text showing the detected pitch, with its octave below. Green means in tune, yellow means close, and red means the string needs significant adjustment.
+- **Needle meter** — a semicircular gauge showing the deviation in cents (-50 to +50), with a green in-tune zone in the centre.
+- **Frequency display** — a numeric readout in hertz (e.g., "440.0 Hz") for precise tuning.
+- **Guidance text** — when a string is matched, "Tune up", "Tune down", or "In tune" tells you which direction to adjust.
 
 ## String Buttons
 
@@ -47,4 +48,4 @@ The tuner adapts to whichever tuning you have selected in [Settings](08-settings
 - Play each string firmly and let it ring — the tuner needs a clear, sustained tone.
 - Tune from below the target pitch upward for better tuning stability.
 - The string buttons double as reference tones — tap them to hear what the string should sound like.
-- If the tuner picks up background noise, increase the **Noise filtering** slider in Settings. If it struggles to detect quiet playing, lower it.
+- If the tuner picks up background noise, increase the **Noise Gate** slider in Settings. If it struggles to detect quiet playing, lower it.

--- a/docs/manual/ios/12-pitch-monitor.md
+++ b/docs/manual/ios/12-pitch-monitor.md
@@ -30,4 +30,4 @@ As you play, the Pitch Monitor collects detected notes and identifies chords. Th
 - Use the Pitch Monitor to practice playing scales and check if your finger placement is producing accurate pitches.
 - Watch the blue trace to see how steady your pitch is — wobble indicates inconsistent fretting pressure.
 - The chromagram glow helps you see which notes are ringing strongest, useful for diagnosing muted or buzzing strings.
-- Adjust the **Noise filtering** slider in Settings if background noise creates unwanted pitch traces, or lower it to detect softer playing.
+- Adjust the **Noise Gate** slider in Settings if background noise creates unwanted pitch traces, or lower it to detect softer playing.

--- a/docs/manual/ios/13-metronome.md
+++ b/docs/manual/ios/13-metronome.md
@@ -16,15 +16,15 @@ You can change the BPM while the metronome is playing — the new tempo takes ef
 
 ## Time Signature
 
-Select from 2/4, 3/4, 4/4, 5/4, 6/4, or 7/4 using the filter chips. The default is 4/4. Changing the time signature updates the number of beat indicators and resets the accent pattern.
+Select from 2/4, 3/4, 4/4, 5/4, 6/4, 7/4, 6/8, or 12/8 using the chips. The default is 4/4. Changing the time signature updates the number of beat indicators and resets the accent pattern.
 
 ## Accent Pattern
 
-A row of circles represents each beat in the measure. The first beat is accented by default (shown with a filled primary-color circle). Tap any beat circle to cycle through three states:
+A row of circles represents each beat in the measure. The first beat is accented by default. Tap any beat circle to cycle through three states:
 
-- **Accent** (filled circle) — plays a higher-pitched click at full volume.
-- **Normal** (outlined circle) — plays a standard click.
-- **Mute** (dotted circle) — silent beat, no click but the visual indicator still pulses.
+- **Accent** (filled, blue) — plays a higher-pitched click at full volume.
+- **Normal** (green) — plays a standard click.
+- **Mute** (empty circle) — silent beat, no click but the visual indicator still pulses.
 
 Customizing the accent pattern lets you practice different feels — for example, accenting beats 1 and 3 in 4/4 for a rock groove, or just beat 1 in 3/4 for a waltz.
 
@@ -35,9 +35,9 @@ Choose how many clicks play per beat:
 - **Quarter** — one click per beat (default).
 - **Eighth** — two clicks per beat.
 - **Triplet** — three clicks per beat.
-- **16th** — four clicks per beat.
+- **Sixteenth** — four clicks per beat.
 
-Subdivision clicks are played quieter than main beats so they don't overpower the pulse. Use subdivisions to practice faster strumming patterns or to develop a feel for rhythmic subdivisions.
+Subdivision clicks are played quieter than main beats so they don't overpower the pulse. (For compound meters such as 6/8 and 12/8, the subdivision is fixed and the chips are disabled.) Use subdivisions to practice faster strumming patterns or to develop a feel for rhythmic subdivisions.
 
 ## Playing
 

--- a/docs/manual/ios/14-melody-notepad.md
+++ b/docs/manual/ios/14-melody-notepad.md
@@ -27,36 +27,35 @@ Notes appear in the sequence display at the top as colored blocks showing the no
 
 Toggle from Linear to **Step Sequencer** mode using the mode switch at the top.
 
-1. The sequencer shows a grid of **8 steps** by default. Tap **Expand** to switch to 16 steps, or **Shrink** to return to 8.
-2. Tap any step in the grid to open a **pitch picker**. Select a note name and octave to assign it to that step.
-3. Use the context menu on a step to **clear** it (reset it to silence).
-4. Tap **Play** to loop the sequence continuously at the current BPM. The active step is highlighted as it plays.
-5. Tap **Stop** to end playback.
+1. The sequencer shows a grid of **8 steps** by default. Tap the **16 Steps** button to expand it, or **8 Steps** to shrink it back.
+2. Tap any step in the grid to open a **pitch picker** and choose a note name for that step. The octave comes from the **Octave** stepper below the grid.
+3. Use the context menu (or the pitch picker's **Clear** button) on a step to clear it back to silence.
+4. Tap **Play** to play the sequence at the current BPM; turn on the **loop** button to repeat it continuously. The active step is highlighted as it plays.
+5. Tap **Stop** to end playback, and **Clear** to empty the grid.
 
 The step sequencer is ideal for building rhythmic patterns and loop-based ideas without worrying about note durations — each step has equal timing determined by the BPM.
 
 ## Editing
 
 - Tap any note in the sequence to select it. The selected note is highlighted.
-- Tap the **delete** icon to remove the selected note.
-- The sequence scrolls horizontally if it extends beyond the screen width.
+- Tap the **×** badge on the selected note to remove it.
+- The sequence wraps onto multiple rows and scrolls vertically if it grows long.
 
 ## Playback
 
-- Set the **BPM** using the slider (40-220 BPM).
+- Set the **BPM** using the slider (40-200 BPM).
 - Tap **Play** to hear the melody played back. The current note is highlighted during playback.
 - Tap **Stop** to halt playback.
-- Tap **Clear** to remove all notes from the sequence.
 
 ## Saving and Loading
 
-Melodies are saved to the device and persist between sessions.
+Melodies are saved to the device and persist between sessions. In Linear mode you have these buttons:
 
-- Tap the **save** icon or use the menu to **Save As** with a custom name.
-- Use **Load** to open a previously saved melody from a list.
-- Use **Rename** to change the name of the current melody.
-- Use **New** to start a fresh empty melody (you will be prompted to save unsaved changes).
-- Use **Delete** to permanently remove the current melody.
+- **New** — start a fresh empty melody (you will be prompted to discard unsaved changes first).
+- **Save** — name and save the current melody.
+- **Load** — open the saved-melody list and tap one to load it.
+
+In the Load list, swipe a melody to **Rename** or **Delete** it.
 
 ## Tips
 
@@ -65,5 +64,5 @@ Melodies are saved to the device and persist between sessions.
 - Use Step Sequencer mode for rhythmic patterns and loop-based ideas — great for experimenting with riffs.
 - Start with quarter notes for simple melodies, then add eighth and sixteenth notes for faster passages.
 - Experiment with different octaves to create melodies that span the full ukulele range.
-- In Record mode, if the app picks up unwanted notes from background noise, increase the **Noise filtering** slider in Settings.
+- In Record mode, if the app picks up unwanted notes from background noise, increase the **Noise Gate** slider in Settings.
 - In the step sequencer, start with 8 steps for short loops and expand to 16 when you need a longer phrase.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -19,21 +19,23 @@ Uke does **not**:
 
 ## Microphone Access
 
-The app requests microphone access **only** for the optional **Tuner** feature.
-When you use the Tuner, the app listens to audio from your device's microphone
-to detect the pitch of your ukulele strings in real time.
+The app requests microphone access **only** for its optional pitch-detection
+features — the **Tuner**, **Pitch Monitor**, **Play Along**, and the recording
+mode of the **Melody Notepad**. When you use one of these features, the app
+listens to audio from your device's microphone to detect the pitch of your
+ukulele strings in real time.
 
 - Audio is processed **entirely on your device** and is never recorded, saved, or transmitted.
 - Audio data is discarded immediately after pitch detection; no audio buffers are retained.
-- The microphone is only active while the Tuner is running. It stops as soon as you leave the Tuner screen or tap "Stop."
+- The microphone is only active while one of these features is running. It stops as soon as you leave the screen or tap "Stop."
 - If you deny microphone permission, every other feature of the app continues to work normally.
 
 ## Backup (Optional)
 
-On Android, you may optionally use Google Drive for backup. The app accesses only
-its own app-specific folder on your Google Drive and does not read or modify any
-other files. Google's own privacy policy applies to Google Sign-In and Drive
-services. On iOS, you can export and import backups as local files.
+You may optionally export your data to a local file and import it back later.
+On both Android and iOS, backups are written to and read from local files you
+choose; the app does not upload your data to any cloud service or external
+server.
 
 ## Local Storage
 

--- a/docs/spec/22-neural-pitch-supervisor.md
+++ b/docs/spec/22-neural-pitch-supervisor.md
@@ -595,8 +595,44 @@ both platforms:
 
 - **Android:** `NeuralPitchSupervisor.kt` uses ONNX Runtime Android AAR.
 - **iOS:** `NeuralPitchSupervisor.swift` uses ONNX Runtime via the C API
-  (`ort_c_api.h`), with `KotlinFloatArray` interop for the shared KMP
-  `AudioResampler`.
+  (`import onnxruntime`, `OrtApi`), with `KotlinFloatArray` interop for the
+  shared KMP `AudioResampler`.
+
+### Shared Arbitrator (NeuralArbitrator)
+
+The spec's `arbitrate()` pseudocode lived inline in `TunerViewModel`. The
+shipped code extracts the arbitration state machine into a single
+platform-independent KMP class,
+`shared/.../domain/NeuralArbitrator.kt`, used unchanged by both the Android
+`TunerViewModel.kt` and the iOS `TunerViewModel.swift` (now its own file under
+`iosApp/.../ViewModels/`, not inside `TunerView.swift`). `NeuralArbitrator`
+owns frame-interval gating, result-TTL aging, failure tracking, a consistency
+window, and the final decision.
+
+The shipped arbitration cascade and constants differ from the design
+pseudocode above:
+
+- `SUPERVISOR_INTERVAL = 5` frames, `RESULT_TTL_FRAMES = 10`,
+  `FAILURE_THRESHOLD = 15`, `CONSISTENCY_FRAMES = 2`.
+- Gaps ≤ `ARBITRATION_IGNORE_SEMITONES` (1.5) keep YIN; a neural override
+  also requires the result to have been consistent (within 0.5 semitone) for
+  `CONSISTENCY_FRAMES`.
+- Octave correction requires neural confidence ≥ 0.85 **and** YIN
+  confidence ≥ 0.12.
+- Strong-disagreement override requires gap ≥ `ARBITRATION_STRONG_SEMITONES`
+  (2.5), neural confidence ≥ 0.93, **and** YIN confidence ≥ 0.16.
+- On override, `frequencyHz` comes from neural but `confidence` is always the
+  YIN confidence (the better-calibrated quality metric).
+
+### No Opt-In Toggle (Always On with Fallback)
+
+Section F above proposed an opt-in `neuralPitchSupervisor` boolean in
+`AppSettings` (default off). The shipped code does **not** add such a setting.
+The supervisor is initialized automatically whenever the tuner opens
+(`initializeNeuralSupervisor()`), surfacing a `NeuralRuntimeStatus`
+(`LOADING` → `ACTIVE` / `FALLBACK`) badge instead. If the model fails to load
+or inference fails repeatedly, it falls back to YIN-only silently — so the
+always-on default carries no functional risk and no user toggle was needed.
 
 ### Async Model Loading (PR #174)
 
@@ -619,12 +655,15 @@ budget. Both `TunerViewModel` and `PitchMonitorViewModel` now guard
 `processBuffer` with an `isProcessing` flag that drops incoming frames
 when the previous frame is still being processed.
 
-### Cached AudioResampler Buffers (PR #177)
+### AudioResampler — Anti-Aliasing and Cached Buffers (PR #177)
 
-The spec's `AudioResampler` allocated `filtered` and `output` arrays on
-every call. The shipped `AudioResampler` caches these as instance fields
-(`cachedFiltered`, `cachedOutput`) and reuses them when the input size is
-unchanged, eliminating ~104 KB/s of GC pressure.
+The spec's `AudioResampler` showed plain linear interpolation and noted a
+low-pass anti-aliasing filter "should precede this in production." The shipped
+`AudioResampler` (a shared KMP `object`, public entry point
+`downsample44kTo16k()`, not `downsample()`) applies a 5-tap moving-average
+pre-filter before the linear-interpolation resample. It also caches its work
+arrays and reuses them when the input size is unchanged, eliminating
+~104 KB/s of GC pressure.
 
 ### Cached PitchDetector Buffers (PR #175)
 

--- a/docs/talk/building-ukulele-companion.md
+++ b/docs/talk/building-ukulele-companion.md
@@ -15,7 +15,7 @@ headingDivider: false
 ![icon](../app-icon-512.png)
 
 <!--
-Speaker: Introduce yourself and the repo (~275 commits on main). Root commit 9abb4b3 “Ukulele Fretboard Chord Explorer.” This deck is about *process*, not a feature tour.
+Speaker: Introduce yourself and the repo (~600+ commits on main). Root commit 9abb4b3 “Ukulele Fretboard Chord Explorer.” This deck is about *process*, not a feature tour.
 -->
 
 ---

--- a/docs/videos/README.md
+++ b/docs/videos/README.md
@@ -29,7 +29,7 @@ Short-form promotional videos targeting 30–50 seconds each. Use true 9:16 reso
 | Chord Detector | [shorts/chord-detector/](shorts/chord-detector/) | 2 | "Tap the fretboard. Know your chord instantly." | TOML ready |
 | Tuner Freeze | [shorts/tuner-freeze/](shorts/tuner-freeze/) | 2 | "The needle freezes so you never lose your note." | TOML ready |
 | Progressions Practice | [shorts/progressions-practice/](shorts/progressions-practice/) | 2 | "Stop fumbling chord changes." | TOML ready |
-| Scale Explorer | [shorts/scale-explorer/](shorts/scale-explorer/) | 2 | "38 scales, color-mapped across the neck." | TOML ready |
+| Scale Explorer | [shorts/scale-explorer/](shorts/scale-explorer/) | 2 | "37 scales, color-mapped across the neck." | TOML ready |
 | Free and Offline | [shorts/free-and-offline/](shorts/free-and-offline/) | 1 | Value-prop closer — free / offline / accessible | TOML ready |
 
 ### Producing a Short

--- a/docs/videos/chords/android.toml
+++ b/docs/videos/chords/android.toml
@@ -1,6 +1,6 @@
 [project]
 title = "Chord Library - Ukulele Companion"
-description = "Browse voicings for 20 chord types across all 12 root notes"
+description = "Browse voicings for 19 chord types across all 12 root notes"
 output = "../../feature-videos/android/chords.mp4"
 resolution = "1080x2424"
 

--- a/docs/videos/shorts/scale-explorer/android.toml
+++ b/docs/videos/shorts/scale-explorer/android.toml
@@ -1,6 +1,6 @@
 [project]
 title = "Scale Explorer — Ukulele Companion Short"
-description = "35–50s YouTube Short / Instagram Reel: 38 scales color-mapped across the fretboard"
+description = "35–50s YouTube Short / Instagram Reel: 37 scales color-mapped across the fretboard"
 output = "../../../feature-videos/android/shorts/scale-explorer.mp4"
 resolution = "1080x1920"
 


### PR DESCRIPTION
## Summary

A multi-agent audit of the documentation against the current codebase. Four agents each owned a disjoint set of docs (root, Android manual, iOS manual, spec/parity/landing), verified every factual claim against the live source, and fixed inaccuracies / removed obsolete content. All numeric and structural claims were independently re-verified before commit.

**31 files changed, +319 / −278.** Documentation only — no app code touched.

## Highlights

**Root docs (README, AGENTS, ATTRIBUTION)**
- Versions: Kotlin 2.4, Gradle 9.5.1, AGP 9.2
- `OGG` → `WAV` audio samples (no OGG files exist; `app/src/main/res/raw/` is all `.wav`)
- Corrected counts: **19** chord types, **37** scales, 76 Compose screens, 14 Android VMs, 50 iOS views, 17 iOS VMs, 16 locales

**Manuals (Android + iOS)**
- iOS documented as a **4-tab TabView** (Play / Create / Learn / Reference) with the Tuner nested under Play — was incorrectly described as 5 tabs / Explorer-first
- Corrected screen, tab, and button labels (e.g. "Chords" → "Chord Library", "Songs" → "Songbook")
- Fixed ranges/counts: all **8** tuning presets (Android page listed only 4), strum delay **0–150 ms**, Play Along BPM **40–200**, metronome **6/8 & 12/8**, grade thresholds, achievement categories
- Removed obsolete / non-existent UI: iOS first-run tips card, explorer transpose section, Compare/FAB/+− stepper controls, "Unfiled" folder chip, Tap Tempo in Play Along & Progressions
- Fixed favorites flow (heart icon saves; long-press shares)
- Preserved genuine platform differences (e.g. Android animates finger movement in Chord Transitions and uses a nav drawer; iOS uses a simpler timed drill and tabs)

**Privacy policy**
- Removed the obsolete **Google Drive backup** claim — there is zero Drive/cloud-sync code in the repo. Now documents local-file backup only, and the full microphone feature scope (Tuner, Pitch Monitor, Play Along, Melody Notepad)

**Spec 22 (neural pitch supervisor)**
- Documented the shipped `NeuralArbitrator` KMP class, its real constants, the always-on (no opt-in toggle) design, and the anti-aliasing resampler — reconciling design pseudocode with shipped code

**Video / talk docs**
- Corrected stale scale (38 → 37), chord (20 → 19), and commit counts

## Verification
Every changed count/version was re-checked against source (`ChordFormulas.ALL` = 19, `Scales.ALL` = 37, `UkuleleTuning` enum = 8, BPM slider ranges in the Swift views, `ContentView.swift` tab structure, `gradle/libs.versions.toml`, audio `res/raw` formats). Full diffs reviewed for markdown coherence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated comprehensive user guides for Android and iOS apps, including refined UI interactions (heart icon for saving favorites, updated progression and pattern workflows)
  * Added new supported time signatures (6/8, 12/8) and expanded tuning presets
  * Clarified feature descriptions: 19 supported chord types, 37 scales, 16 localized languages
  * Updated tech stack versions (Kotlin 2.4, Gradle 9.5, updated audio format support)
  * Refreshed privacy policy with expanded microphone access and backup details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->