### PR TITLE
Fix: persist ScalePractice direction, loop, and fret-position settings

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
@@ -148,7 +148,10 @@ internal fun PlayAlongContent(
         PlayDirection.entries.forEach { dir ->
             FilterChip(
                 selected = state.direction == dir,
-                onClick = { viewModel.setDirection(dir) },
+                onClick = {
+                    viewModel.setDirection(dir)
+                    onSettingsChanged(viewModel.currentSettings())
+                },
                 label = { Text(dir.localizedLabel()) },
                 colors = FilterChipDefaults.filterChipColors(
                     selectedContainerColor = MaterialTheme.colorScheme.tertiary,
@@ -172,7 +175,10 @@ internal fun PlayAlongContent(
     ) {
         FilterChip(
             selected = state.loopPlayback,
-            onClick = { viewModel.toggleLoop() },
+            onClick = {
+                viewModel.toggleLoop()
+                onSettingsChanged(viewModel.currentSettings())
+            },
             label = { Text(stringResource(R.string.scale_practice_loop)) },
             colors = FilterChipDefaults.filterChipColors(
                 selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -208,7 +214,10 @@ internal fun PlayAlongContent(
             FretPosition.entries.forEach { pos ->
                 FilterChip(
                     selected = state.fretPosition == pos,
-                    onClick = { viewModel.setFretPosition(pos) },
+                    onClick = {
+                        viewModel.setFretPosition(pos)
+                        onSettingsChanged(viewModel.currentSettings())
+                    },
                     label = { Text(pos.localizedLabel()) },
                     colors = FilterChipDefaults.filterChipColors(
                         selectedContainerColor = MaterialTheme.colorScheme.tertiary,

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModel.kt
@@ -128,6 +128,9 @@ class ScalePracticeViewModel : ViewModel() {
         val scale = scales.firstOrNull { it.name == settings.lastScaleName } ?: scales.first()
         val mode = PracticeMode.entries.getOrElse(settings.lastMode) { PracticeMode.PLAY_ALONG }
 
+        val direction = PlayDirection.entries.getOrElse(settings.lastDirection) { PlayDirection.ASCENDING }
+        val fretPosition = FretPosition.entries.getOrElse(settings.lastFretPosition) { FretPosition.ALL }
+
         _uiState.update {
             it.copy(
                 mode = mode,
@@ -140,6 +143,9 @@ class ScalePracticeViewModel : ViewModel() {
                     ScalePracticeSettings.MAX_BPM,
                 ),
                 showFretboard = settings.showFretboard,
+                direction = direction,
+                loopPlayback = settings.loopPlayback,
+                fretPosition = fretPosition,
             )
         }
     }
@@ -156,6 +162,9 @@ class ScalePracticeViewModel : ViewModel() {
             lastBpm = s.bpm,
             lastMode = s.mode.ordinal,
             showFretboard = s.showFretboard,
+            lastDirection = s.direction.ordinal,
+            loopPlayback = s.loopPlayback,
+            lastFretPosition = s.fretPosition.ordinal,
         )
     }
 

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
@@ -175,6 +175,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             .putInt(KEY_SCALE_PRACTICE_BPM, s.scalePractice.lastBpm)
             .putInt(KEY_SCALE_PRACTICE_MODE, s.scalePractice.lastMode)
             .putBoolean(KEY_SCALE_PRACTICE_FRETBOARD, s.scalePractice.showFretboard)
+            .putInt(KEY_SCALE_PRACTICE_DIRECTION, s.scalePractice.lastDirection)
+            .putBoolean(KEY_SCALE_PRACTICE_LOOP, s.scalePractice.loopPlayback)
+            .putInt(KEY_SCALE_PRACTICE_FRET_POSITION, s.scalePractice.lastFretPosition)
             // Tuner
             .putBoolean(KEY_TUNER_SPOKEN_FEEDBACK, s.tuner.spokenFeedback)
             .putBoolean(KEY_TUNER_PRECISION_MODE, s.tuner.precisionMode)
@@ -231,6 +234,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 lastBpm = prefs.getInt(KEY_SCALE_PRACTICE_BPM, ScalePracticeSettings.DEFAULT_BPM),
                 lastMode = prefs.getInt(KEY_SCALE_PRACTICE_MODE, 0),
                 showFretboard = prefs.getBoolean(KEY_SCALE_PRACTICE_FRETBOARD, false),
+                lastDirection = prefs.getInt(KEY_SCALE_PRACTICE_DIRECTION, 0),
+                loopPlayback = prefs.getBoolean(KEY_SCALE_PRACTICE_LOOP, false),
+                lastFretPosition = prefs.getInt(KEY_SCALE_PRACTICE_FRET_POSITION, 0),
             ),
             tuner = TunerSettings(
                 spokenFeedback = prefs.getBoolean(KEY_TUNER_SPOKEN_FEEDBACK, false),
@@ -266,6 +272,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         private const val KEY_SCALE_PRACTICE_BPM = "scale_practice_bpm"
         private const val KEY_SCALE_PRACTICE_MODE = "scale_practice_mode"
         private const val KEY_SCALE_PRACTICE_FRETBOARD = "scale_practice_fretboard"
+        private const val KEY_SCALE_PRACTICE_DIRECTION = "scale_practice_direction"
+        private const val KEY_SCALE_PRACTICE_LOOP = "scale_practice_loop"
+        private const val KEY_SCALE_PRACTICE_FRET_POSITION = "scale_practice_fret_position"
         private const val KEY_TUNER_SPOKEN_FEEDBACK = "tuner_spoken_feedback"
         private const val KEY_TUNER_PRECISION_MODE = "tuner_precision_mode"
         private const val KEY_TUNER_A4_REFERENCE = "tuner_a4_reference"

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
@@ -160,6 +160,9 @@ data class ScalePracticeSettings(
     val lastBpm: Int = DEFAULT_BPM,
     val lastMode: Int = 0,
     val showFretboard: Boolean = false,
+    val lastDirection: Int = 0,
+    val loopPlayback: Boolean = false,
+    val lastFretPosition: Int = 0,
 ) {
     companion object {
         const val MIN_BPM = 40


### PR DESCRIPTION
## Summary
- Direction, loop toggle, and fret position chip `onClick` handlers called the viewModel setter but never invoked `onSettingsChanged()`, so those preferences were lost on mode switch or app restart.
- Added the missing `onSettingsChanged(viewModel.currentSettings())` calls, matching the existing pattern used by root note, scale, BPM, and fretboard toggle.

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [x] Unit tests pass (`testDebugUnitTest`)
- [ ] Manual: Open Scale Practice → Play Along, change direction/loop/position, switch to Quiz and back — settings should persist

Fixes #359

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where changes to the direction, loop playback, and fret position settings were not being properly registered during scale practice sessions. The app now correctly communicates settings updates in response to user interactions with these controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->