### PR TITLE
Fix: wire up iOS PerformanceModeView auto-scroll with timer logic

### DIFF
--- a/iosApp/UkuleleCompanion/Views/PerformanceModeView.swift
+++ b/iosApp/UkuleleCompanion/Views/PerformanceModeView.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+private struct ScrollOffsetKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
 struct PerformanceModeView: View {
     @Environment(\.dismiss) private var dismiss
     let content: String
@@ -9,21 +16,63 @@ struct PerformanceModeView: View {
     @State private var scrollSpeed: Double = 1.0
     @State private var scrollTimer: Timer?
     @State private var showControls = true
+    @State private var scrollOffset: CGFloat = 0
+    @State private var trackedScrollOffset: CGFloat = 0
+    @State private var contentHeight: CGFloat = 1
+    @State private var viewportHeight: CGFloat = 1
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(content.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
-                        if line.trimmingCharacters(in: .whitespaces).isEmpty {
-                            Spacer().frame(height: 20)
-                        } else {
-                            Text(line)
-                                .font(font)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(content.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
+                            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                                Spacer().frame(height: 20)
+                            } else {
+                                Text(line)
+                                    .font(font)
+                            }
                         }
+                        Color.clear.frame(height: 1).id("bottom")
+                    }
+                    .padding(24)
+                    .background(
+                        GeometryReader { geo in
+                            Color.clear
+                                .preference(key: ScrollOffsetKey.self,
+                                            value: -geo.frame(in: .named("perfScroll")).minY)
+                                .onChange(of: geo.size.height) { newHeight in
+                                    contentHeight = newHeight
+                                }
+                                .onAppear { contentHeight = geo.size.height }
+                        }
+                    )
+                }
+                .coordinateSpace(name: "perfScroll")
+                .onPreferenceChange(ScrollOffsetKey.self) { value in
+                    trackedScrollOffset = max(0, value)
+                }
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.onAppear { viewportHeight = geo.size.height }
+                            .onChange(of: geo.size.height) { newHeight in
+                                viewportHeight = newHeight
+                            }
+                    }
+                )
+                .onChange(of: scrollSpeed) { _ in
+                    guard isAutoScrolling else { return }
+                    scrollTimer?.invalidate()
+                    scrollTimer = createScrollTimer(proxy: proxy)
+                }
+                .onChange(of: isAutoScrolling) { scrolling in
+                    if scrolling {
+                        startAutoScroll(proxy: proxy)
+                    } else {
+                        pauseAutoScroll()
                     }
                 }
-                .padding(24)
             }
 
             if showControls {
@@ -58,7 +107,10 @@ struct PerformanceModeView: View {
                         .accessibilityLabel("Increase speed")
                     }
 
-                    Button { dismiss() } label: {
+                    Button {
+                        pauseAutoScroll()
+                        dismiss()
+                    } label: {
                         Image(systemName: "arrow.down.right.and.arrow.up.left")
                     }
                     .buttonStyle(.bordered)
@@ -86,10 +138,44 @@ struct PerformanceModeView: View {
                 showControls = true
             }
         }
+        .onDisappear {
+            pauseAutoScroll()
+        }
         .onReceive(NotificationCenter.default.publisher(for: UIAccessibility.voiceOverStatusDidChangeNotification)) { _ in
             if UIAccessibility.isVoiceOverRunning {
                 showControls = true
             }
         }
+    }
+
+    // MARK: - Auto-scroll helpers
+
+    @discardableResult
+    private func createScrollTimer(proxy: ScrollViewProxy) -> Timer {
+        let interval = 1.0 / (scrollSpeed * 2)
+        nonisolated(unsafe) let scrollProxy = proxy
+        let timer = Timer(timeInterval: interval, repeats: true) { [self] _ in
+            MainActor.assumeIsolated {
+                guard self.isAutoScrolling else { return }
+                self.scrollOffset += 1
+                let maxScroll = max(1, self.contentHeight - self.viewportHeight)
+                let anchorY = min(1.0, self.scrollOffset / maxScroll)
+                scrollProxy.scrollTo("bottom", anchor: .init(x: 0.5, y: 1.0 - anchorY))
+            }
+        }
+        RunLoop.current.add(timer, forMode: .common)
+        return timer
+    }
+
+    private func startAutoScroll(proxy: ScrollViewProxy) {
+        let maxScroll = max(1, contentHeight - viewportHeight)
+        scrollOffset = (trackedScrollOffset / maxScroll) * maxScroll
+        scrollTimer = createScrollTimer(proxy: proxy)
+    }
+
+    private func pauseAutoScroll() {
+        isAutoScrolling = false
+        scrollTimer?.invalidate()
+        scrollTimer = nil
     }
 }


### PR DESCRIPTION
## Summary
- PerformanceModeView's auto-scroll controls were toggling `@State` variables but never driving actual `ScrollView` scrolling
- Ported the working timer-based scroll pattern from `SongViewerView` using `ScrollViewReader`, geometry tracking, and a repeating `Timer` that advances the scroll position

## Test plan
- [x] iOS build succeeds
- [ ] Manual: Open a song → Performance mode → tap Scroll → content scrolls down
- [ ] Speed +/- buttons change scroll rate
- [ ] Pause stops scrolling, resume continues from current position
- [ ] Exiting performance mode cleans up the timer

Fixes #360

Made with [Cursor](https://cursor.com)