### PR TITLE
Fix: add heading semantics to section labels for TalkBack navigation

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/AboutSection.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/AboutSection.kt
@@ -98,6 +98,7 @@ internal fun AboutSection() {
         style = MaterialTheme.typography.titleSmall,
         fontWeight = FontWeight.SemiBold,
         color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.semantics { heading() },
     )
     Spacer(modifier = Modifier.height(8.dp))
     CreditItem(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordLibraryTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordLibraryTab.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
@@ -306,6 +308,8 @@ internal fun SectionLabel(text: String) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp),
+        modifier = Modifier
+            .semantics { heading() }
+            .padding(horizontal = 16.dp, vertical = 2.dp),
     )
 }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -73,7 +74,9 @@ internal fun PlayAlongContent(
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 4.dp),
+        modifier = Modifier
+            .semantics { heading() }
+            .padding(bottom = 4.dp),
     )
     Row(
         modifier = Modifier
@@ -109,7 +112,9 @@ internal fun PlayAlongContent(
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 4.dp),
+        modifier = Modifier
+            .semantics { heading() }
+            .padding(bottom = 4.dp),
     )
     Row(
         modifier = Modifier
@@ -140,7 +145,9 @@ internal fun PlayAlongContent(
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 4.dp),
+        modifier = Modifier
+            .semantics { heading() }
+            .padding(bottom = 4.dp),
     )
     Row(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -168,7 +175,9 @@ internal fun PlayAlongContent(
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 4.dp),
+        modifier = Modifier
+            .semantics { heading() }
+            .padding(bottom = 4.dp),
     )
     Row(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -206,7 +215,9 @@ internal fun PlayAlongContent(
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 4.dp),
+            modifier = Modifier
+                .semantics { heading() }
+                .padding(bottom = 4.dp),
         )
         Row(
             horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeStats.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeStats.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
@@ -30,6 +32,7 @@ internal fun StatsRow(
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.semantics { heading() },
     )
     Spacer(modifier = Modifier.height(4.dp))
     Row(
@@ -53,6 +56,7 @@ internal fun AllTimeStatsRow(stats: LearningStats) {
         style = MaterialTheme.typography.labelSmall,
         fontWeight = FontWeight.Bold,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.semantics { heading() },
     )
     Spacer(modifier = Modifier.height(4.dp))
     Row(


### PR DESCRIPTION
## Summary
- Added `Modifier.semantics { heading() }` to section header `Text` composables so TalkBack announces them as headings during swipe navigation
- Fixed `SectionLabel` (used throughout chord library), "Credits" in AboutSection, all 5 labels in ScalePracticePlayAlong, and both stats row labels in ScalePracticeStats

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [ ] Enable TalkBack → navigate Scale Practice and Chord Library with heading swipe gesture (up/down with 3 fingers or rotor heading) → headers should be announced

Fixes #361

Made with [Cursor](https://cursor.com)