### PR TITLE
Fix: add Role.Button to clickable rows for TalkBack announcements

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/AboutSection.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/AboutSection.kt
@@ -62,7 +62,7 @@ internal fun AboutSection() {
         text = stringResource(R.string.settings_website),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.clickable {
+        modifier = Modifier.clickable(role = Role.Button) {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://baijum.github.io/ukulele-companion"))
             context.startActivity(intent)
         },
@@ -72,7 +72,7 @@ internal fun AboutSection() {
         text = stringResource(R.string.settings_free_book),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.clickable {
+        modifier = Modifier.clickable(role = Role.Button) {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://archive.org/details/ukulele-book"))
             context.startActivity(intent)
         },
@@ -82,7 +82,7 @@ internal fun AboutSection() {
         text = stringResource(R.string.settings_video_guide),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.clickable {
+        modifier = Modifier.clickable(role = Role.Button) {
             val intent = Intent(
                 Intent.ACTION_VIEW,
                 Uri.parse("https://www.youtube.com/playlist?list=PL4GycHdD--uonaifRHrBvNU7ym5jAVs8c"),

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordSearchBar.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordSearchBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
@@ -145,7 +146,7 @@ private fun ChordSuggestionRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(role = Role.Button, onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 10.dp)
             .semantics {
                 contentDescription = accessibilityLabel

--- a/app/src/main/java/com/baijum/ukufretboard/ui/DisplaySection.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/DisplaySection.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -128,7 +129,7 @@ internal fun LanguageSection() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { showDialog = true },
+            .clickable(role = Role.Button) { showDialog = true },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -168,7 +169,7 @@ internal fun LanguageSection() {
                             else MaterialTheme.colorScheme.onSurface,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable {
+                                .clickable(role = Role.Button) {
                                     val localeList = if (tag.isEmpty()) {
                                         LocaleListCompat.getEmptyLocaleList()
                                     } else {


### PR DESCRIPTION
## Summary
- Added `role = Role.Button` to clickable `Text` and `Row` elements so TalkBack announces them as actionable buttons
- Fixed language selector row and dialog options in DisplaySection, website/book/video links in AboutSection, and ChordSuggestionRow in ChordSearchBar

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [ ] Enable TalkBack → navigate to Settings About section → links should announce as buttons
- [ ] Navigate to Chord Library search → suggestion items should announce as buttons

Fixes #362

Made with [Cursor](https://cursor.com)