### PR TITLE
Fix: localize hardcoded inversion chip labels

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordSelectors.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordSelectors.kt
@@ -191,10 +191,10 @@ internal fun InversionFilterChips(
     val options = buildList {
         add(null to stringResource(R.string.label_all))
         add(ChordInfo.Inversion.ROOT to stringResource(R.string.label_root))
-        add(ChordInfo.Inversion.FIRST to "1st Inv")
-        add(ChordInfo.Inversion.SECOND to "2nd Inv")
+        add(ChordInfo.Inversion.FIRST to stringResource(R.string.chord_library_first_inv))
+        add(ChordInfo.Inversion.SECOND to stringResource(R.string.chord_library_second_inv))
         if (hasSeventhIntervals) {
-            add(ChordInfo.Inversion.THIRD to "3rd Inv")
+            add(ChordInfo.Inversion.THIRD to stringResource(R.string.chord_library_third_inv))
         }
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d توزيع صوتي</string>
     <string name="chord_library_reentrant_limited">يحتوي هذا الوتر على %d توزيعات صوتية فقط. يحد الضبط المتكرر (High-G) من الانعكاسات لأن وتر C (C4) يكون دائماً تقريباً أخفض نغمة. يتيح ضبط Low-G تنوعاً أكبر في الانعكاسات.</string>
     <string name="chord_library_reentrant_empty">في الضبط المتكرر (High-G)، يكون وتر C دائماً تقريباً أخفض نوتة، لذا معظم التوزيعات الصوتية في الوضع الأصلي. جرّب اختيار \"الكل\" لرؤية التوزيعات المتاحة.</string>
+    <string name="chord_library_first_inv">قلب ١</string>
+    <string name="chord_library_second_inv">قلب ٢</string>
+    <string name="chord_library_third_inv">قلب ٣</string>
     <string name="chord_library_no_voicings">لم يتم العثور على توزيعات صوتية</string>
     <string name="chord_library_search_hint">بحث عن وتر (مثل Cm7, C/E)</string>
     <string name="chord_library_search_clear">مسح البحث</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d 种指法</string>
     <string name="chord_library_reentrant_limited">这个和弦只有 %d 种指法。回旋调弦（High-G）限制了转位的可能，因为 C 弦 (C4) 几乎总是最低音。Low-G 调弦可以提供更多转位变化。</string>
     <string name="chord_library_reentrant_empty">在回旋调弦（High-G）下，C 弦几乎总是最低音，因此大多数指法都是原位。试试选择"全部"来查看可用指法。</string>
+    <string name="chord_library_first_inv">第一转位</string>
+    <string name="chord_library_second_inv">第二转位</string>
+    <string name="chord_library_third_inv">第三转位</string>
     <string name="chord_library_no_voicings">未找到指法</string>
     <string name="chord_library_search_hint">搜索和弦（例如 Cm7, C/E）</string>
     <string name="chord_library_search_clear">清除搜索</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d Voicing</string>
     <string name="chord_library_reentrant_limited">Dieser Akkord hat nur %d Voicings. Die rückläufige Stimmung (High-G) begrenzt die Umkehrungen, da die C-Saite (C4) fast immer der tiefste Ton ist. Low-G-Stimmung ermöglicht mehr Umkehrungsvielfalt.</string>
     <string name="chord_library_reentrant_empty">Bei rückläufiger Stimmung (High-G) ist die C-Saite fast immer der tiefste Ton, daher sind die meisten Voicings in Grundstellung. Wähle \"Alle\", um verfügbare Voicings zu sehen.</string>
+    <string name="chord_library_first_inv">1. Umk.</string>
+    <string name="chord_library_second_inv">2. Umk.</string>
+    <string name="chord_library_third_inv">3. Umk.</string>
     <string name="chord_library_no_voicings">Keine Voicings gefunden</string>
     <string name="chord_library_search_hint">Akkord suchen (z.B. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Suche löschen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">Este acorde solo tiene %d voicings. La afinación reentrante (Sol agudo) limita las inversiones porque la cuerda Do (Do4) casi siempre es el tono más grave. La afinación Sol grave permite más variedad de inversiones.</string>
     <string name="chord_library_reentrant_empty">En afinación reentrante (Sol agudo), la cuerda Do casi siempre es la nota más grave, así que la mayoría de los voicings son en posición fundamental. Prueba seleccionar \"Todos\" para ver los voicings disponibles.</string>
+    <string name="chord_library_first_inv">1.ª Inv</string>
+    <string name="chord_library_second_inv">2.ª Inv</string>
+    <string name="chord_library_third_inv">3.ª Inv</string>
     <string name="chord_library_no_voicings">No se encontraron voicings</string>
     <string name="chord_library_search_hint">Buscar acorde (ej., Cm7, C/E)</string>
     <string name="chord_library_search_clear">Borrar búsqueda</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">Cet accord n\'a que %d voicings. L\'accordage rentrant (Sol aigu) limite les renversements car la corde Do (Do4) est presque toujours la note la plus grave. L\'accordage Sol grave permet plus de variété.</string>
     <string name="chord_library_reentrant_empty">En accordage rentrant (Sol aigu), la corde Do est presque toujours la note la plus grave, donc la plupart des voicings sont en position fondamentale. Essayez de sélectionner \"Tout\" pour voir les voicings disponibles.</string>
+    <string name="chord_library_first_inv">1er Renv</string>
+    <string name="chord_library_second_inv">2e Renv</string>
+    <string name="chord_library_third_inv">3e Renv</string>
     <string name="chord_library_no_voicings">Aucun voicing trouvé</string>
     <string name="chord_library_search_hint">Rechercher un accord (ex. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Effacer la recherche</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d वॉइसिंग</string>
     <string name="chord_library_reentrant_limited">इस कॉर्ड में केवल %d वॉइसिंग हैं। री-एंट्रेंट ट्यूनिंग (High-G) इन्वर्शन को सीमित करती है क्योंकि C स्ट्रिंग (C4) लगभग हमेशा सबसे नीची पिच होती है। Low-G ट्यूनिंग अधिक इन्वर्शन विविधता प्रदान करती है।</string>
     <string name="chord_library_reentrant_empty">री-एंट्रेंट ट्यूनिंग (High-G) में, C स्ट्रिंग लगभग हमेशा सबसे नीचा नोट होता है, इसलिए अधिकांश वॉइसिंग मूल स्थिति में हैं। उपलब्ध वॉइसिंग देखने के लिए \"सभी\" चुनें।</string>
+    <string name="chord_library_first_inv">प्रथम व्युत्क्रम</string>
+    <string name="chord_library_second_inv">द्वितीय व्युत्क्रम</string>
+    <string name="chord_library_third_inv">तृतीय व्युत्क्रम</string>
     <string name="chord_library_no_voicings">कोई वॉइसिंग नहीं मिली</string>
     <string name="chord_library_search_hint">कॉर्ड खोजें (जैसे, Cm7, C/E)</string>
     <string name="chord_library_search_clear">खोज साफ़ करें</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">Akor ini hanya memiliki %d voicing. Tuning re-entrant (G tinggi) membatasi inversi karena senar C (C4) hampir selalu menjadi nada terendah. Tuning G rendah memungkinkan lebih banyak variasi inversi.</string>
     <string name="chord_library_reentrant_empty">Pada tuning re-entrant (G tinggi), senar C hampir selalu menjadi not terendah, sehingga sebagian besar voicing berada di posisi dasar. Coba pilih \"Semua\" untuk melihat voicing yang tersedia.</string>
+    <string name="chord_library_first_inv">Inv ke-1</string>
+    <string name="chord_library_second_inv">Inv ke-2</string>
+    <string name="chord_library_third_inv">Inv ke-3</string>
     <string name="chord_library_no_voicings">Tidak ada voicing ditemukan</string>
     <string name="chord_library_search_hint">Cari akor (mis., Cm7, C/E)</string>
     <string name="chord_library_search_clear">Hapus pencarian</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voce</string>
     <string name="chord_library_reentrant_limited">Questo accordo ha solo %d voci. L\'accordatura rientrante (Sol alto) limita i rivolti perché la corda di Do (Do4) è quasi sempre la nota più bassa. L\'accordatura con Sol basso consente maggiore varietà di rivolti.</string>
     <string name="chord_library_reentrant_empty">Con l\'accordatura rientrante (Sol alto), la corda di Do è quasi sempre la nota più bassa, quindi la maggior parte delle voci è in posizione fondamentale. Prova a selezionare \"Tutti\" per vedere le voci disponibili.</string>
+    <string name="chord_library_first_inv">1° Riv</string>
+    <string name="chord_library_second_inv">2° Riv</string>
+    <string name="chord_library_third_inv">3° Riv</string>
     <string name="chord_library_no_voicings">Nessuna voce trovata</string>
     <string name="chord_library_search_hint">Cerca accordo (es. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Cancella ricerca</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%dつのボイシング</string>
     <string name="chord_library_reentrant_limited">このコードには%dつのボイシングしかありません。リエントラントチューニング（High-G）では、C弦（C4）がほぼ常に最低音となるため、転回形が制限されます。Low-Gチューニングではより多くの転回バリエーションが可能です。</string>
     <string name="chord_library_reentrant_empty">リエントラントチューニング（High-G）ではC弦がほぼ常に最低音となるため、ほとんどのボイシングが基本形になります。利用可能なボイシングを表示するには「すべて」を選択してください。</string>
+    <string name="chord_library_first_inv">第1転回</string>
+    <string name="chord_library_second_inv">第2転回</string>
+    <string name="chord_library_third_inv">第3転回</string>
     <string name="chord_library_no_voicings">ボイシングが見つかりません</string>
     <string name="chord_library_search_hint">コード検索（例：Cm7, C/E）</string>
     <string name="chord_library_search_clear">検索をクリア</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">보이싱 %d개</string>
     <string name="chord_library_reentrant_limited">이 코드는 보이싱이 %d개뿐입니다. 리엔트런트 튜닝(High-G)에서는 C현(C4)이 거의 항상 가장 낮은 음이 되어 전위가 제한됩니다. Low-G 튜닝에서는 더 다양한 전위가 가능합니다.</string>
     <string name="chord_library_reentrant_empty">리엔트런트 튜닝(High-G)에서는 C현이 거의 항상 가장 낮은 음이므로 대부분의 보이싱이 기본형입니다. 사용 가능한 보이싱을 보려면 \"전체\"를 선택하세요.</string>
+    <string name="chord_library_first_inv">제1전위</string>
+    <string name="chord_library_second_inv">제2전위</string>
+    <string name="chord_library_third_inv">제3전위</string>
     <string name="chord_library_no_voicings">보이싱을 찾을 수 없습니다</string>
     <string name="chord_library_search_hint">코드 검색 (예: Cm7, C/E)</string>
     <string name="chord_library_search_clear">검색 지우기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">Dit akkoord heeft slechts %d voicings. Re-entrant stemming (hoge G) beperkt omkeringen omdat de C-snaar (C4) bijna altijd de laagste toon is. Lage G-stemming biedt meer variatie in omkeringen.</string>
     <string name="chord_library_reentrant_empty">Bij re-entrant stemming (hoge G) is de C-snaar bijna altijd de laagste noot, dus de meeste voicings staan in grondpositie. Probeer \"Alle\" te selecteren om beschikbare voicings te zien.</string>
+    <string name="chord_library_first_inv">1e Omk</string>
+    <string name="chord_library_second_inv">2e Omk</string>
+    <string name="chord_library_third_inv">3e Omk</string>
     <string name="chord_library_no_voicings">Geen voicings gevonden</string>
     <string name="chord_library_search_hint">Akkoord zoeken (bijv. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Zoekopdracht wissen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d prowadzenie głosów</string>
     <string name="chord_library_reentrant_limited">Ten akord ma tylko %d prowadzeń głosów. Strój re-entrant (wysokie G) ogranicza przewroty, ponieważ struna C (C4) jest prawie zawsze najniższym dźwiękiem. Strój z niskim G umożliwia większą różnorodność przewrotów.</string>
     <string name="chord_library_reentrant_empty">W stroju re-entrant (wysokie G) struna C jest prawie zawsze najniższą nutą, więc większość prowadzeń głosów jest w pozycji zasadniczej. Spróbuj wybrać \"Wszystkie\", aby zobaczyć dostępne prowadzenia głosów.</string>
+    <string name="chord_library_first_inv">1. przew.</string>
+    <string name="chord_library_second_inv">2. przew.</string>
+    <string name="chord_library_third_inv">3. przew.</string>
     <string name="chord_library_no_voicings">Nie znaleziono prowadzeń głosów</string>
     <string name="chord_library_search_hint">Szukaj akordu (np. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Wyczyść wyszukiwanie</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">Este acorde tem apenas %d voicings. A afinação reentrante (Sol agudo) limita as inversões porque a corda Dó (Dó4) é quase sempre o tom mais grave. A afinação Sol grave permite mais variedade de inversões.</string>
     <string name="chord_library_reentrant_empty">Na afinação reentrante (Sol agudo), a corda Dó é quase sempre a nota mais grave, então a maioria dos voicings está na posição fundamental. Tente selecionar \"Todos\" para ver os voicings disponíveis.</string>
+    <string name="chord_library_first_inv">1ª Inv</string>
+    <string name="chord_library_second_inv">2ª Inv</string>
+    <string name="chord_library_third_inv">3ª Inv</string>
     <string name="chord_library_no_voicings">Nenhum voicing encontrado</string>
     <string name="chord_library_search_hint">Pesquisar acorde (ex., Cm7, C/E)</string>
     <string name="chord_library_search_clear">Limpar pesquisa</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d вариант</string>
     <string name="chord_library_reentrant_limited">У этого аккорда всего %d вариантов. Реентрантный строй (High-G) ограничивает обращения, поскольку струна C (C4) почти всегда является самым низким звуком. Строй Low-G даёт больше вариантов обращений.</string>
     <string name="chord_library_reentrant_empty">При реентрантном строе (High-G) струна C почти всегда является самой низкой нотой, поэтому большинство вариантов — в основной позиции. Попробуйте выбрать «Все», чтобы увидеть доступные варианты.</string>
+    <string name="chord_library_first_inv">1-е обр.</string>
+    <string name="chord_library_second_inv">2-е обр.</string>
+    <string name="chord_library_third_inv">3-е обр.</string>
     <string name="chord_library_no_voicings">Варианты не найдены</string>
     <string name="chord_library_search_hint">Поиск аккорда (напр., Cm7, C/E)</string>
     <string name="chord_library_search_clear">Очистить поиск</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -133,6 +133,9 @@
     <string name="chord_library_voicing_singular">%d seslendirme</string>
     <string name="chord_library_reentrant_limited">Bu akorun yalnızca %d seslendirmesi var. Yeniden giriş akort (Yüksek G), C teli (C4) neredeyse her zaman en düşük perde olduğu için çevrimleri sınırlar. Düşük G akort daha fazla çevrim çeşitliliği sağlar.</string>
     <string name="chord_library_reentrant_empty">Yeniden giriş akordunda (Yüksek G), C teli neredeyse her zaman en düşük notadır, bu yüzden çoğu seslendirme kök pozisyondadır. Mevcut seslendirmeleri görmek için \"Tümü\" seçeneğini deneyin.</string>
+    <string name="chord_library_first_inv">1. Çevirme</string>
+    <string name="chord_library_second_inv">2. Çevirme</string>
+    <string name="chord_library_third_inv">3. Çevirme</string>
     <string name="chord_library_no_voicings">Seslendirme bulunamadı</string>
     <string name="chord_library_search_hint">Akor ara (ör. Cm7, C/E)</string>
     <string name="chord_library_search_clear">Aramayı temizle</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,9 @@
     <string name="chord_library_voicing_singular">%d voicing</string>
     <string name="chord_library_reentrant_limited">This chord only has %d voicings. Re-entrant tuning (High-G) limits inversions because the C string (C4) is almost always the lowest pitch. Low-G tuning allows more inversion variety.</string>
     <string name="chord_library_reentrant_empty">In re-entrant tuning (High-G), the C string is almost always the lowest note, so most voicings are root position. Try selecting \"All\" to see available voicings.</string>
+    <string name="chord_library_first_inv">1st Inv</string>
+    <string name="chord_library_second_inv">2nd Inv</string>
+    <string name="chord_library_third_inv">3rd Inv</string>
     <string name="chord_library_no_voicings">No voicings found</string>
     <string name="chord_library_search_hint">Search chord (e.g., Cm7, C/E)</string>
     <string name="chord_library_search_clear">Clear search</string>

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -12202,6 +12202,100 @@
         }
       }
     },
+    "cd_decrease_capo": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease capo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diminuer le capo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capo verringern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disminuir cejilla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diminuisci capo"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diminuir capo"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capo verlagen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уменьшить капо"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapoyu azalt"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmniejsz capo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カポを下げる"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카포 감소"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कैपो घटाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurangi capo"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تقليل الكابو"
+          }
+        }
+      }
+    },
     "cd_decrease_octave": {
       "localizations": {
         "en": {
@@ -13702,6 +13796,100 @@
         }
       }
     },
+    "cd_increase_capo": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase capo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Augmenter le capo"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capo erhöhen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar cejilla"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumenta capo"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aumentar capo"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capo verhogen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увеличить капо"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapoyu artır"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwiększ capo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カポを上げる"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "카포 증가"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कैपो बढ़ाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tambah capo"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "زيادة الكابو"
+          }
+        }
+      }
+    },
     "cd_increase_octave": {
       "localizations": {
         "en": {
@@ -14098,6 +14286,106 @@
           "stringUnit": {
             "state": "translated",
             "value": "上次检测到的音符，%@"
+          }
+        }
+      }
+    },
+    "cd_linear_mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linear mode, sequential note entry"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode linéaire, saisie séquentielle des notes"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linearer Modus, sequenzielle Noteneingabe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo lineal, entrada secuencial de notas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità lineare, inserimento sequenziale delle note"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo linear, entrada sequencial de notas"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lineaire modus, opeenvolgende nootinvoer"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Линейный режим, последовательный ввод нот"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doğrusal mod, sıralı nota girişi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryb liniowy, sekwencyjne wprowadzanie nut"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リニアモード、順次音符入力"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순차 모드, 순서대로 음표 입력"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रैखिक मोड, क्रमिक नोट प्रविष्टि"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode linear, input not berurutan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الوضع الخطي، إدخال متتابع للنوتات"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "线性模式，逐个输入音符"
           }
         }
       }
@@ -14598,6 +14886,100 @@
           "stringUnit": {
             "state": "translated",
             "value": "更多选项"
+          }
+        }
+      }
+    },
+    "cd_navigation_drawer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigation drawer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiroir de navigation"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigationsleiste"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cajón de navegación"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cassetto di navigazione"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gaveta de navegação"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Navigatielade"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель навигации"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gezinme çekmecesi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel nawigacji"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ナビゲーションドロワー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탐색 서랍"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नेविगेशन ड्रॉअर"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Laci navigasi"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "درج التنقل"
           }
         }
       }
@@ -17602,6 +17984,194 @@
         }
       }
     },
+    "cd_section_collapsed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapsed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réduit"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eingeklappt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contraído"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compresso"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recolhido"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingeklapt"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свёрнуто"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daraltıldı"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwinięte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "折りたたみ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "접힘"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "संकुचित"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diciutkan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مطوي"
+          }
+        }
+      }
+    },
+    "cd_section_expanded": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expanded"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Développé"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgeklappt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandido"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espanso"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expandido"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uitgevouwen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Развёрнуто"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genişletildi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozwinięte"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "펼침"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "विस्तारित"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diperluas"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "موسّع"
+          }
+        }
+      }
+    },
     "cd_settings": {
       "localizations": {
         "en": {
@@ -18398,6 +18968,406 @@
           "stringUnit": {
             "state": "translated",
             "value": "开始调音"
+          }
+        }
+      }
+    },
+    "cd_step_empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %lld: empty"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas %lld : vide"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schritt %lld: leer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso %lld: vacío"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo %lld: vuoto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo %lld: vazio"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stap %lld: leeg"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шаг %lld: пусто"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım %lld: boş"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krok %lld: pusty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップ %lld: 空"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 %lld: 비어 있음"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप %lld: खाली"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langkah %lld: kosong"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوة %lld: فارغة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %lld 步：空"
+          }
+        }
+      }
+    },
+    "cd_step_note": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step %1$lld: %2$@ %3$@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas %1$lld : %2$@ %3$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schritt %1$lld: %2$@ %3$@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paso %1$lld: %2$@ %3$@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo %1$lld: %2$@ %3$@"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Passo %1$lld: %2$@ %3$@"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stap %1$lld: %2$@ %3$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шаг %1$lld: %2$@ %3$@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım %1$lld: %2$@ %3$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krok %1$lld: %2$@ %3$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップ %1$lld: %2$@ %3$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 %1$lld: %2$@ %3$@"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप %1$lld: %2$@ %3$@"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langkah %1$lld: %2$@ %3$@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطوة %1$lld: %2$@ %3$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第 %1$lld 步：%2$@ %3$@"
+          }
+        }
+      }
+    },
+    "cd_step_sequencer_grid": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melody step sequencer, %lld steps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Séquenceur de mélodie, %lld pas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melodie-Step-Sequenzer, %lld Schritte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secuenciador de melodía, %lld pasos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenziatore melodia, %lld passi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenciador de melodia, %lld passos"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melodie-stappensequencer, %lld stappen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Секвенсор мелодии, %lld шагов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Melodi adım sıralayıcı, %lld adım"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekwencer melodii, %lld kroków"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メロディーステップシーケンサー、%lld ステップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "멜로디 스텝 시퀀서, %lld 스텝"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मेलोडी स्टेप सीक्वेंसर, %lld स्टेप"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step sequencer melodi, %lld langkah"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُتتابع خطوات اللحن، %lld خطوة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旋律步进音序器，%lld 步"
+          }
+        }
+      }
+    },
+    "cd_step_sequencer_mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step sequencer mode, grid-based entry"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode séquenceur, saisie en grille"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step-Sequenzer-Modus, rasterbasierte Eingabe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo secuenciador, entrada en cuadrícula"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modalità sequenziatore, inserimento a griglia"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modo sequenciador, entrada em grade"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stappensequencermodus, rasterinvoer"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Режим секвенсора, ввод по сетке"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım sıralayıcı modu, ızgara tabanlı giriş"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tryb sekwencera krokowego, wprowadzanie w siatce"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップシーケンサーモード、グリッド入力"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 시퀀서 모드, 격자 기반 입력"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप सीक्वेंसर मोड, ग्रिड-आधारित प्रविष्टि"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mode step sequencer, input berbasis grid"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وضع المُتتابع، إدخال شبكي"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "步进音序器模式，网格式输入"
           }
         }
       }
@@ -23002,6 +23972,106 @@
         }
       }
     },
+    "chord_library_first_inv": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1st Inv"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1er Renv"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Umk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1.ª Inv"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1° Riv"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1ª Inv"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1e Omk"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1-е обр."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Çevirme"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. przew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1転回"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제1전위"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "प्रथम व्युत्क्रम"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inv ke-1"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قلب ١"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第一转位"
+          }
+        }
+      }
+    },
     "chord_library_hide_filters": {
       "localizations": {
         "en": {
@@ -24002,6 +25072,106 @@
         }
       }
     },
+    "chord_library_second_inv": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2nd Inv"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2e Renv"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Umk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2.ª Inv"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2° Riv"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2ª Inv"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2e Omk"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2-е обр."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Çevirme"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. przew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2転回"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제2전위"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "द्वितीय व्युत्क्रम"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inv ke-2"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قلب ٢"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第二转位"
+          }
+        }
+      }
+    },
     "chord_library_show_filters": {
       "localizations": {
         "en": {
@@ -24098,6 +25268,106 @@
           "stringUnit": {
             "state": "translated",
             "value": "显示筛选"
+          }
+        }
+      }
+    },
+    "chord_library_third_inv": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3rd Inv"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3e Renv"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Umk."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3.ª Inv"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3° Riv"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3ª Inv"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3e Omk"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3-е обр."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Çevirme"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. przew."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第3転回"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제3전위"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "तृतीय व्युत्क्रम"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inv ke-3"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قلب ٣"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第三转位"
           }
         }
       }
@@ -48712,6 +49982,106 @@
         }
       }
     },
+    "melody_added_feedback": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Added %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ajouté"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ hinzugefügt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ añadido"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ aggiunto"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ adicionado"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ toegevoegd"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавлено: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ eklendi"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodano %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ を追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 추가됨"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ जोड़ा गया"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ditambahkan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تمت إضافة %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已添加 %@"
+          }
+        }
+      }
+    },
     "melody_added_note": {
       "localizations": {
         "en": {
@@ -49512,6 +50882,506 @@
         }
       }
     },
+    "melody_duration_eighth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "eighth"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "croche"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "achtel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "corchea"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "croma"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "colcheia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "achtste"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "восьмая"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sekizlik"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ósemka"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8分音符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8분음표"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आठवीं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "seperdelapan"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ثُمن"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "八分音符"
+          }
+        }
+      }
+    },
+    "melody_duration_half": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "half"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blanche"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "halb"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "blanca"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "minima"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mínima"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "half"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "половинная"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yarım"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "półnuta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2分音符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2분음표"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "आधी"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "setengah"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نصف"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "二分音符"
+          }
+        }
+      }
+    },
+    "melody_duration_quarter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "quarter"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "noire"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "viertel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "negra"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semiminima"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semínima"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kwart"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "четвертная"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dörtlük"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ćwierćnuta"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4分音符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4분음표"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "चौथाई"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "seperempat"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ربع"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "四分音符"
+          }
+        }
+      }
+    },
+    "melody_duration_sixteenth": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sixteenth"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "double croche"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sechzehntel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semicorchea"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semicroma"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semicolcheia"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zestiende"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "шестнадцатая"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "on altılık"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "szesnastka"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16分音符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16분음표"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सोलहवीं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "seperenam belas"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ذات السادس عشر"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "十六分音符"
+          }
+        }
+      }
+    },
+    "melody_duration_whole": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "whole"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ronde"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ganz"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "redonda"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semibreve"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "semibreve"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "heel"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "целая"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tam"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cała"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全音符"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "온음표"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "पूर्ण"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "penuh"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كاملة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全音符"
+          }
+        }
+      }
+    },
     "melody_eighth": {
       "localizations": {
         "en": {
@@ -50308,6 +52178,206 @@
           "stringUnit": {
             "state": "translated",
             "value": "暂无已保存的旋律"
+          }
+        }
+      }
+    },
+    "melody_mode_linear": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linear"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linéaire"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linear"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lineal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lineare"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linear"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lineair"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Линейный"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doğrusal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liniowy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リニア"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순차"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "रैखिक"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Linear"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خطي"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "线性"
+          }
+        }
+      }
+    },
+    "melody_mode_step_sequencer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step Sequencer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Séquenceur"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step-Sequenzer"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secuenciador"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenziatore"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenciador"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stappensequencer"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Секвенсор"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım Sıralayıcı"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekwencer krokowy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップシーケンサー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 시퀀서"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप सीक्वेंसर"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step Sequencer"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُتتابع خطوات"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "步进音序器"
           }
         }
       }
@@ -52108,6 +54178,306 @@
           "stringUnit": {
             "state": "translated",
             "value": "开始录音"
+          }
+        }
+      }
+    },
+    "melody_step_sequencer_title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step Sequencer (%lld steps)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Séquenceur (%lld pas)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step-Sequenzer (%lld Schritte)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Secuenciador (%lld pasos)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenziatore (%lld passi)"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sequenciador (%lld passos)"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stappensequencer (%lld stappen)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Секвенсор (%lld шагов)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım Sıralayıcı (%lld adım)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sekwencer krokowy (%lld kroków)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップシーケンサー（%lld ステップ）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 시퀀서 (%lld 스텝)"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप सीक्वेंसर (%lld स्टेप)"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step Sequencer (%lld langkah)"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُتتابع خطوات (%lld خطوة)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "步进音序器（%lld 步）"
+          }
+        }
+      }
+    },
+    "melody_steps_16": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 steps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 pas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 Schritte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 pasos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 passi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 passos"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 stappen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 шагов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 adım"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 kroków"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 ステップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 스텝"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 स्टेप"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 langkah"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 خطوة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "16 步"
+          }
+        }
+      }
+    },
+    "melody_steps_8": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 steps"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 pas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 Schritte"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 pasos"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 passi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 passos"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 stappen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 шагов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 adım"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 kroków"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 ステップ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 스텝"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 स्टेप"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 langkah"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 خطوات"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "8 步"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Replaced hardcoded English strings "1st Inv", "2nd Inv", "3rd Inv" in `ChordSelectors.kt` with `stringResource()` calls
- Added `chord_library_first_inv`, `chord_library_second_inv`, `chord_library_third_inv` to all 16 locale `strings.xml` files
- Regenerated iOS `Localizable.xcstrings` from Android sources

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [x] No MissingTranslation lint errors
- [ ] Switch device language to non-English → inversion chips show translated text

Fixes #363

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chord inversion labels now display in your preferred language. Added translations for first, second, and third inversion labels in 15+ languages including Arabic, Chinese, German, Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Russian, and Turkish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->