### PR TITLE
Fix: add stable keys to LazyColumn/LazyRow items to reduce recompositions

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordSearchBar.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordSearchBar.kt
@@ -96,7 +96,7 @@ internal fun ChordSearchBar(
                         LazyColumn(
                             modifier = Modifier.heightIn(max = 480.dp),
                         ) {
-                            items(results) { result ->
+                            items(results, key = { "${it.rootPitchClass}_${it.formula.symbol}" }) { result ->
                                 ChordSuggestionRow(
                                     result = result,
                                     onClick = { onResultSelected(result) },

--- a/app/src/main/java/com/baijum/ukufretboard/ui/InversionCompareView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/InversionCompareView.kt
@@ -137,7 +137,7 @@ internal fun InversionCompareView(
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    items(voicings) { voicing ->
+                    items(voicings, key = { it.frets.joinToString(",") }) { voicing ->
                         val bassIndex = ChordInfo.findBassStringIndex(voicing.frets, tuning)
                         VerticalChordDiagram(
                             voicing = voicing,

--- a/app/src/main/java/com/baijum/ukufretboard/ui/VoicingGrid.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/VoicingGrid.kt
@@ -69,7 +69,7 @@ internal fun VoicingGrid(
         ) {
             val chordName = Notes.pitchClassToName(rootPitchClass) + (formula?.symbol ?: "")
 
-            items(voicings) { voicing ->
+            items(voicings, key = { it.frets.joinToString(",") }) { voicing ->
                 val inversionLabel = formula?.let {
                     ChordInfo.determineInversion(voicing.frets, rootPitchClass, it, tuning).localizedLabel()
                 }


### PR DESCRIPTION
## Summary
- Added stable `key` parameters to `items()` calls in lazy lists/grids that were missing them
- `ChordSearchBar`: key by `rootPitchClass_formula.symbol`
- `InversionCompareView` and `VoicingGrid`: key by fret pattern string

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [ ] Chord library search, inversion compare, and voicing grid still render correctly

Fixes #364

Made with [Cursor](https://cursor.com)