### PR TITLE
Fix: fretPositionsForNote now returns all octave positions, not just lowest

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
@@ -51,11 +51,14 @@ internal fun fretPositionsForNote(
     pitchClass: Int,
     tuning: List<UkuleleString>,
     maxFret: Int = 12,
-): Map<Int, Int> {
+): Map<Int, List<Int>> {
     return tuning.mapIndexedNotNull { stringIndex, string ->
-        val fret = (pitchClass - string.openPitchClass + Notes.PITCH_CLASS_COUNT) %
+        val base = (pitchClass - string.openPitchClass + Notes.PITCH_CLASS_COUNT) %
             Notes.PITCH_CLASS_COUNT
-        if (fret <= maxFret) stringIndex to fret else null
+        val frets = generateSequence(base) { it + Notes.PITCH_CLASS_COUNT }
+            .takeWhile { it <= maxFret }
+            .toList()
+        if (frets.isNotEmpty()) stringIndex to frets else null
     }.toMap()
 }
 
@@ -324,12 +327,13 @@ internal fun PlayAlongContent(
             val currentPc = state.playAlongNotes[state.currentNoteIndex]
             val allPositions = fretPositionsForNote(currentPc, tuning, maxFret = lastFret)
             val filtered = if (posRange != null) {
-                allPositions.filter { (_, fret) -> fret in posRange }
+                allPositions.mapValues { (_, frets) -> frets.filter { it in posRange } }
+                    .filterValues { it.isNotEmpty() }
             } else {
                 allPositions
             }
             val effective = filtered.ifEmpty { allPositions }
-            effective.mapValues { (_, fret) -> fret }
+            effective.mapValues { (_, frets) -> frets.first() }
         } else {
             tuning.indices.associateWith { null }
         }


### PR DESCRIPTION
## Summary
- `fretPositionsForNote()` now returns `Map<Int, List<Int>>` (all valid fret positions per string) instead of just the lowest modulo-12 fret
- The caller filters by the active position range and picks the best match within range
- Fixes the scenario where selecting "9th-12th" position would fail to find fret 12 (since only fret 0 was computed) and fall back to showing all positions

## Test plan
- [x] Build succeeds (`assembleDebug`)
- [x] Unit tests pass (`testDebugUnitTest`)
- [ ] Manual: Scale Practice → Play Along → enable Fretboard, select position "9th-12th" → play C Major → note C highlights fret 12 on string 3

Fixes #365

Made with [Cursor](https://cursor.com)