### PR TITLE
Fix: handle PDF write failures in iOS song export

### DIFF
--- a/iosApp/UkuleleCompanion/Views/SongViewerView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongViewerView.swift
@@ -313,7 +313,12 @@ struct SongViewerView: View {
 
         let sanitized = title.replacingOccurrences(of: "[^a-zA-Z0-9._-]", with: "_", options: .regularExpression)
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(sanitized).pdf")
-        try? data.write(to: url)
+        do {
+            try data.write(to: url)
+        } catch {
+            AccessibilityAnnouncer.shared.announce("Failed to create PDF")
+            return
+        }
 
         let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,


### PR DESCRIPTION
## Summary
- Replace `try?` with `do-catch` in `SongViewerView.sharePdf()` so write failures surface an accessibility announcement ("Failed to create PDF") and abort before presenting the share sheet with an invalid URL.
- Follows the existing error-handling pattern used in `SettingsView.swift` backup export.

## Test plan
- [ ] Trigger PDF export on a song — verify share sheet appears normally
- [ ] Simulate write failure (e.g. read-only temp dir) — verify share sheet does NOT appear and VoiceOver announces "Failed to create PDF"

Fixes #376

Made with [Cursor](https://cursor.com)