### PR TITLE
Fix: add chord name to Play button accessibility label in song viewer

### DIFF
--- a/iosApp/UkuleleCompanion/Views/SongViewerView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongViewerView.swift
@@ -856,6 +856,7 @@ struct SongViewerView: View {
                             .font(.caption)
                     }
                     .buttonStyle(.bordered)
+                    .accessibilityLabel("Play \(chord)")
                 } else {
                     Text("No voicing found")
                         .font(.caption)


### PR DESCRIPTION
## Summary
- Add `.accessibilityLabel("Play \(chord)")` to the Play button in the chord popover of `SongViewerView.swift`, so VoiceOver announces which chord will be played (e.g. "Play Am" instead of just "Play").
- Follows the existing pattern in `FavoritesView.swift` and `VoiceLeadingView.swift`.

## Test plan
- [ ] Open a song in Songbook, tap a chord to open the popover
- [ ] With VoiceOver enabled, navigate to the Play button — verify it announces "Play <chord name>"

Fixes #377

Made with [Cursor](https://cursor.com)