### PR TITLE
Fix: validate bracket content as real chords before transposing

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordParser.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordParser.kt
@@ -1,23 +1,36 @@
 package com.baijum.ukufretboard.data
 
+import com.baijum.ukufretboard.domain.ChordNameParser
+
 /**
  * Parses chord names from text containing `[ChordName]` markers.
  *
- * Uses the same permissive regex as [com.baijum.ukufretboard.domain.ChordSheetTranspose]
- * to ensure consistent chord recognition across parsing and transposition.
+ * Uses [ChordNameParser.parse] to validate that bracket contents are
+ * real chords, so section labels like `[Coda]`, `[Fine]`, `[Ending]`
+ * are never mistaken for chord markers.
+ *
  * Accepts any content after the root note (A-G with optional # or b),
  * supporting all chord qualities including slash chords (e.g., `[C/G]`).
- *
- * Section labels like `[Chorus]`, `[Bridge]`, `[Intro]` are excluded via a
- * negative lookahead so they are not mistakenly treated as chord markers.
  */
 object ChordParser {
 
-    /** Known section label names that must not be matched as chords. */
-    val SECTION_NAMES = "Chorus|Verse|Bridge|Intro|Outro|Tab|Interlude"
+    /** Regex matching potential `[ChordName]` markers — root note + any suffix. */
+    private val BRACKET_PATTERN = Regex("""\[([A-G][#b]?[^]]*)]""")
 
-    /** Regex matching `[ChordName]` markers — root note + any quality suffix. */
-    val CHORD_PATTERN = Regex("""\[(?!(?:$SECTION_NAMES)\b)([A-G][#b]?[^]]*)]""")
+    /**
+     * Returns true if the bracket content parses as a valid chord.
+     * For slash chords, only the part before the slash is validated
+     * (preserving unknown bass notes like `[C/X]`).
+     */
+    private fun isValidChord(bracketContent: String): Boolean {
+        val slashIdx = bracketContent.indexOf('/')
+        val toValidate = if (slashIdx >= 0) {
+            bracketContent.substring(0, slashIdx)
+        } else {
+            bracketContent
+        }
+        return ChordNameParser.parse(toValidate) != null
+    }
 
     /**
      * Extracts all unique chord names from the given text.
@@ -26,8 +39,9 @@ object ChordParser {
      * @return A list of unique chord name strings found in order.
      */
     fun extractChords(text: String): List<String> =
-        CHORD_PATTERN.findAll(text)
+        BRACKET_PATTERN.findAll(text)
             .map { it.groupValues[1] }
+            .filter { isValidChord(it) }
             .distinct()
             .toList()
 
@@ -41,17 +55,17 @@ object ChordParser {
         val segments = mutableListOf<TextSegment>()
         var lastEnd = 0
 
-        CHORD_PATTERN.findAll(line).forEach { match ->
-            // Add text before the chord
-            if (match.range.first > lastEnd) {
-                segments.add(TextSegment.PlainText(line.substring(lastEnd, match.range.first)))
+        BRACKET_PATTERN.findAll(line).forEach { match ->
+            val content = match.groupValues[1]
+            if (isValidChord(content)) {
+                if (match.range.first > lastEnd) {
+                    segments.add(TextSegment.PlainText(line.substring(lastEnd, match.range.first)))
+                }
+                segments.add(TextSegment.Chord(content))
+                lastEnd = match.range.last + 1
             }
-            // Add the chord
-            segments.add(TextSegment.Chord(match.groupValues[1]))
-            lastEnd = match.range.last + 1
         }
 
-        // Add remaining text
         if (lastEnd < line.length) {
             segments.add(TextSegment.PlainText(line.substring(lastEnd)))
         }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetTranspose.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetTranspose.kt
@@ -1,6 +1,5 @@
 package com.baijum.ukufretboard.domain
 
-import com.baijum.ukufretboard.data.ChordParser
 import com.baijum.ukufretboard.data.Notes
 
 /**
@@ -9,11 +8,14 @@ import com.baijum.ukufretboard.data.Notes
  * Parses inline `[ChordName]` markers from chord sheet content,
  * transposes each chord root and slash-chord bass note by the given
  * number of semitones, and preserves the chord quality suffix.
+ *
+ * Section labels like `[Coda]`, `[Fine]`, `[Ending]` are left intact
+ * because their content does not parse as a valid chord via [ChordNameParser].
  */
 object ChordSheetTranspose {
 
     /** Regex matching `[ChordName]` markers, capturing root and quality separately. */
-    private val CHORD_MARKER = Regex("""\[(?!(?:${ChordParser.SECTION_NAMES})\b)([A-G][#b]?)([^]]*)]""")
+    private val CHORD_MARKER = Regex("""\[([A-G][#b]?)([^]]*)]""")
 
     /** Bass note at the start of the post-slash segment, e.g. "/G" or "m7/G". */
     private val BASS_NOTE = Regex("""^([A-G][#b]?)""")
@@ -22,6 +24,8 @@ object ChordSheetTranspose {
      * Transposes all `[Chord]` markers in the given content by [semitones].
      *
      * Root and slash-chord bass notes are transposed; quality suffixes are preserved.
+     * Bracket tokens that do not parse as valid chords (e.g. `[Coda]`, `[Fine]`)
+     * are left unchanged.
      *
      * @param content The raw chord sheet content with `[ChordName]` markers.
      * @param semitones Number of semitones to transpose (positive = up, negative = down).
@@ -34,6 +38,17 @@ object ChordSheetTranspose {
             val rootStr = match.groupValues[1]
             var qualitySuffix = match.groupValues[2]
 
+            val slashIdx = qualitySuffix.indexOf('/')
+            val qualityBeforeSlash = if (slashIdx >= 0) {
+                qualitySuffix.substring(0, slashIdx)
+            } else {
+                qualitySuffix
+            }
+
+            if (ChordNameParser.parse(rootStr + qualityBeforeSlash) == null) {
+                return@replace match.value
+            }
+
             val rootPc = parseNoteToPitchClass(rootStr)
                 ?: return@replace match.value
 
@@ -41,7 +56,6 @@ object ChordSheetTranspose {
                 Transpose.transposePitchClass(rootPc, semitones),
             )
 
-            val slashIdx = qualitySuffix.indexOf('/')
             if (slashIdx >= 0) {
                 val afterSlash = qualitySuffix.substring(slashIdx + 1)
                 val bassMatch = BASS_NOTE.matchAt(afterSlash, 0)

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordParserTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordParserTest.kt
@@ -58,6 +58,42 @@ class ChordParserTest {
     }
 
     @Test
+    fun codaNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Coda]")
+        assertTrue(chords.isEmpty(), "Coda should not be a chord: $chords")
+    }
+
+    @Test
+    fun endingNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Ending]")
+        assertTrue(chords.isEmpty(), "Ending should not be a chord: $chords")
+    }
+
+    @Test
+    fun breakNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Break]")
+        assertTrue(chords.isEmpty(), "Break should not be a chord: $chords")
+    }
+
+    @Test
+    fun fineNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Fine]")
+        assertTrue(chords.isEmpty(), "Fine should not be a chord: $chords")
+    }
+
+    @Test
+    fun bassLabelNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Bass]")
+        assertTrue(chords.isEmpty(), "Bass should not be a chord: $chords")
+    }
+
+    @Test
+    fun guitarSoloNotMatchedAsChord() {
+        val chords = ChordParser.extractChords("[Guitar Solo]")
+        assertTrue(chords.isEmpty(), "Guitar Solo should not be a chord: $chords")
+    }
+
+    @Test
     fun chorusMixedWithChordsOnlyExtractsChords() {
         val chords = ChordParser.extractChords("[Chorus]\n[C]Hello [G]World")
         assertEquals(listOf("C", "G"), chords)

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetTransposePropertyTest.kt
@@ -164,6 +164,48 @@ class ChordSheetTransposePropertyTest {
     }
 
     @Test
+    fun codaUntouchedByTranspose() {
+        assertEquals("[Coda]", ChordSheetTranspose.transpose("[Coda]", 2))
+    }
+
+    @Test
+    fun endingUntouchedByTranspose() {
+        assertEquals("[Ending]", ChordSheetTranspose.transpose("[Ending]", 2))
+    }
+
+    @Test
+    fun breakUntouchedByTranspose() {
+        assertEquals("[Break]", ChordSheetTranspose.transpose("[Break]", 2))
+    }
+
+    @Test
+    fun fineUntouchedByTranspose() {
+        assertEquals("[Fine]", ChordSheetTranspose.transpose("[Fine]", 1))
+    }
+
+    @Test
+    fun bassLabelUntouchedByTranspose() {
+        assertEquals("[Bass]", ChordSheetTranspose.transpose("[Bass]", 2))
+    }
+
+    @Test
+    fun drumSoloUntouchedByTranspose() {
+        assertEquals("[Drum Solo]", ChordSheetTranspose.transpose("[Drum Solo]", 2))
+    }
+
+    @Test
+    fun guitarSoloUntouchedByTranspose() {
+        assertEquals("[Guitar Solo]", ChordSheetTranspose.transpose("[Guitar Solo]", 2))
+    }
+
+    @Test
+    fun sectionLabelsMixedWithChords() {
+        val input = "[Verse]\n[C]Twinkle [G]twinkle\n\n[Coda]\n[F]How I [C]wonder"
+        val result = ChordSheetTranspose.transpose(input, 2)
+        assertEquals("[Verse]\n[D]Twinkle [A]twinkle\n\n[Coda]\n[G]How I [D]wonder", result)
+    }
+
+    @Test
     fun unknownBassPreservedOnTranspose() {
         assertEquals("[D/X]", ChordSheetTranspose.transpose("[C/X]", 2))
     }


### PR DESCRIPTION
## Summary
- Replace the incomplete `SECTION_NAMES` denylist in `ChordParser` and `ChordSheetTranspose` with parse-based validation using `ChordNameParser.parse()`.
- Bracket tokens whose content does not parse as a valid chord (e.g. `[Coda]`, `[Ending]`, `[Fine]`, `[Break]`, `[Bass]`, `[Guitar Solo]`) are now left intact during transposition and chord extraction.
- This prevents corruption like `[Coda]` → `[Doda]` when transposing +2 semitones.
- Added comprehensive tests for section labels that start with note letters A–G.

## Technical approach
Instead of maintaining a hand-maintained denylist of section names (which is inherently incomplete), the code now validates each bracket match by passing `root + quality` (the part before any `/`) through `ChordNameParser.parse()`. If parsing fails (i.e., the quality suffix doesn't match any known chord formula), the bracket content is treated as a section label and left unchanged.

## Test plan
- [ ] Existing tests pass (shared module tests, Android unit tests)
- [ ] New tests verify: `[Coda]`, `[Ending]`, `[Break]`, `[Fine]`, `[Bass]`, `[Drum Solo]`, `[Guitar Solo]` are untouched by transpose
- [ ] Real chords (`[C]`, `[Am7]`, `[D/F#]`) still transpose correctly
- [ ] Slash chords with unknown bass (`[C/X]`) still preserve the bass note

Fixes #378

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of chord recognition to prevent section labels (such as [Coda], [Ending], [Break], [Fine], [Bass], and [Guitar Solo]) from being misidentified as chords.

* **Tests**
  * Added test coverage to verify section labels and markers remain unaffected during transposition operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->