### PR TITLE
Add: persistent chord diagram rail in Songbook viewer

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/DisplaySection.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/DisplaySection.kt
@@ -149,6 +149,14 @@ internal fun DisplaySection(
             )
         }
     }
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    SettingsSwitch(
+        label = stringResource(R.string.settings_show_chord_diagram_rail),
+        checked = settings.showChordDiagramRail,
+        onCheckedChange = { onSettingsChange(settings.copy(showChordDiagramRail = it)) },
+    )
 }
 
 private val SUPPORTED_LANGUAGES = linkedMapOf(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
@@ -619,6 +619,7 @@ fun FretboardScreen(
                             leftHanded = appSettings.fretboard.leftHanded,
                             chordDisplayStyle = appSettings.display.chordDisplayStyle,
                             chordColor = appSettings.display.chordColor,
+                            showChordDiagramRail = appSettings.display.showChordDiagramRail,
                         )
                     }
                     NAV_SETLISTS -> ConstrainedWidthContent(isCompactWidth) {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
@@ -4,11 +4,13 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -121,6 +123,7 @@ internal fun SheetViewer(
     onApplyTranspose: (Int) -> Unit,
     chordDisplayStyle: ChordDisplayStyle = ChordDisplayStyle.ABOVE,
     chordColor: ChordColorOption = ChordColorOption.THEME,
+    showChordDiagramRail: Boolean = true,
 ) {
     val context = LocalContext.current
     val view = LocalView.current
@@ -425,6 +428,42 @@ internal fun SheetViewer(
         }
 
         val sectionLineIndices = remember(sections) { sections.map { it.lineIndex }.toSet() }
+
+        if (showChordDiagramRail) {
+            val uniqueChords = remember(displayContent) {
+                ChordParser.extractChords(displayContent)
+            }
+            val chordVoicings = remember(uniqueChords, tuning) {
+                uniqueChords.mapNotNull { name ->
+                    val parsed = ChordNameParser.parse(name) ?: return@mapNotNull null
+                    if (tuning.isEmpty()) return@mapNotNull null
+                    val voicing = VoicingGenerator.generate(
+                        parsed.rootPitchClass, parsed.formula, tuning,
+                    ).firstOrNull() ?: return@mapNotNull null
+                    name to voicing
+                }
+            }
+            if (chordVoicings.isNotEmpty()) {
+                LazyRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                ) {
+                    items(chordVoicings.size, key = { chordVoicings[it].first }) { idx ->
+                        val (name, voicing) = chordVoicings[idx]
+                        VerticalChordDiagram(
+                            voicing = voicing,
+                            onClick = { tappedChord = name },
+                            chordName = name,
+                            leftHanded = leftHanded,
+                        )
+                    }
+                }
+                HorizontalDivider()
+            }
+        }
 
         Box(modifier = Modifier.weight(1f)) {
             Column(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SongbookTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SongbookTab.kt
@@ -93,6 +93,7 @@ fun SongbookTab(
     leftHanded: Boolean = false,
     chordDisplayStyle: ChordDisplayStyle = ChordDisplayStyle.ABOVE,
     chordColor: ChordColorOption = ChordColorOption.THEME,
+    showChordDiagramRail: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     val sheets by viewModel.sheets.collectAsState()
@@ -143,6 +144,7 @@ fun SongbookTab(
                 onApplyTranspose = { viewModel.applyTranspose(it) },
                 chordDisplayStyle = chordDisplayStyle,
                 chordColor = chordColor,
+                showChordDiagramRail = showChordDiagramRail,
             )
         }
         else -> {

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
@@ -164,6 +164,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             .putBoolean(KEY_SHOW_REFERENCE_SECTION, s.display.showReferenceSection)
             .putString(KEY_CHORD_DISPLAY_STYLE, s.display.chordDisplayStyle.name)
             .putString(KEY_CHORD_COLOR, s.display.chordColor.name)
+            .putBoolean(KEY_SHOW_CHORD_DIAGRAM_RAIL, s.display.showChordDiagramRail)
             // Tuning
             .putString(KEY_TUNING, s.tuning.tuning.name)
             // Fretboard
@@ -226,6 +227,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 } catch (_: Exception) {
                     ChordColorOption.THEME
                 },
+                showChordDiagramRail = prefs.getBoolean(KEY_SHOW_CHORD_DIAGRAM_RAIL, true),
             ),
             tuning = TuningSettings(
                 tuning = try {
@@ -302,5 +304,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         private const val KEY_SHOW_REFERENCE_SECTION = "show_reference_section"
         private const val KEY_CHORD_DISPLAY_STYLE = "chord_display_style"
         private const val KEY_CHORD_COLOR = "chord_color"
+        private const val KEY_SHOW_CHORD_DIAGRAM_RAIL = "show_chord_diagram_rail"
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -941,6 +941,7 @@
     <string name="settings_show_reference_section">إظهار قسم المرجع</string>
     <string name="settings_chord_display_style">عرض التوافقية</string>
     <string name="settings_chord_color">لون التوافقية</string>
+    <string name="settings_show_chord_diagram_rail">إظهار مخططات التوافقية</string>
     <string name="cd_collapse_section">طي %s</string>
     <string name="cd_expand_section">توسيع %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -936,6 +936,7 @@
     <string name="settings_show_reference_section">显示参考部分</string>
     <string name="settings_chord_display_style">和弦显示</string>
     <string name="settings_chord_color">和弦颜色</string>
+    <string name="settings_show_chord_diagram_rail">显示和弦图</string>
     <string name="cd_collapse_section">折叠%s</string>
     <string name="cd_expand_section">展开%s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -937,6 +937,7 @@
     <string name="settings_show_reference_section">Bereich Nachschlagewerk anzeigen</string>
     <string name="settings_chord_display_style">Akkord-Anzeige</string>
     <string name="settings_chord_color">Akkord-Farbe</string>
+    <string name="settings_show_chord_diagram_rail">Akkorddiagramme anzeigen</string>
     <string name="cd_collapse_section">%s einklappen</string>
     <string name="cd_expand_section">%s ausklappen</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -933,6 +933,7 @@
     <string name="settings_show_reference_section">Mostrar sección Referencia</string>
     <string name="settings_chord_display_style">Mostrar acordes</string>
     <string name="settings_chord_color">Color de acordes</string>
+    <string name="settings_show_chord_diagram_rail">Mostrar diagramas de acordes</string>
     <string name="cd_collapse_section">Contraer %s</string>
     <string name="cd_expand_section">Expandir %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -933,6 +933,7 @@
     <string name="settings_show_reference_section">Afficher la section Référence</string>
     <string name="settings_chord_display_style">Affichage des accords</string>
     <string name="settings_chord_color">Couleur des accords</string>
+    <string name="settings_show_chord_diagram_rail">Afficher les diagrammes d\'accords</string>
     <string name="cd_collapse_section">Réduire %s</string>
     <string name="cd_expand_section">Développer %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -937,6 +937,7 @@
     <string name="settings_show_reference_section">संदर्भ अनुभाग दिखाएं</string>
     <string name="settings_chord_display_style">कॉर्ड प्रदर्शन</string>
     <string name="settings_chord_color">कॉर्ड रंग</string>
+    <string name="settings_show_chord_diagram_rail">कॉर्ड आरेख दिखाएँ</string>
     <string name="cd_collapse_section">%s संकुचित करें</string>
     <string name="cd_expand_section">%s विस्तारित करें</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -934,6 +934,7 @@
     <string name="settings_show_reference_section">Tampilkan bagian Referensi</string>
     <string name="settings_chord_display_style">Tampilan akor</string>
     <string name="settings_chord_color">Warna akor</string>
+    <string name="settings_show_chord_diagram_rail">Tampilkan diagram akor</string>
     <string name="cd_collapse_section">Ciutkan %s</string>
     <string name="cd_expand_section">Perluas %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -935,6 +935,7 @@
     <string name="settings_show_reference_section">Mostra sezione Riferimento</string>
     <string name="settings_chord_display_style">Visualizzazione accordi</string>
     <string name="settings_chord_color">Colore accordi</string>
+    <string name="settings_show_chord_diagram_rail">Mostra diagrammi accordi</string>
     <string name="cd_collapse_section">Comprimi %s</string>
     <string name="cd_expand_section">Espandi %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -936,6 +936,7 @@
     <string name="settings_show_reference_section">リファレンスセクションを表示</string>
     <string name="settings_chord_display_style">コード表示</string>
     <string name="settings_chord_color">コードの色</string>
+    <string name="settings_show_chord_diagram_rail">コード図を表示</string>
     <string name="cd_collapse_section">%sを折りたたむ</string>
     <string name="cd_expand_section">%sを展開</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -936,6 +936,7 @@
     <string name="settings_show_reference_section">참고 섹션 표시</string>
     <string name="settings_chord_display_style">코드 표시</string>
     <string name="settings_chord_color">코드 색상</string>
+    <string name="settings_show_chord_diagram_rail">코드 다이어그램 표시</string>
     <string name="cd_collapse_section">%s 접기</string>
     <string name="cd_expand_section">%s 펼치기</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -935,6 +935,7 @@
     <string name="settings_show_reference_section">Sectie Naslagwerk tonen</string>
     <string name="settings_chord_display_style">Akkoordweergave</string>
     <string name="settings_chord_color">Akkoordkleur</string>
+    <string name="settings_show_chord_diagram_rail">Akkoorddiagrammen tonen</string>
     <string name="cd_collapse_section">%s inklappen</string>
     <string name="cd_expand_section">%s uitklappen</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -937,6 +937,7 @@
     <string name="settings_show_reference_section">Pokaż sekcję Materiały</string>
     <string name="settings_chord_display_style">Wyświetlanie akordów</string>
     <string name="settings_chord_color">Kolor akordów</string>
+    <string name="settings_show_chord_diagram_rail">Pokaż diagramy akordów</string>
     <string name="cd_collapse_section">Zwiń %s</string>
     <string name="cd_expand_section">Rozwiń %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -933,6 +933,7 @@
     <string name="settings_show_reference_section">Mostrar secção Referência</string>
     <string name="settings_chord_display_style">Exibição de acordes</string>
     <string name="settings_chord_color">Cor dos acordes</string>
+    <string name="settings_show_chord_diagram_rail">Mostrar diagramas de acordes</string>
     <string name="cd_collapse_section">Recolher %s</string>
     <string name="cd_expand_section">Expandir %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -939,6 +939,7 @@
     <string name="settings_show_reference_section">Показать раздел Справочник</string>
     <string name="settings_chord_display_style">Отображение аккордов</string>
     <string name="settings_chord_color">Цвет аккордов</string>
+    <string name="settings_show_chord_diagram_rail">Показать диаграммы аккордов</string>
     <string name="cd_collapse_section">Свернуть %s</string>
     <string name="cd_expand_section">Развернуть %s</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -935,6 +935,7 @@
     <string name="settings_show_reference_section">Başvuru bölümünü göster</string>
     <string name="settings_chord_display_style">Akor gösterimi</string>
     <string name="settings_chord_color">Akor rengi</string>
+    <string name="settings_show_chord_diagram_rail">Akor diyagramlarını göster</string>
     <string name="cd_collapse_section">%s daralt</string>
     <string name="cd_expand_section">%s genişlet</string>
     <string name="metronome_bpm">BPM</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -410,6 +410,7 @@
     <string name="settings_show_reference_section">Show Reference section</string>
     <string name="settings_chord_display_style">Chord display</string>
     <string name="settings_chord_color">Chord color</string>
+    <string name="settings_show_chord_diagram_rail">Show chord diagrams</string>
     <string name="cd_collapse_section">Collapse %s</string>
     <string name="cd_expand_section">Expand %s</string>
     <string name="settings_language">Language</string>

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -86492,6 +86492,106 @@
         }
       }
     },
+    "settings_show_chord_diagram_rail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show chord diagrams"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les diagrammes d'accords"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akkorddiagramme anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar diagramas de acordes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra diagrammi accordi"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar diagramas de acordes"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akkoorddiagrammen tonen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать диаграммы аккордов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Akor diyagramlarını göster"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż diagramy akordów"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コード図を表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "코드 다이어그램 표시"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "कॉर्ड आरेख दिखाएँ"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tampilkan diagram akor"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار مخططات التوافقية"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示和弦图"
+          }
+        }
+      }
+    },
     "settings_show_explorer_tips": {
       "localizations": {
         "en": {

--- a/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
@@ -29,7 +29,8 @@ final class SettingsRepository {
             appLanguage: defaults.string(forKey: "app_language") ?? "system",
             onboardingCompleted: defaults.bool(forKey: "onboarding_completed"),
             chordDisplayStyle: defaults.string(forKey: "chord_display_style") ?? "above",
-            chordColor: defaults.string(forKey: "chord_color") ?? "theme"
+            chordColor: defaults.string(forKey: "chord_color") ?? "theme",
+            showChordDiagramRail: defaults.object(forKey: "show_chord_diagram_rail") as? Bool ?? true
         )
     }
 
@@ -59,6 +60,7 @@ final class SettingsRepository {
         defaults.set(data.onboardingCompleted, forKey: "onboarding_completed")
         defaults.set(data.chordDisplayStyle, forKey: "chord_display_style")
         defaults.set(data.chordColor, forKey: "chord_color")
+        defaults.set(data.showChordDiagramRail, forKey: "show_chord_diagram_rail")
     }
 
     func exportSettings() -> [String: Any] {
@@ -88,6 +90,7 @@ final class SettingsRepository {
             "onboarding_completed": defaults.bool(forKey: "onboarding_completed"),
             "chord_display_style": defaults.string(forKey: "chord_display_style") ?? "above",
             "chord_color": defaults.string(forKey: "chord_color") ?? "theme",
+            "show_chord_diagram_rail": defaults.object(forKey: "show_chord_diagram_rail") as? Bool ?? true,
         ]
     }
 
@@ -117,6 +120,7 @@ final class SettingsRepository {
         if let v = dict["onboarding_completed"] as? Bool { defaults.set(v, forKey: "onboarding_completed") }
         if let v = dict["chord_display_style"] as? String { defaults.set(v, forKey: "chord_display_style") }
         if let v = dict["chord_color"] as? String { defaults.set(v, forKey: "chord_color") }
+        if let v = dict["show_chord_diagram_rail"] as? Bool { defaults.set(v, forKey: "show_chord_diagram_rail") }
     }
 }
 
@@ -146,4 +150,5 @@ struct SettingsData {
     var onboardingCompleted: Bool
     var chordDisplayStyle: String
     var chordColor: String
+    var showChordDiagramRail: Bool
 }

--- a/iosApp/UkuleleCompanion/ViewModels/SettingsViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/SettingsViewModel.swift
@@ -47,6 +47,7 @@ final class SettingsViewModel: ObservableObject {
     // Chord display
     @Published var chordDisplayStyle: String = "above"
     @Published var chordColor: String = "theme"
+    @Published var showChordDiagramRail: Bool = true
 
     private let repository: SettingsRepository
 
@@ -82,6 +83,7 @@ final class SettingsViewModel: ObservableObject {
         onboardingCompleted = data.onboardingCompleted
         chordDisplayStyle = data.chordDisplayStyle
         chordColor = data.chordColor
+        showChordDiagramRail = data.showChordDiagramRail
     }
 
     func save() {
@@ -110,7 +112,8 @@ final class SettingsViewModel: ObservableObject {
             appLanguage: appLanguage,
             onboardingCompleted: onboardingCompleted,
             chordDisplayStyle: chordDisplayStyle,
-            chordColor: chordColor
+            chordColor: chordColor,
+            showChordDiagramRail: showChordDiagramRail
         ))
     }
 

--- a/iosApp/UkuleleCompanion/Views/SettingsView.swift
+++ b/iosApp/UkuleleCompanion/Views/SettingsView.swift
@@ -124,6 +124,9 @@ struct SettingsView: View {
                     }
                     .onChange(of: viewModel.chordColor) { _ in viewModel.save() }
 
+                    Toggle("Show chord diagrams", isOn: $viewModel.showChordDiagramRail)
+                        .onChange(of: viewModel.showChordDiagramRail) { _ in viewModel.save() }
+
                     Toggle("Show Tips", isOn: $viewModel.showTips)
                         .onChange(of: viewModel.showTips) { _ in viewModel.save() }
 

--- a/iosApp/UkuleleCompanion/Views/SongViewerView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongViewerView.swift
@@ -70,6 +70,8 @@ struct SongViewerView: View {
 
                     tempoSection(content: displaySong.content)
 
+                    chordDiagramRail(content: displaySong.content)
+
                     parsedContentView(song: displaySong)
 
                     Color.clear.frame(height: 1).id("bottom")
@@ -743,6 +745,48 @@ struct SongViewerView: View {
                 let segments = ChordParser.shared.parseLine(line: lines[i])
                 parsedLineView(segments: segments.asArray(of: ChordParser.TextSegment.self))
                     .id("line_\(i)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func chordDiagramRail(content: String) -> some View {
+        if settingsVM.showChordDiagramRail {
+            let chordNames = ChordParser.shared.extractChords(text: content)
+                .asArray(of: NSString.self).map { $0 as String }
+            let voicings: [(String, ChordVoicing)] = chordNames.compactMap { name in
+                guard let parsed = ChordNameParser.shared.parse(input: name) else { return nil }
+                let tuning = UkuleleTuning.highG.asUkuleleStrings
+                let generated = VoicingGenerator.shared.generate(
+                    rootPitchClass: Int32(parsed.rootPitchClass),
+                    formula: parsed.formula,
+                    tuning: tuning,
+                    allowMutedStrings: false
+                ).asArray(of: ChordVoicing.self)
+                guard let voicing = generated.first else { return nil }
+                return (name, voicing)
+            }
+            if !voicings.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        ForEach(0..<voicings.count, id: \.self) { i in
+                            let (name, voicing) = voicings[i]
+                            VStack(spacing: 4) {
+                                ChordDiagramView(voicing: voicing, chordName: name)
+                                Text(name)
+                                    .font(.caption2)
+                                    .bold()
+                            }
+                            .onTapGesture { tappedChord = name }
+                            .accessibilityElement(children: .combine)
+                            .accessibilityLabel("\(name) chord diagram")
+                            .accessibilityAddTraits(.isButton)
+                            .accessibilityHint("Show chord options")
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+                Divider()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
@@ -93,6 +93,7 @@ data class DisplaySettings(
     val showReferenceSection: Boolean = true,
     val chordDisplayStyle: ChordDisplayStyle = ChordDisplayStyle.ABOVE,
     val chordColor: ChordColorOption = ChordColorOption.THEME,
+    val showChordDiagramRail: Boolean = true,
 )
 
 /**


### PR DESCRIPTION
## Summary
- Add a scrollable horizontal row of chord diagrams at the top of the Songbook chord sheet viewer, showing one diagram per unique chord in the song.
- Tapping a diagram opens the existing chord popover (iOS) / bottom sheet (Android).
- Diagrams recompute when the song is transposed.
- New "Show chord diagrams" toggle in Display settings (both platforms), enabled by default.

## Technical changes
- **Shared**: Added `showChordDiagramRail` boolean to `DisplaySettings`
- **Android**: `LazyRow` of `VerticalChordDiagram` in `SheetViewer.kt`, threaded through `SongbookTab` → `FretboardScreen`; persisted in `SettingsViewModel`; toggle in `DisplaySection`
- **iOS**: `ScrollView(.horizontal)` of `ChordDiagramView` in `SongViewerView.swift`; persisted in `SettingsRepository`/`SettingsViewModel`; toggle in `SettingsView`

## Test plan
- [ ] Shared module tests pass
- [ ] Android unit tests and lint pass
- [ ] iOS builds successfully
- [ ] Chord diagrams appear when a song is opened (one per unique chord)
- [ ] Tapping a diagram opens the chord detail popover/sheet
- [ ] Diagrams update after transposing
- [ ] Toggling "Show chord diagrams" off hides the rail
- [ ] Setting persists across launches and round-trips through backup

Fixes #382

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings toggle to show or hide a chord diagram rail in the songbook viewer
  * When enabled (by default), displays a horizontally scrollable collection of chord diagrams above sheet music for quick reference while playing or practicing
  * Setting persists across app sessions and is available in all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->