### PR TITLE
Add: highlight section markers in Songbook chord sheet viewer

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
@@ -481,7 +481,19 @@ internal fun SheetViewer(
                     }
                     val segments = ChordParser.parseLine(line)
                     Column(modifier = sectionModifier) {
-                        if (segments.isEmpty()) {
+                        if (lineIndex in sectionLineIndices) {
+                            val label = line.trim().removePrefix("[").removeSuffix("]")
+                            Text(
+                                text = label,
+                                style = songTextStyle.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.tertiary,
+                                ),
+                                modifier = Modifier
+                                    .padding(top = 8.dp, bottom = 4.dp)
+                                    .semantics { heading() },
+                            )
+                        } else if (segments.isEmpty()) {
                             Text(
                                 text = " ",
                                 style = songTextStyle,

--- a/iosApp/UkuleleCompanion/Views/SongViewerView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongViewerView.swift
@@ -742,9 +742,28 @@ struct SongViewerView: View {
         let lines = song.content.components(separatedBy: "\n")
         return VStack(alignment: .leading, spacing: 2) {
             ForEach(0..<lines.count, id: \.self) { i in
-                let segments = ChordParser.shared.parseLine(line: lines[i])
-                parsedLineView(segments: segments.asArray(of: ChordParser.TextSegment.self))
-                    .id("line_\(i)")
+                let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") && !trimmed.contains("\n") {
+                    let label = String(trimmed.dropFirst().dropLast())
+                    if ChordNameParser.shared.parse(input: label) == nil {
+                        Text(label)
+                            .font(songFont)
+                            .bold()
+                            .foregroundColor(.secondary)
+                            .padding(.top, 8)
+                            .padding(.bottom, 2)
+                            .accessibilityAddTraits(.isHeader)
+                            .id("line_\(i)")
+                    } else {
+                        let segments = ChordParser.shared.parseLine(line: lines[i])
+                        parsedLineView(segments: segments.asArray(of: ChordParser.TextSegment.self))
+                            .id("line_\(i)")
+                    }
+                } else {
+                    let segments = ChordParser.shared.parseLine(line: lines[i])
+                    parsedLineView(segments: segments.asArray(of: ChordParser.TextSegment.self))
+                        .id("line_\(i)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Section markers (e.g. `[Chorus]`, `[Verse]`, `[Coda]`, `[Intro]`, `[Guitar Solo]`) are now rendered as bold, colored labels with heading semantics instead of plain monospace text.
- Brackets are stripped for cleaner display (`Chorus` instead of `[Chorus]`).
- Builds on the parser fix from #378 which ensures non-chord bracket tokens are correctly identified.

## Technical changes
- **Android** (`SheetViewer.kt`): When a line index is in `sectionLineIndices`, render the label with `FontWeight.Bold`, `colorScheme.tertiary`, extra padding, and `heading()` semantics.
- **iOS** (`SongViewerView.swift`): In `parsedContentView`, detect single-bracket lines whose content doesn't parse as a chord via `ChordNameParser`, and render them with `.bold()`, `.foregroundColor(.secondary)`, padding, and `.accessibilityAddTraits(.isHeader)`.

## Test plan
- [ ] Section markers render as bold colored labels (not plain text)
- [ ] Brackets are stripped from display
- [ ] Real chords on their own line (e.g. `[C]`) still render as chord (not as section header)
- [ ] TalkBack (Android) and VoiceOver (iOS) announce section labels as headings
- [ ] Jump chips still work for section navigation
- [ ] Existing tests pass

Fixes #383

Made with [Cursor](https://cursor.com)