### PR TITLE
Fix: use target-string cents for tuner needle on iOS

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -209,7 +209,6 @@ final class TunerViewModel: ObservableObject {
                 let newNoteName = noteInfo.noteName
                 noteName = newNoteName
                 octave = Int(noteInfo.octave)
-                centsDeviation = noteInfo.centsDeviation
                 frequency = finalHz
 
                 // Announce note changes to VoiceOver
@@ -231,6 +230,7 @@ final class TunerViewModel: ObservableObject {
                 activeStringIndex = stringIdx
 
                 let cents = stringResult.centsFromTarget
+                centsDeviation = min(max(cents, -50), 50)
                 let justTuned: Bool
                 isInTune = abs(cents) <= 6
                 if abs(cents) <= 6 {


### PR DESCRIPTION
## Summary
- The iOS TunerViewModel was setting `centsDeviation` from `noteInfo.centsDeviation` (deviation from nearest chromatic note) instead of `stringResult.centsFromTarget` (deviation from the target tuning string). This caused the needle position to show misleading values when the detected pitch fell between two tuning strings, conflicting with the tuning status text.
- Moved the `centsDeviation` assignment after the string match computation and clamped to [-50, 50] to match Android behavior.

## Test plan
- [ ] Open tuner on iOS simulator
- [ ] Verify needle position aligns with tuning status text
- [ ] Confirm VoiceOver announces correct cents value
- [ ] Compare behavior with Android tuner

Fixes #389

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tuner cent deviation calculation to display deviation relative to the nearest target string, with values bounded for more accurate tuning feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->