### PR TITLE
Fix: add string-switch hysteresis to iOS tuner

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -49,6 +49,9 @@ final class TunerViewModel: ObservableObject {
     private static let displayDeadbandCents = 0.8
     private var displayCentsFiltered = 0.0
 
+    // String-switch hysteresis (cents)
+    private static let stringSwitchHysteresisCents = 4.0
+
     // Onset (pluck attack) detection — adaptive threshold + blanking
     private static let onsetMinRatio: Float = 2.5
     private static let onsetMaxRatio: Float = 5.0
@@ -265,9 +268,11 @@ final class TunerViewModel: ObservableObject {
                     )
                 }
 
-                let stringResult = TunerNoteMapper.shared.findNearestString(
+                let stringResult = TunerNoteMapper.shared.findNearestStringWithHysteresis(
                     noteInfo: noteInfo,
                     tuning: currentTuning,
+                    previousStringIndex: activeStringIndex.map { KotlinInt(int: Int32($0)) },
+                    switchHysteresisCents: Self.stringSwitchHysteresisCents,
                     a4Reference: a4Reference
                 )
                 stringMatch = stringResult.stringName


### PR DESCRIPTION
## Summary
- Switched from `findNearestString()` to `findNearestStringWithHysteresis()` (already available via KMP) with a 4-cent deadband, matching Android behavior.
- Without hysteresis, when the detected pitch is near the midpoint between two tuning strings, the string indicator rapidly alternates between them on consecutive frames.
- The previous string assignment is kept unless the new match is more than 4 cents closer.

## Test plan
- [ ] Open tuner on iOS and play a pitch between two strings — indicator should stay stable
- [ ] Normal tuning still works correctly (each string detected properly)
- [ ] Compare string indicator behavior with Android

Fixes #392

Made with [Cursor](https://cursor.com)