### PR TITLE
Refactor: remove dead knownChords field from BackupData

### DIFF
--- a/app/src/test/java/com/baijum/ukufretboard/data/sync/BackupRestoreManagerTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/sync/BackupRestoreManagerTest.kt
@@ -340,8 +340,7 @@ class BackupRestoreManagerTest {
             "learningProgress": $learningProgress,
             "achievements": $achievements,
             "practiceTimer": $practiceTimer,
-            "settings": $settings,
-            "knownChords": []
+            "settings": $settings
         }
     """.trimIndent()
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/sync/IosBackupNormalizationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/sync/IosBackupNormalizationTest.kt
@@ -60,8 +60,7 @@ class IosBackupNormalizationTest {
             "learningProgress": {"entries":{}},
             "achievements": {},
             "practiceTimer": {"totalMinutes":0,"totalSessions":0,"longestSession":0,"lastSessionTime":0,"dailyGoal":15,"dailyMinutes":{}},
-            "settings": {"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true},
-            "knownChords": []
+            "settings": {"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true}
         }
         """.trimIndent()
         manager.importBackup(kmpBackup)
@@ -304,8 +303,7 @@ class IosBackupNormalizationTest {
             "learningProgress": {"entries":{}},
             "achievements": {},
             "practiceTimer": {"totalMinutes":10,"totalSessions":2,"longestSession":8,"lastSessionTime":1700000000.321,"dailyGoal":15,"dailyMinutes":{}},
-            "settings": {"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true},
-            "knownChords": []
+            "settings": {"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true}
         }
         """.trimIndent()
         manager.importBackup(kmpBackup)

--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -101,8 +101,7 @@ final class BackupRestoreManager: ObservableObject {
             learningProgress: buildLearningProgress(learnData),
             settings: buildSettings(settingsVM.exportSettings()),
             achievements: buildAchievements(learnData),
-            practiceTimer: buildPracticeTimer(practiceTimerVM.exportData()),
-            knownChords: []
+            practiceTimer: buildPracticeTimer(practiceTimerVM.exportData())
         )
 
         let jsonString = BackupCodec.shared.encode(data: backup)

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupCodec.kt
@@ -100,8 +100,6 @@ object BackupCodec {
             }
             normalizeIosPracticeTimer(root)?.let { put("practiceTimer", it) }
             normalizeIosSettings(root)?.let { put("settings", it) }
-
-            put("knownChords", root["knownChords"] ?: buildJsonArray {})
         }
 
         return json.encodeToString(JsonObject.serializer(), out)

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupData.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/sync/BackupData.kt
@@ -37,7 +37,6 @@ data class BackupData(
     val settings: BackupSettings = BackupSettings(),
     val achievements: Map<String, Long> = emptyMap(),
     val practiceTimer: BackupPracticeTimer = BackupPracticeTimer(),
-    val knownChords: List<String> = emptyList(),
 ) {
     companion object {
         const val CURRENT_VERSION = 3

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/BackupDataTest.kt
@@ -42,7 +42,6 @@ class BackupDataTest {
         assertEquals(data.exportedAt, decoded.exportedAt)
         assertTrue(decoded.favorites.isEmpty())
         assertTrue(decoded.chordSheets.isEmpty())
-        assertTrue(decoded.knownChords.isEmpty())
     }
 
     @Test
@@ -82,17 +81,6 @@ class BackupDataTest {
     }
 
     @Test
-    fun backupWithKnownChordsRoundTrips() {
-        val data = BackupData(
-            exportedAt = 12345L,
-            knownChords = listOf("C", "Am", "F", "G"),
-        )
-        val jsonStr = json.encodeToString(data)
-        val decoded = json.decodeFromString<BackupData>(jsonStr)
-        assertEquals(listOf("C", "Am", "F", "G"), decoded.knownChords)
-    }
-
-    @Test
     fun defaultListsAreEmpty() {
         val data = BackupData()
         assertTrue(data.favorites.isEmpty())
@@ -102,7 +90,6 @@ class BackupDataTest {
         assertTrue(data.customStrumPatterns.isEmpty())
         assertTrue(data.customFingerpickingPatterns.isEmpty())
         assertTrue(data.melodies.isEmpty())
-        assertTrue(data.knownChords.isEmpty())
         assertTrue(data.setlists.isEmpty())
         assertTrue(data.achievements.isEmpty())
     }
@@ -401,8 +388,7 @@ class BackupDataTest {
                 "lastSessionTime": 1717430400000,
                 "dailyGoal": 15,
                 "dailyMinutes": {"2026-06-01": 25}
-            },
-            "knownChords": []
+            }
         }
         """.trimIndent()
 

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/sync/BackupCodecTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/sync/BackupCodecTest.kt
@@ -117,7 +117,6 @@ class BackupCodecTest {
                 dailyGoal = 15,
                 dailyMinutes = mapOf("2026-06-01" to 25),
             ),
-            knownChords = listOf("C", "Am"),
         )
 
         val encoded = BackupCodec.encode(original)
@@ -137,7 +136,6 @@ class BackupCodecTest {
         assertEquals(original.settings, decoded.settings)
         assertEquals(original.achievements, decoded.achievements)
         assertEquals(original.practiceTimer, decoded.practiceTimer)
-        assertEquals(original.knownChords, decoded.knownChords)
     }
 
     @Test
@@ -194,8 +192,7 @@ class BackupCodecTest {
                 "lastSessionTime": 0,
                 "dailyGoal": 15,
                 "dailyMinutes": {}
-            },
-            "knownChords": ["C", "Am", "F"]
+            }
         }
         """.trimIndent()
 
@@ -208,7 +205,6 @@ class BackupCodecTest {
         assertEquals(listOf(0, 2, 1, 2), decoded.favorites[0].frets)
         assertEquals(listOf("folder-jazz"), decoded.favorites[0].folderIds)
         assertEquals("Jazz Voicings", decoded.favoriteFolders[0].name)
-        assertEquals(listOf("C", "Am", "F"), decoded.knownChords)
     }
 
     @Test
@@ -554,6 +550,5 @@ class BackupCodecTest {
         assertEquals(data.exportedAt, decoded.exportedAt)
         assertTrue(decoded.favorites.isEmpty())
         assertTrue(decoded.chordSheets.isEmpty())
-        assertTrue(decoded.knownChords.isEmpty())
     }
 }


### PR DESCRIPTION
## Summary

- Removes the vestigial `knownChords` field from `BackupData` — it was always exported as an empty list and never imported or consumed on either platform
- Removes the `put("knownChords", ...)` line from `BackupCodec.normalizeIosFormat`
- Removes `knownChords: []` from iOS `BackupRestoreManager.swift`
- Updates all test fixtures and assertions

## Test plan

- [x] Shared module builds (`./gradlew :shared:build`)
- [x] Android debug build succeeds (`./gradlew assembleDebug`)
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)
- [x] `ignoreUnknownKeys = true` in BackupCodec ensures old backups with the field still decode

Fixes #402

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "known chords" field from backup data format. Existing backups may need to be regenerated to ensure compatibility with the updated backup/restore system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->