### PR TITLE
Refactor: remove vestigial UkuleleString typealias from FretboardViewModel

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/CapoVisualizerView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/CapoVisualizerView.kt
@@ -31,7 +31,7 @@ import com.baijum.ukufretboard.data.ChordFormula
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.VoicingGenerator
 import com.baijum.ukufretboard.domain.ChordVoicing
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Capo Chord Shape Visualizer — shows how a chord shape looks and sounds

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordLibraryTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordLibraryTab.kt
@@ -35,7 +35,7 @@ import com.baijum.ukufretboard.domain.CapoCalculator
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.viewmodel.ChordLibraryViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 @Composable
 fun ChordLibraryTab(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordResultView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordResultView.kt
@@ -49,7 +49,7 @@ import com.baijum.ukufretboard.domain.AlternateChord
 import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.viewmodel.FretboardViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Displays the chord detection result below the fretboard.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ChordTransitionView.kt
@@ -60,7 +60,7 @@ import com.baijum.ukufretboard.data.VoicingGenerator
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.Note
 import com.baijum.ukufretboard.viewmodel.FretboardViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Chord Transition Trainer — practise switching between two chords with a metronome.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/FavoritesTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/FavoritesTab.kt
@@ -57,7 +57,7 @@ import com.baijum.ukufretboard.data.FavoriteVoicing
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.viewmodel.FavoritesViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyGridState
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/FretboardView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/FretboardView.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.domain.Note
 import com.baijum.ukufretboard.viewmodel.FretboardViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /** Default width of each fret cell — large enough for comfortable touch targets. */
 internal val CELL_WIDTH = 48.dp

--- a/app/src/main/java/com/baijum/ukufretboard/ui/InversionCompareView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/InversionCompareView.kt
@@ -33,7 +33,7 @@ import com.baijum.ukufretboard.data.ChordFormula
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.domain.ChordVoicing
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 @Composable
 internal fun InversionCompareView(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PlayAlongView.kt
@@ -75,7 +75,7 @@ import com.baijum.ukufretboard.domain.AudioChordDetector
 import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.PlayAlongScorer
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 import com.baijum.ukufretboard.domain.FrameGate
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPlaybackBar.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPlaybackBar.kt
@@ -48,7 +48,7 @@ import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.Progression
 import com.baijum.ukufretboard.data.VoicingGenerator
 import com.baijum.ukufretboard.domain.ChordVoicing
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * A playback toolbar for chord progressions with tempo control.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPracticeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionPracticeView.kt
@@ -62,7 +62,7 @@ import com.baijum.ukufretboard.data.VoicingGenerator
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.Note
 import com.baijum.ukufretboard.viewmodel.FretboardViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Full-screen practice view for a chord progression.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionsTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ProgressionsTab.kt
@@ -65,7 +65,7 @@ import com.baijum.ukufretboard.domain.HarmonicFunction
 import com.baijum.ukufretboard.ui.ShareUtils
 import com.baijum.ukufretboard.domain.VoiceLeading
 import com.baijum.ukufretboard.domain.harmonicFunction
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Tab showing common chord progressions for a selected key.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
@@ -45,7 +45,7 @@ import com.baijum.ukufretboard.viewmodel.PlayDirection
 import com.baijum.ukufretboard.viewmodel.PlaybackState
 import com.baijum.ukufretboard.viewmodel.ScalePracticeUiState
 import com.baijum.ukufretboard.viewmodel.ScalePracticeViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 internal fun fretPositionsForNote(
     pitchClass: Int,

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
@@ -31,7 +31,7 @@ import com.baijum.ukufretboard.viewmodel.FretboardViewModel
 import com.baijum.ukufretboard.viewmodel.LearningProgressViewModel
 import com.baijum.ukufretboard.viewmodel.PracticeMode
 import com.baijum.ukufretboard.viewmodel.ScalePracticeViewModel
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 @Composable
 fun ScalePracticeView(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/VoiceLeadingView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/VoiceLeadingView.kt
@@ -46,7 +46,7 @@ import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.VoiceLeading
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * Dedicated view for exploring voice leading through a chord progression.

--- a/app/src/main/java/com/baijum/ukufretboard/ui/VoicingGrid.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/VoicingGrid.kt
@@ -20,7 +20,7 @@ import com.baijum.ukufretboard.data.ChordFormula
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.domain.ChordVoicing
-import com.baijum.ukufretboard.viewmodel.UkuleleString
+import com.baijum.ukufretboard.domain.UkuleleString
 
 @Composable
 internal fun VoicingGrid(

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/ChordLibraryViewModel.kt
@@ -11,6 +11,7 @@ import com.baijum.ukufretboard.domain.ChordNameParser
 import com.baijum.ukufretboard.domain.ChordSearchResult
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.Transpose
+import com.baijum.ukufretboard.domain.UkuleleString
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModel.kt
@@ -8,6 +8,7 @@ import com.baijum.ukufretboard.data.FavoritesRepository
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.domain.Note
+import com.baijum.ukufretboard.domain.UkuleleString
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
@@ -16,14 +16,13 @@ import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordNameParser
 import com.baijum.ukufretboard.domain.ChordResult
 import com.baijum.ukufretboard.domain.Note
+import com.baijum.ukufretboard.domain.UkuleleString
 import com.baijum.ukufretboard.domain.calculateNote
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-
-typealias UkuleleString = com.baijum.ukufretboard.domain.UkuleleString
 
 /**
  * State for the scale note overlay on the fretboard.


### PR DESCRIPTION
## Summary

- Removes the backward-compatibility `typealias UkuleleString = com.baijum.ukufretboard.domain.UkuleleString` from `FretboardViewModel.kt`
- Updates all 15 UI files and 2 ViewModel files that imported `UkuleleString` via the viewmodel package to import directly from `domain`

## Test plan

- [x] Clean Kotlin recompile passes (`./gradlew compileDebugKotlin --rerun-tasks`)
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)
- [x] No files import `UkuleleString` via the viewmodel package path

Fixes #403

Made with [Cursor](https://cursor.com)