### PR TITLE
Refactor: move duplicated platform enums to shared KMP module

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/audio/MetronomeEngine.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/audio/MetronomeEngine.kt
@@ -1,13 +1,11 @@
 package com.baijum.ukufretboard.audio
 
+import com.baijum.ukufretboard.data.BeatType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-
-/** The type of a beat in a metronome accent pattern. */
-enum class BeatType { ACCENT, NORMAL, MUTE }
 
 /**
  * A coroutine-based metronome engine that supports both chord-progression playback

--- a/app/src/main/java/com/baijum/ukufretboard/ui/I18nMappings.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/I18nMappings.kt
@@ -23,9 +23,9 @@ import com.baijum.ukufretboard.domain.AchievementCategory
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.domain.QuizGenerator
 import com.baijum.ukufretboard.domain.PracticeRoutineGenerator
-import com.baijum.ukufretboard.viewmodel.FretPosition
-import com.baijum.ukufretboard.viewmodel.PlayDirection
-import com.baijum.ukufretboard.viewmodel.PracticeMode
+import com.baijum.ukufretboard.data.FretPosition
+import com.baijum.ukufretboard.data.PlayDirection
+import com.baijum.ukufretboard.data.PracticeMode
 
 @Composable
 fun ThemeMode.localizedLabel(): String = stringResource(

--- a/app/src/main/java/com/baijum/ukufretboard/ui/MetronomeTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/MetronomeTab.kt
@@ -54,7 +54,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
-import com.baijum.ukufretboard.audio.BeatType
+import com.baijum.ukufretboard.data.BeatType
 import com.baijum.ukufretboard.viewmodel.MetronomeViewModel
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticePlayAlong.kt
@@ -40,8 +40,8 @@ import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.ScalePracticeSettings
 import com.baijum.ukufretboard.data.Scales
 import com.baijum.ukufretboard.domain.Note
-import com.baijum.ukufretboard.viewmodel.FretPosition
-import com.baijum.ukufretboard.viewmodel.PlayDirection
+import com.baijum.ukufretboard.data.FretPosition
+import com.baijum.ukufretboard.data.PlayDirection
 import com.baijum.ukufretboard.viewmodel.PlaybackState
 import com.baijum.ukufretboard.viewmodel.ScalePracticeUiState
 import com.baijum.ukufretboard.viewmodel.ScalePracticeViewModel

--- a/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/ScalePracticeView.kt
@@ -29,7 +29,7 @@ import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.ScaleCategory
 import com.baijum.ukufretboard.viewmodel.FretboardViewModel
 import com.baijum.ukufretboard.viewmodel.LearningProgressViewModel
-import com.baijum.ukufretboard.viewmodel.PracticeMode
+import com.baijum.ukufretboard.data.PracticeMode
 import com.baijum.ukufretboard.viewmodel.ScalePracticeViewModel
 import com.baijum.ukufretboard.domain.UkuleleString
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SongbookTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SongbookTab.kt
@@ -71,7 +71,7 @@ import com.baijum.ukufretboard.data.ChordDisplayStyle
 import com.baijum.ukufretboard.data.ChordProParser
 import com.baijum.ukufretboard.data.ChordSheet
 import com.baijum.ukufretboard.domain.UkuleleString
-import com.baijum.ukufretboard.viewmodel.SongSortOrder
+import com.baijum.ukufretboard.data.SongSortOrder
 import com.baijum.ukufretboard.viewmodel.SongbookViewModel
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MetronomeViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MetronomeViewModel.kt
@@ -3,7 +3,7 @@ package com.baijum.ukufretboard.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.baijum.ukufretboard.audio.BeatType
+import com.baijum.ukufretboard.data.BeatType
 import com.baijum.ukufretboard.audio.ClickSoundPlayer
 import com.baijum.ukufretboard.audio.MetronomeEngine
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import com.baijum.ukufretboard.audio.MetronomeEngine
 import com.baijum.ukufretboard.audio.ToneGenerator
 import com.baijum.ukufretboard.data.Notes
+import com.baijum.ukufretboard.data.PlayDirection
+import com.baijum.ukufretboard.data.FretPosition
+import com.baijum.ukufretboard.data.PracticeMode
 import com.baijum.ukufretboard.data.Scale
 import com.baijum.ukufretboard.data.ScaleCategory
 import com.baijum.ukufretboard.data.ScalePracticeSettings
@@ -17,51 +20,10 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
- * Practice mode selector.
- */
-enum class PracticeMode(val label: String) {
-    PLAY_ALONG("Play Along"),
-    QUIZ("Scale Quiz"),
-    EAR_TRAINING("Ear Training"),
-}
-
-/**
- * Direction for Play Along mode.
- */
-enum class PlayDirection(val label: String) {
-    ASCENDING("Ascending"),
-    DESCENDING("Descending"),
-    BOTH("Both"),
-}
-
-/**
  * Play Along playback state.
  */
 enum class PlaybackState {
     STOPPED, PLAYING, PAUSED,
-}
-
-/**
- * Fret position filter for the Play Along fretboard diagram.
- *
- * Restricts which fret range shows scale overlay dots so the user
- * can focus on a specific area of the neck.
- *
- * The HIGH range adapts to the user's configured last fret.
- */
-enum class FretPosition(val label: String) {
-    ALL("All"),
-    OPEN("Open"),
-    MID("Mid"),
-    HIGH("High");
-
-    /** Returns the fret range for this position, or null for ALL. */
-    fun range(lastFret: Int = 12): IntRange? = when (this) {
-        ALL -> null
-        OPEN -> 0..4
-        MID -> 4..8
-        HIGH -> 7..lastFret
-    }
 }
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/SongbookViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/SongbookViewModel.kt
@@ -5,17 +5,11 @@ import androidx.lifecycle.AndroidViewModel
 import com.baijum.ukufretboard.data.ChordProParser
 import com.baijum.ukufretboard.data.ChordSheet
 import com.baijum.ukufretboard.data.ChordSheetRepository
+import com.baijum.ukufretboard.data.SongSortOrder
 import com.baijum.ukufretboard.domain.ChordSheetTranspose
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-
-enum class SongSortOrder {
-    LAST_MODIFIED,
-    DATE_ADDED,
-    TITLE,
-    ARTIST,
-}
 
 /**
  * ViewModel for managing the songbook (list of chord sheets).

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/MetronomeViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/MetronomeViewModelTest.kt
@@ -2,7 +2,7 @@ package com.baijum.ukufretboard.viewmodel
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
-import com.baijum.ukufretboard.audio.BeatType
+import com.baijum.ukufretboard.data.BeatType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/ScalePracticeViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.baijum.ukufretboard.viewmodel
 
+import com.baijum.ukufretboard.data.FretPosition
+import com.baijum.ukufretboard.data.PlayDirection
+import com.baijum.ukufretboard.data.PracticeMode
 import com.baijum.ukufretboard.data.ScaleCategory
 import com.baijum.ukufretboard.data.ScalePracticeSettings
 import com.baijum.ukufretboard.data.Scales

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SongbookViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SongbookViewModelTest.kt
@@ -3,6 +3,7 @@ package com.baijum.ukufretboard.viewmodel
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.baijum.ukufretboard.data.ChordSheet
+import com.baijum.ukufretboard.data.SongSortOrder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/BeatType.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/BeatType.kt
@@ -1,0 +1,3 @@
+package com.baijum.ukufretboard.data
+
+enum class BeatType { ACCENT, NORMAL, MUTE }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ScalePracticeEnums.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ScalePracticeEnums.kt
@@ -1,0 +1,28 @@
+package com.baijum.ukufretboard.data
+
+enum class PracticeMode(val label: String) {
+    PLAY_ALONG("Play Along"),
+    QUIZ("Scale Quiz"),
+    EAR_TRAINING("Ear Training"),
+}
+
+enum class PlayDirection(val label: String) {
+    ASCENDING("Ascending"),
+    DESCENDING("Descending"),
+    BOTH("Both"),
+}
+
+enum class FretPosition(val label: String) {
+    ALL("All"),
+    OPEN("Open"),
+    MID("Mid"),
+    HIGH("High");
+
+    /** Returns the fret range for this position, or null for ALL. */
+    fun range(lastFret: Int = 12): IntRange? = when (this) {
+        ALL -> null
+        OPEN -> 0..4
+        MID -> 4..8
+        HIGH -> 7..lastFret
+    }
+}

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/SongSortOrder.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/SongSortOrder.kt
@@ -1,0 +1,8 @@
+package com.baijum.ukufretboard.data
+
+enum class SongSortOrder {
+    LAST_MODIFIED,
+    DATE_ADDED,
+    TITLE,
+    ARTIST,
+}


### PR DESCRIPTION
## Summary

- Moves 5 enums from Android-only packages to `shared/src/commonMain/.../data/`:
  - `SongSortOrder` (from `SongbookViewModel.kt`)
  - `PracticeMode`, `PlayDirection`, `FretPosition` (from `ScalePracticeViewModel.kt`)
  - `BeatType` (from `MetronomeEngine.kt`)
- Updates all Android imports (UI, ViewModel, and test files)
- iOS can now use these enums directly from the shared framework

## Test plan

- [x] Shared module builds (`./gradlew :shared:build`)
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Kotlin compilation clean (`./gradlew compileDebugKotlin`)

Fixes #400

Made with [Cursor](https://cursor.com)