### PR TITLE
Refactor: replace navigation magic integers with NavSection enum

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/DailyChallengeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/DailyChallengeView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.DailyChallengeGenerator
+import com.baijum.ukufretboard.data.NavSection
 
 /**
  * Daily Challenges screen — shows today's 3 challenges.
@@ -42,11 +43,11 @@ import com.baijum.ukufretboard.data.DailyChallengeGenerator
  * practice a song, etc.) and provides a button to navigate to the relevant
  * section of the app.
  *
- * @param onNavigate Callback to navigate to a specific section index.
+ * @param onNavigate Callback to navigate to a specific section.
  */
 @Composable
 fun DailyChallengeView(
-    onNavigate: (Int) -> Unit = {},
+    onNavigate: (NavSection) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val challenges = remember { DailyChallengeGenerator.today() }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/PracticeRoutineView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/PracticeRoutineView.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
+import com.baijum.ukufretboard.data.NavSection
 import com.baijum.ukufretboard.domain.PracticeRoutine
 import com.baijum.ukufretboard.domain.PracticeRoutineGenerator
 import com.baijum.ukufretboard.domain.PracticeStep
@@ -57,11 +58,11 @@ import com.baijum.ukufretboard.domain.PracticeStep
  * Generates a personalised practice routine and guides the user through
  * each step with timers and navigation to relevant app sections.
  *
- * @param onNavigate Callback to navigate to a specific section index.
+ * @param onNavigate Callback to navigate to a specific section.
  */
 @Composable
 fun PracticeRoutineView(
-    onNavigate: (Int) -> Unit = {},
+    onNavigate: (NavSection) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     var routine by remember { mutableStateOf<PracticeRoutine?>(null) }
@@ -248,7 +249,7 @@ private fun ActiveRoutine(
     completedSteps: Set<Int>,
     activeStep: Int,
     onCompleteStep: (Int) -> Unit,
-    onNavigate: (Int) -> Unit,
+    onNavigate: (NavSection) -> Unit,
     onReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/DrawerContent.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/DrawerContent.kt
@@ -44,13 +44,14 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
+import com.baijum.ukufretboard.data.NavSection
 
 @Composable
 internal fun DrawerContent(
     visibleSections: List<DrawerSection>,
     expandedState: MutableMap<String, Boolean>,
-    selectedSection: Int,
-    onItemSelected: (Int) -> Unit,
+    selectedSection: NavSection,
+    onItemSelected: (NavSection) -> Unit,
 ) {
     val navigationDrawerDescription = stringResource(R.string.cd_navigation_drawer)
     Column(
@@ -129,8 +130,8 @@ internal fun DrawerContent(
                         NavigationDrawerItem(
                             icon = { Icon(item.icon, contentDescription = item.label) },
                             label = { Text(item.label) },
-                            selected = selectedSection == item.index,
-                            onClick = { onItemSelected(item.index) },
+                            selected = selectedSection == item.section,
+                            onClick = { onItemSelected(item.section) },
                             modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
                         )
                     }
@@ -142,8 +143,8 @@ internal fun DrawerContent(
         NavigationDrawerItem(
             icon = { Icon(Icons.Filled.Info, contentDescription = stringResource(R.string.nav_help)) },
             label = { Text(stringResource(R.string.nav_help)) },
-            selected = selectedSection == NAV_HELP,
-            onClick = { onItemSelected(NAV_HELP) },
+            selected = selectedSection == NavSection.HELP,
+            onClick = { onItemSelected(NavSection.HELP) },
             modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding),
         )
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
@@ -31,9 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,6 +50,7 @@ import com.baijum.ukufretboard.R
 import kotlinx.coroutines.launch
 import com.baijum.ukufretboard.audio.ToneGenerator
 import com.baijum.ukufretboard.data.AchievementRepository
+import com.baijum.ukufretboard.data.NavSection
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.PracticeTimerRepository
 import com.baijum.ukufretboard.data.ReviewPromptRepository
@@ -137,15 +138,20 @@ fun FretboardScreen(
     val isCompactWidth = widthSizeClass == WindowWidthSizeClass.Compact
     val isTabletWidth = widthSizeClass == WindowWidthSizeClass.Expanded &&
         heightSizeClass != WindowHeightSizeClass.Compact
-    var selectedSection by rememberSaveable { mutableIntStateOf(NAV_EXPLORER) }
-    var previousSection by rememberSaveable { mutableStateOf<Int?>(null) }
+    var selectedSection by rememberSaveable(
+        stateSaver = Saver(
+            save = { it.id },
+            restore = { NavSection.fromId(it) ?: NavSection.EXPLORER },
+        ),
+    ) { mutableStateOf(NavSection.EXPLORER) }
+    var previousSection by rememberSaveable { mutableStateOf<NavSection?>(null) }
     var showSettings by remember { mutableStateOf(false) }
     var showFullScreen by rememberSaveable { mutableStateOf(false) }
     var shareChordInfo by remember { mutableStateOf<ShareChordInfo?>(null) }
     var sheetVoicing by remember { mutableStateOf<SheetVoicingInfo?>(null) }
     val currentFolders by favoritesViewModel.folders.collectAsState()
 
-    BackHandler(enabled = previousSection != null && selectedSection == NAV_LIBRARY) {
+    BackHandler(enabled = previousSection != null && selectedSection == NavSection.LIBRARY) {
         selectedSection = previousSection!!
         previousSection = null
     }
@@ -263,8 +269,8 @@ fun FretboardScreen(
                     title = {
                         Text(
                             text = when (selectedSection) {
-                                NAV_HELP -> stringResource(R.string.nav_help)
-                                else -> allItems.firstOrNull { it.index == selectedSection }?.label
+                                NavSection.HELP -> stringResource(R.string.nav_help)
+                                else -> allItems.firstOrNull { it.section == selectedSection }?.label
                                     ?: stringResource(R.string.nav_explorer)
                             },
                             style = MaterialTheme.typography.titleLarge,
@@ -272,7 +278,7 @@ fun FretboardScreen(
                         )
                     },
                     navigationIcon = {
-                        if (previousSection != null && selectedSection == NAV_LIBRARY) {
+                        if (previousSection != null && selectedSection == NavSection.LIBRARY) {
                             IconButton(onClick = {
                                 selectedSection = previousSection!!
                                 previousSection = null
@@ -313,7 +319,7 @@ fun FretboardScreen(
                     .padding(innerPadding),
             ) {
                 when (selectedSection) {
-                    NAV_EXPLORER -> ExplorerTabContent(
+                    NavSection.EXPLORER -> ExplorerTabContent(
                         viewModel = fretboardViewModel,
                         settingsViewModel = settingsViewModel,
                         soundEnabled = appSettings.sound.enabled,
@@ -336,10 +342,10 @@ fun FretboardScreen(
                             libraryViewModel.selectCategory(formula.category)
                             libraryViewModel.selectFormula(formula)
                             previousSection = selectedSection
-                            selectedSection = NAV_LIBRARY
+                            selectedSection = NavSection.LIBRARY
                         },
                     )
-                    NAV_TUNER -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.TUNER -> ConstrainedWidthContent(isCompactWidth) {
                         TunerTab(
                             viewModel = tunerViewModel,
                             tuning = appSettings.tuning.tuning,
@@ -348,15 +354,15 @@ fun FretboardScreen(
                             tunerSettings = appSettings.tuner,
                         )
                     }
-                    NAV_PITCH_MONITOR -> PitchMonitorTab(
+                    NavSection.PITCH_MONITOR -> PitchMonitorTab(
                         viewModel = pitchMonitorViewModel,
                     )
-                    NAV_METRONOME -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.METRONOME -> ConstrainedWidthContent(isCompactWidth) {
                         MetronomeTab(
                             viewModel = metronomeViewModel,
                         )
                     }
-                    NAV_LIBRARY -> ChordLibraryTab(
+                    NavSection.LIBRARY -> ChordLibraryTab(
                         viewModel = libraryViewModel,
                         tuning = fretboardViewModel.tuning,
                         onVoicingSelected = { voicing ->
@@ -366,7 +372,7 @@ fun FretboardScreen(
                                 rootPitchClass = state.selectedRoot,
                                 formula = state.selectedFormula,
                             )
-                            selectedSection = NAV_EXPLORER
+                            selectedSection = NavSection.EXPLORER
                         },
                         onVoicingLongPressed = { voicing ->
                             val state = libraryViewModel.uiState.value
@@ -409,12 +415,12 @@ fun FretboardScreen(
                         },
                         leftHanded = appSettings.fretboard.leftHanded,
                     )
-                    NAV_PATTERNS -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.PATTERNS -> ConstrainedWidthContent(isCompactWidth) {
                         StrumPatternsTab(
                             tuning = appSettings.tuning.tuning,
                         )
                     }
-                    NAV_PROGRESSIONS -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.PROGRESSIONS -> ConstrainedWidthContent(isCompactWidth) {
                         ProgressionsTab(
                         leftHanded = appSettings.fretboard.leftHanded,
                         tuning = fretboardViewModel.tuning,
@@ -429,7 +435,7 @@ fun FretboardScreen(
                                 libraryViewModel.selectFormula(formula)
                             }
                             previousSection = selectedSection
-                            selectedSection = NAV_LIBRARY
+                            selectedSection = NavSection.LIBRARY
                         },
                         onSaveProgression = { name, description, degrees, scaleType ->
                             customProgressionViewModel.create(name, description, degrees, scaleType)
@@ -448,12 +454,12 @@ fun FretboardScreen(
                         },
                     )
                     }
-                    NAV_FAVORITES -> FavoritesTab(
+                    NavSection.FAVORITES -> FavoritesTab(
                         viewModel = favoritesViewModel,
                         tuning = fretboardViewModel.tuning,
                         onVoicingSelected = { voicing ->
                             fretboardViewModel.applyVoicing(voicing)
-                            selectedSection = NAV_EXPLORER
+                            selectedSection = NavSection.EXPLORER
                         },
                         onShareVoicing = { voicing, chordName ->
                             shareChordInfo = ShareChordInfo(
@@ -464,7 +470,7 @@ fun FretboardScreen(
                         },
                         leftHanded = appSettings.fretboard.leftHanded,
                     )
-                    NAV_SONGWRITER_MODE -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.SONGWRITER_MODE -> ConstrainedWidthContent(isCompactWidth) {
                         SongwriterModeFlow(
                             songbookViewModel = songbookViewModel,
                             onSaveProgression = { name, description, degrees, scaleType ->
@@ -472,13 +478,13 @@ fun FretboardScreen(
                             },
                         )
                     }
-                    NAV_SONGBOOK -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.SONGBOOK -> ConstrainedWidthContent(isCompactWidth) {
                         SongbookTab(
                             viewModel = songbookViewModel,
                             onChordTapped = { chordName ->
                                 navigateToChord(chordName, libraryViewModel) {
                                     previousSection = selectedSection
-                                    selectedSection = NAV_LIBRARY
+                                    selectedSection = NavSection.LIBRARY
                                 }
                             },
                             onPlayChord = { chordName ->
@@ -490,7 +496,7 @@ fun FretboardScreen(
                                     metronomeViewModel.togglePlayback()
                                 }
                                 previousSection = selectedSection
-                                selectedSection = NAV_METRONOME
+                                selectedSection = NavSection.METRONOME
                             },
                             tuning = fretboardViewModel.tuning,
                             leftHanded = appSettings.fretboard.leftHanded,
@@ -499,33 +505,33 @@ fun FretboardScreen(
                             showChordDiagramRail = appSettings.display.showChordDiagramRail,
                         )
                     }
-                    NAV_SETLISTS -> ConstrainedWidthContent(isCompactWidth) {
+                    NavSection.SETLISTS -> ConstrainedWidthContent(isCompactWidth) {
                         SetlistTab(
                             setlistViewModel = setlistViewModel,
                             songbookViewModel = songbookViewModel,
                         )
                     }
-                    NAV_CAPO_GUIDE -> CapoGuideView(
+                    NavSection.CAPO_GUIDE -> CapoGuideView(
                         tuning = appSettings.tuning.tuning,
                     )
-                    NAV_THEORY_QUIZ -> TheoryQuizView(
+                    NavSection.THEORY_QUIZ -> TheoryQuizView(
                         progressViewModel = learningProgressViewModel,
                     )
-                    NAV_INTERVAL_TRAINER -> IntervalTrainerView(
+                    NavSection.INTERVAL_TRAINER -> IntervalTrainerView(
                         progressViewModel = learningProgressViewModel,
                     )
-                    NAV_CHORD_SUBS -> ChordSubstitutionsView()
-                    NAV_THEORY_LESSONS -> TheoryLessonsView(
+                    NavSection.CHORD_SUBS -> ChordSubstitutionsView()
+                    NavSection.THEORY_LESSONS -> TheoryLessonsView(
                         progressViewModel = learningProgressViewModel,
                     )
-                    NAV_LEARNING_PROGRESS -> LearningProgressView(
+                    NavSection.LEARNING_PROGRESS -> LearningProgressView(
                         viewModel = learningProgressViewModel,
                         practiceStats = practiceStats,
                     )
-                    NAV_MELODY_NOTEPAD -> MelodyNotepadView(
+                    NavSection.MELODY_NOTEPAD -> MelodyNotepadView(
                         viewModel = melodyViewModel,
                     )
-                    NAV_CIRCLE_OF_FIFTHS -> CircleOfFifthsView(
+                    NavSection.CIRCLE_OF_FIFTHS -> CircleOfFifthsView(
                         onChordTapped = { rootPitchClass, quality ->
                             libraryViewModel.selectRoot(rootPitchClass)
                             val formula = com.baijum.ukufretboard.data.ChordFormulas.ALL
@@ -535,17 +541,17 @@ fun FretboardScreen(
                                 libraryViewModel.selectFormula(formula)
                             }
                             previousSection = selectedSection
-                            selectedSection = NAV_LIBRARY
+                            selectedSection = NavSection.LIBRARY
                         },
                     )
-                    NAV_NOTE_QUIZ -> NoteQuizView(
+                    NavSection.NOTE_QUIZ -> NoteQuizView(
                         tuning = appSettings.tuning.tuning,
                         progressViewModel = learningProgressViewModel,
                     )
-                    NAV_CHORD_EAR -> ChordEarTrainingView(
+                    NavSection.CHORD_EAR -> ChordEarTrainingView(
                         progressViewModel = learningProgressViewModel,
                     )
-                    NAV_SCALE_PRACTICE -> ScalePracticeView(
+                    NavSection.SCALE_PRACTICE -> ScalePracticeView(
                         viewModel = scalePracticeViewModel,
                         progressViewModel = learningProgressViewModel,
                         onSettingsChanged = { newSettings ->
@@ -554,24 +560,20 @@ fun FretboardScreen(
                         tuning = fretboardViewModel.tuning,
                         lastFret = appSettings.fretboard.lastFret,
                     )
-                    NAV_SCALE_CHORDS -> ScaleChordView()
-                    NAV_GLOSSARY -> GlossaryView()
-                    NAV_NOTE_MAP -> FretboardNoteMapView(
+                    NavSection.SCALE_CHORDS -> ScaleChordView()
+                    NavSection.GLOSSARY -> GlossaryView()
+                    NavSection.NOTE_MAP -> FretboardNoteMapView(
                         tuning = appSettings.tuning.tuning,
                         lastFret = appSettings.fretboard.lastFret,
                     )
-                    NAV_PRACTICE_ROUTINE -> PracticeRoutineView(
-                        onNavigate = { navIndex ->
-                            selectedSection = navIndex
-                        },
+                    NavSection.PRACTICE_ROUTINE -> PracticeRoutineView(
+                        onNavigate = { selectedSection = it },
                     )
 
-                    NAV_DAILY_CHALLENGE -> DailyChallengeView(
-                        onNavigate = { navIndex ->
-                            selectedSection = navIndex
-                        },
+                    NavSection.DAILY_CHALLENGE -> DailyChallengeView(
+                        onNavigate = { selectedSection = it },
                     )
-                    NAV_CHORD_TRANSITION -> ChordTransitionView(
+                    NavSection.CHORD_TRANSITION -> ChordTransitionView(
                         tuning = fretboardViewModel.tuning,
                         lastFret = appSettings.fretboard.lastFret,
                         leftHanded = appSettings.fretboard.leftHanded,
@@ -579,13 +581,13 @@ fun FretboardScreen(
                             fretboardViewModel.playVoicing(voicing)
                         },
                     )
-                    NAV_PLAY_ALONG -> PlayAlongSetup(
+                    NavSection.PLAY_ALONG -> PlayAlongSetup(
                         tuning = fretboardViewModel.tuning,
                         onPlayVoicing = { voicing ->
                             fretboardViewModel.playVoicing(voicing)
                         },
                     )
-                    NAV_ACHIEVEMENTS -> {
+                    NavSection.ACHIEVEMENTS -> {
                         val progressState by learningProgressViewModel.state.collectAsState()
                         val sheetsState by songbookViewModel.sheets.collectAsState()
                         val achievementContext = progressState.toAchievementContext(
@@ -612,16 +614,16 @@ fun FretboardScreen(
                             favoritesCount = currentFavorites.size,
                         )
                     }
-                    NAV_HELP -> HelpView()
+                    NavSection.HELP -> HelpView()
                 }
             }
         }
     }
 
-    val drawerItemOnClick: (Int) -> Unit = { index ->
+    val drawerItemOnClick: (NavSection) -> Unit = { section ->
         previousSection = null
-        selectedSection = index
-        if (index in PLAY_CREATE_NAV_INDICES) {
+        selectedSection = section
+        if (section in PLAY_CREATE_SECTIONS) {
             reviewPromptRepository.recordActiveDay()
         }
         if (!isTabletWidth) scope.launch { drawerState.close() }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/NavigationConstants.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/NavigationConstants.kt
@@ -18,48 +18,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import com.baijum.ukufretboard.R
+import com.baijum.ukufretboard.data.NavSection
 import com.baijum.ukufretboard.domain.ChordNameParser
 import com.baijum.ukufretboard.viewmodel.ChordLibraryViewModel
 
-internal const val NAV_EXPLORER = 0
-internal const val NAV_LIBRARY = 1
-internal const val NAV_PATTERNS = 2
-internal const val NAV_PROGRESSIONS = 3
-internal const val NAV_FAVORITES = 4
-internal const val NAV_SONGBOOK = 5
-internal const val NAV_CAPO_GUIDE = 6
-internal const val NAV_CIRCLE_OF_FIFTHS = 7
-internal const val NAV_THEORY_QUIZ = 8
-internal const val NAV_INTERVAL_TRAINER = 9
-internal const val NAV_CHORD_SUBS = 10
-internal const val NAV_THEORY_LESSONS = 11
-internal const val NAV_MELODY_NOTEPAD = 12
-internal const val NAV_TUNER = 13
-internal const val NAV_LEARNING_PROGRESS = 14
-internal const val NAV_SCALE_CHORDS = 15
-internal const val NAV_GLOSSARY = 16
-internal const val NAV_NOTE_MAP = 17
-internal const val NAV_NOTE_QUIZ = 18
-internal const val NAV_CHORD_EAR = 19
-internal const val NAV_HELP = 20
-internal const val NAV_PITCH_MONITOR = 21
-internal const val NAV_SCALE_PRACTICE = 22
-internal const val NAV_ACHIEVEMENTS = 23
-internal const val NAV_CHORD_TRANSITION = 25
-internal const val NAV_DAILY_CHALLENGE = 26
-internal const val NAV_SONGWRITER_MODE = 27
-internal const val NAV_PRACTICE_ROUTINE = 28
-internal const val NAV_PLAY_ALONG = 29
-internal const val NAV_METRONOME = 30
-internal const val NAV_SETLISTS = 31
-
-internal val PLAY_CREATE_NAV_INDICES = setOf(
-    NAV_EXPLORER, NAV_TUNER, NAV_PITCH_MONITOR, NAV_METRONOME, NAV_LIBRARY, NAV_FAVORITES,
-    NAV_SONGWRITER_MODE, NAV_SONGBOOK, NAV_MELODY_NOTEPAD, NAV_PATTERNS, NAV_PROGRESSIONS,
+internal val PLAY_CREATE_SECTIONS = setOf(
+    NavSection.EXPLORER, NavSection.TUNER, NavSection.PITCH_MONITOR, NavSection.METRONOME,
+    NavSection.LIBRARY, NavSection.FAVORITES, NavSection.SONGWRITER_MODE, NavSection.SONGBOOK,
+    NavSection.MELODY_NOTEPAD, NavSection.PATTERNS, NavSection.PROGRESSIONS,
 )
 
 internal data class DrawerItem(
-    val index: Int,
+    val section: NavSection,
     val label: String,
     val icon: ImageVector,
 )
@@ -78,42 +48,42 @@ internal data class SheetVoicingInfo(
 @Composable
 internal fun drawerSections(): List<DrawerSection> = listOf(
     DrawerSection(stringResource(R.string.nav_section_play), listOf(
-        DrawerItem(NAV_EXPLORER, stringResource(R.string.nav_explorer), Icons.Filled.Home),
-        DrawerItem(NAV_TUNER, stringResource(R.string.nav_tuner), Icons.Filled.Mic),
-        DrawerItem(NAV_PITCH_MONITOR, stringResource(R.string.nav_pitch_monitor), Icons.Filled.Equalizer),
-        DrawerItem(NAV_METRONOME, stringResource(R.string.nav_metronome), Icons.Filled.Speed),
-        DrawerItem(NAV_LIBRARY, stringResource(R.string.nav_chords), Icons.Filled.Search),
-        DrawerItem(NAV_FAVORITES, stringResource(R.string.nav_favorites), Icons.Filled.Favorite),
+        DrawerItem(NavSection.EXPLORER, stringResource(R.string.nav_explorer), Icons.Filled.Home),
+        DrawerItem(NavSection.TUNER, stringResource(R.string.nav_tuner), Icons.Filled.Mic),
+        DrawerItem(NavSection.PITCH_MONITOR, stringResource(R.string.nav_pitch_monitor), Icons.Filled.Equalizer),
+        DrawerItem(NavSection.METRONOME, stringResource(R.string.nav_metronome), Icons.Filled.Speed),
+        DrawerItem(NavSection.LIBRARY, stringResource(R.string.nav_chords), Icons.Filled.Search),
+        DrawerItem(NavSection.FAVORITES, stringResource(R.string.nav_favorites), Icons.Filled.Favorite),
     )),
     DrawerSection(stringResource(R.string.nav_section_create), listOf(
-        DrawerItem(NAV_SONGWRITER_MODE, stringResource(R.string.nav_songwriter_mode), Icons.Filled.Create),
-        DrawerItem(NAV_SONGBOOK, stringResource(R.string.nav_songs), Icons.Filled.Create),
-        DrawerItem(NAV_SETLISTS, stringResource(R.string.nav_setlists), Icons.AutoMirrored.Filled.List),
-        DrawerItem(NAV_MELODY_NOTEPAD, stringResource(R.string.nav_melody_notepad), Icons.Filled.Create),
-        DrawerItem(NAV_PATTERNS, stringResource(R.string.nav_patterns), Icons.AutoMirrored.Filled.List),
-        DrawerItem(NAV_PROGRESSIONS, stringResource(R.string.nav_progressions), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.SONGWRITER_MODE, stringResource(R.string.nav_songwriter_mode), Icons.Filled.Create),
+        DrawerItem(NavSection.SONGBOOK, stringResource(R.string.nav_songs), Icons.Filled.Create),
+        DrawerItem(NavSection.SETLISTS, stringResource(R.string.nav_setlists), Icons.AutoMirrored.Filled.List),
+        DrawerItem(NavSection.MELODY_NOTEPAD, stringResource(R.string.nav_melody_notepad), Icons.Filled.Create),
+        DrawerItem(NavSection.PATTERNS, stringResource(R.string.nav_patterns), Icons.AutoMirrored.Filled.List),
+        DrawerItem(NavSection.PROGRESSIONS, stringResource(R.string.nav_progressions), Icons.Filled.PlayArrow),
     )),
     DrawerSection(stringResource(R.string.nav_section_learn), listOf(
-        DrawerItem(NAV_THEORY_LESSONS, stringResource(R.string.nav_learn_theory), Icons.Filled.Info),
-        DrawerItem(NAV_THEORY_QUIZ, stringResource(R.string.nav_theory_quiz), Icons.Filled.Create),
-        DrawerItem(NAV_INTERVAL_TRAINER, stringResource(R.string.nav_interval_trainer), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_NOTE_QUIZ, stringResource(R.string.nav_note_quiz), Icons.Filled.Search),
-        DrawerItem(NAV_CHORD_EAR, stringResource(R.string.nav_chord_ear_training), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_SCALE_PRACTICE, stringResource(R.string.nav_scale_practice), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_LEARNING_PROGRESS, stringResource(R.string.nav_progress), Icons.Filled.Favorite),
-        DrawerItem(NAV_DAILY_CHALLENGE, stringResource(R.string.nav_daily_challenge), Icons.Filled.Star),
-        DrawerItem(NAV_PRACTICE_ROUTINE, stringResource(R.string.nav_practice_routine), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_CHORD_TRANSITION, stringResource(R.string.nav_chord_transitions), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_PLAY_ALONG, stringResource(R.string.nav_play_along), Icons.Filled.Mic),
-        DrawerItem(NAV_ACHIEVEMENTS, stringResource(R.string.nav_achievements), Icons.Filled.Star),
+        DrawerItem(NavSection.THEORY_LESSONS, stringResource(R.string.nav_learn_theory), Icons.Filled.Info),
+        DrawerItem(NavSection.THEORY_QUIZ, stringResource(R.string.nav_theory_quiz), Icons.Filled.Create),
+        DrawerItem(NavSection.INTERVAL_TRAINER, stringResource(R.string.nav_interval_trainer), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.NOTE_QUIZ, stringResource(R.string.nav_note_quiz), Icons.Filled.Search),
+        DrawerItem(NavSection.CHORD_EAR, stringResource(R.string.nav_chord_ear_training), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.SCALE_PRACTICE, stringResource(R.string.nav_scale_practice), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.LEARNING_PROGRESS, stringResource(R.string.nav_progress), Icons.Filled.Favorite),
+        DrawerItem(NavSection.DAILY_CHALLENGE, stringResource(R.string.nav_daily_challenge), Icons.Filled.Star),
+        DrawerItem(NavSection.PRACTICE_ROUTINE, stringResource(R.string.nav_practice_routine), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.CHORD_TRANSITION, stringResource(R.string.nav_chord_transitions), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.PLAY_ALONG, stringResource(R.string.nav_play_along), Icons.Filled.Mic),
+        DrawerItem(NavSection.ACHIEVEMENTS, stringResource(R.string.nav_achievements), Icons.Filled.Star),
     )),
     DrawerSection(stringResource(R.string.nav_section_reference), listOf(
-        DrawerItem(NAV_CAPO_GUIDE, stringResource(R.string.nav_capo_guide), Icons.Filled.Info),
-        DrawerItem(NAV_CIRCLE_OF_FIFTHS, stringResource(R.string.nav_circle_of_fifths), Icons.Filled.Refresh),
-        DrawerItem(NAV_CHORD_SUBS, stringResource(R.string.nav_chord_substitutions), Icons.AutoMirrored.Filled.List),
-        DrawerItem(NAV_SCALE_CHORDS, stringResource(R.string.nav_chords_in_scale), Icons.Filled.PlayArrow),
-        DrawerItem(NAV_NOTE_MAP, stringResource(R.string.nav_fretboard_notes), Icons.Filled.Search),
-        DrawerItem(NAV_GLOSSARY, stringResource(R.string.nav_glossary), Icons.Filled.Info),
+        DrawerItem(NavSection.CAPO_GUIDE, stringResource(R.string.nav_capo_guide), Icons.Filled.Info),
+        DrawerItem(NavSection.CIRCLE_OF_FIFTHS, stringResource(R.string.nav_circle_of_fifths), Icons.Filled.Refresh),
+        DrawerItem(NavSection.CHORD_SUBS, stringResource(R.string.nav_chord_substitutions), Icons.AutoMirrored.Filled.List),
+        DrawerItem(NavSection.SCALE_CHORDS, stringResource(R.string.nav_chords_in_scale), Icons.Filled.PlayArrow),
+        DrawerItem(NavSection.NOTE_MAP, stringResource(R.string.nav_fretboard_notes), Icons.Filled.Search),
+        DrawerItem(NavSection.GLOSSARY, stringResource(R.string.nav_glossary), Icons.Filled.Info),
     )),
 )
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/DailyChallengeGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/DailyChallengeGenerator.kt
@@ -32,14 +32,14 @@ object DailyChallengeGenerator {
      * @property title Display title.
      * @property description What the user should do.
      * @property targetCount How many repetitions/correct answers to achieve.
-     * @property navTarget The navigation target index (if applicable).
+     * @property navTarget The navigation section to open (if applicable).
      */
     data class DailyChallenge(
         val type: ChallengeType,
         val title: String,
         val description: String,
         val targetCount: Int = 1,
-        val navTarget: Int? = null,
+        val navTarget: NavSection? = null,
     )
 
     /**
@@ -86,7 +86,7 @@ object DailyChallengeGenerator {
                 type = type,
                 title = "Learn $chordName",
                 description = "Find and practice the $chordName chord. Try all voicings!",
-                navTarget = 1, // NAV_LIBRARY
+                navTarget = NavSection.LIBRARY,
             )
         }
         ChallengeType.THEORY_QUIZ -> {
@@ -96,7 +96,7 @@ object DailyChallengeGenerator {
                 title = "Theory Quiz: $count Questions",
                 description = "Answer $count theory quiz questions correctly.",
                 targetCount = count,
-                navTarget = 8, // NAV_THEORY_QUIZ
+                navTarget = NavSection.THEORY_QUIZ,
             )
         }
         ChallengeType.PRACTICE_SONG -> {
@@ -104,7 +104,7 @@ object DailyChallengeGenerator {
                 type = type,
                 title = "Practice a Song",
                 description = "Open the songbook and practice any song for 5 minutes.",
-                navTarget = 5, // NAV_SONGBOOK
+                navTarget = NavSection.SONGBOOK,
             )
         }
         ChallengeType.SCALE_PRACTICE -> {
@@ -114,7 +114,7 @@ object DailyChallengeGenerator {
                 type = type,
                 title = "Scale: $scale",
                 description = "Practice the $scale scale in at least 2 different keys.",
-                navTarget = 22, // NAV_SCALE_PRACTICE
+                navTarget = NavSection.SCALE_PRACTICE,
             )
         }
         ChallengeType.CHORD_TRANSITION -> {
@@ -127,7 +127,7 @@ object DailyChallengeGenerator {
                 title = "Switch: $root1$quality to $root2",
                 description = "Practice switching between $root1$quality and $root2 at 60 BPM. Aim for 20 switches per minute.",
                 targetCount = 20,
-                navTarget = 25, // NAV_CHORD_TRANSITION
+                navTarget = NavSection.CHORD_TRANSITION,
             )
         }
         ChallengeType.EAR_TRAINING -> {
@@ -137,7 +137,7 @@ object DailyChallengeGenerator {
                 title = "Ear Training: $count Rounds",
                 description = "Complete $count rounds of ear training with at least 60% accuracy.",
                 targetCount = count,
-                navTarget = 19, // NAV_CHORD_EAR
+                navTarget = NavSection.CHORD_EAR,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/NavSection.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/NavSection.kt
@@ -1,0 +1,46 @@
+package com.baijum.ukufretboard.data
+
+/**
+ * Navigation sections in the app. Each entry has a stable [id] used for
+ * persisting the selected section across configuration changes and process death.
+ */
+enum class NavSection(val id: Int) {
+    EXPLORER(0),
+    LIBRARY(1),
+    PATTERNS(2),
+    PROGRESSIONS(3),
+    FAVORITES(4),
+    SONGBOOK(5),
+    CAPO_GUIDE(6),
+    CIRCLE_OF_FIFTHS(7),
+    THEORY_QUIZ(8),
+    INTERVAL_TRAINER(9),
+    CHORD_SUBS(10),
+    THEORY_LESSONS(11),
+    MELODY_NOTEPAD(12),
+    TUNER(13),
+    LEARNING_PROGRESS(14),
+    SCALE_CHORDS(15),
+    GLOSSARY(16),
+    NOTE_MAP(17),
+    NOTE_QUIZ(18),
+    CHORD_EAR(19),
+    HELP(20),
+    PITCH_MONITOR(21),
+    SCALE_PRACTICE(22),
+    ACHIEVEMENTS(23),
+    CHORD_TRANSITION(25),
+    DAILY_CHALLENGE(26),
+    SONGWRITER_MODE(27),
+    PRACTICE_ROUTINE(28),
+    PLAY_ALONG(29),
+    METRONOME(30),
+    SETLISTS(31),
+    ;
+
+    companion object {
+        private val byId = entries.associateBy { it.id }
+
+        fun fromId(id: Int): NavSection? = byId[id]
+    }
+}

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
@@ -1,6 +1,7 @@
 package com.baijum.ukufretboard.domain
 
 import com.baijum.ukufretboard.data.ChordFormulas
+import com.baijum.ukufretboard.data.NavSection
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.platform.currentTimeMillis
 import kotlin.random.Random
@@ -113,7 +114,7 @@ object PracticeRoutineGenerator {
                 title = "Chord Transition: $chord1 ↔ $chord2",
                 description = "Switch between $chord1 and $chord2 with a metronome. Start at 60 BPM and increase by 10 each minute.",
                 durationMinutes = minutes,
-                navTarget = 25, // NAV_CHORD_TRANSITION
+                navTarget = NavSection.CHORD_TRANSITION,
             )
         }
         StepType.SCALE_PRACTICE -> {
@@ -128,7 +129,7 @@ object PracticeRoutineGenerator {
                 title = "Scale: $scale",
                 description = "Play the $scale scale ascending and descending. Try in different positions on the fretboard.",
                 durationMinutes = minutes,
-                navTarget = 22, // NAV_SCALE_PRACTICE
+                navTarget = NavSection.SCALE_PRACTICE,
             )
         }
         StepType.EAR_TRAINING -> {
@@ -137,7 +138,7 @@ object PracticeRoutineGenerator {
                 title = "Ear Training",
                 description = "Identify intervals and chord types by ear. Focus on getting at least 70% correct.",
                 durationMinutes = minutes,
-                navTarget = 19, // NAV_CHORD_EAR
+                navTarget = NavSection.CHORD_EAR,
             )
         }
         StepType.THEORY_QUIZ -> {
@@ -146,7 +147,7 @@ object PracticeRoutineGenerator {
                 title = "Theory Check",
                 description = "Answer theory questions to reinforce your knowledge. Aim for a 5-question streak!",
                 durationMinutes = minutes,
-                navTarget = 8, // NAV_THEORY_QUIZ
+                navTarget = NavSection.THEORY_QUIZ,
             )
         }
         StepType.SONG_PRACTICE -> {
@@ -155,7 +156,7 @@ object PracticeRoutineGenerator {
                 title = "Song Practice",
                 description = "Pick a song from your songbook and play through it. Focus on smooth chord changes.",
                 durationMinutes = minutes,
-                navTarget = 5, // NAV_SONGBOOK
+                navTarget = NavSection.SONGBOOK,
             )
         }
 
@@ -223,5 +224,5 @@ data class PracticeStep(
     val title: String,
     val description: String,
     val durationMinutes: Int,
-    val navTarget: Int?,
+    val navTarget: NavSection?,
 )


### PR DESCRIPTION
## Summary

- Introduces `NavSection` enum in the shared KMP module with stable integer IDs for backward-compatible `rememberSaveable` state persistence
- Replaces all 30 `NAV_*` integer constants with exhaustive enum cases — the compiler now catches missing navigation branches
- Updates `DrawerItem.index: Int` to `DrawerItem.section: NavSection`
- Renames `PLAY_CREATE_NAV_INDICES` to `PLAY_CREATE_SECTIONS` (now `Set<NavSection>`)
- Types `DailyChallenge.navTarget` and `PracticeStep.navTarget` as `NavSection?` instead of `Int?`
- Types `DailyChallengeView`/`PracticeRoutineView` `onNavigate` callbacks as `(NavSection) -> Unit`

## Impact

- Eliminates the index 24 gap problem
- Adding/removing nav items no longer requires index arithmetic
- `when` blocks are now exhaustive (compiler-enforced)

## Test plan

- [x] Shared module builds and tests pass (`./gradlew :shared:build`)
- [x] Android builds without errors (`./gradlew compileDebugKotlin`)
- [x] All unit tests pass (`./gradlew testDebugUnitTest`)

Fixes #401

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation system architecture for enhanced type safety and state management reliability across the app
  * Upgraded navigation state persistence with better recovery handling during app lifecycle changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->