### PR TITLE
Refactor: migrate FavoritesRepository from pipe-delimited to JSON serialization

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
@@ -3,28 +3,39 @@ package com.baijum.ukufretboard.data
 import android.content.Context
 import android.content.SharedPreferences
 import com.baijum.ukufretboard.domain.mergeKeepExisting
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 
 /**
  * Repository for persisting favorite voicings using SharedPreferences.
  *
- * Each favorite is stored as a key-value pair where the key is derived from
- * the voicing's root, symbol, and frets, and the value is a serialized string.
- *
- * This is intentionally simple (no Room, no DataStore) to avoid adding
- * dependencies for what is essentially a small list.
+ * Stores favorites as a single JSON array under [KEY_FAVORITES] and folders
+ * as a single JSON array under [KEY_FOLDERS]. On first access, transparently
+ * migrates from the legacy per-entry pipe-delimited format.
  */
 class FavoritesRepository(context: Context) {
 
     private val prefs: SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+    private val folderPrefs: SharedPreferences =
+        context.getSharedPreferences(FOLDER_PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    // ── Voicing CRUD ─────────────────────────────────────────────────
+
     /**
      * Returns all saved favorites, sorted by time added (newest first).
      */
     fun getAll(): List<FavoriteVoicing> {
-        return prefs.all.entries
-            .mapNotNull { (_, value) -> deserialize(value as? String) }
-            .sortedByDescending { it.addedAt }
+        val raw = prefs.getString(KEY_FAVORITES, null)
+        if (raw != null) {
+            return tryParseVoicings(raw)
+                ?: tryParseVoicings(prefs.getString(BACKUP_KEY_FAVORITES, null))
+                ?: migrateLegacyVoicings()
+        }
+        return migrateLegacyVoicings()
     }
 
     /**
@@ -32,7 +43,9 @@ class FavoritesRepository(context: Context) {
      */
     fun add(voicing: FavoriteVoicing) {
         if (!contains(voicing)) {
-            prefs.edit().putString(voicing.key, serialize(voicing)).apply()
+            val items = getAll().toMutableList()
+            items.add(0, voicing)
+            persistVoicings(items)
         }
     }
 
@@ -40,12 +53,11 @@ class FavoritesRepository(context: Context) {
      * Removes a voicing from favorites. Also removes its key from any folder ordering.
      */
     fun remove(voicing: FavoriteVoicing) {
-        prefs.edit().remove(voicing.key).apply()
-        // Clean up ordering in all folders that referenced this voicing
+        persistVoicings(getAll().filter { it.key != voicing.key })
         getAllFolders().forEach { folder ->
             if (voicing.key in folder.voicingOrder) {
                 val updated = folder.copy(voicingOrder = folder.voicingOrder - voicing.key)
-                saveFolder(updated)
+                saveFolderInternal(updated, getAllFolders().map { if (it.id == updated.id) updated else it })
             }
         }
     }
@@ -54,14 +66,14 @@ class FavoritesRepository(context: Context) {
      * Checks if a voicing is already in favorites.
      */
     fun contains(voicing: FavoriteVoicing): Boolean =
-        prefs.contains(voicing.key)
+        getAll().any { it.key == voicing.key }
 
     /**
      * Checks if a voicing with the given root, symbol, and frets is in favorites.
      */
     fun contains(rootPitchClass: Int, chordSymbol: String, frets: List<Int>): Boolean {
         val key = "$rootPitchClass|$chordSymbol|${frets.joinToString(",")}"
-        return prefs.contains(key)
+        return getAll().any { it.key == key }
     }
 
     /**
@@ -71,110 +83,192 @@ class FavoritesRepository(context: Context) {
         val oldFolderIds = voicing.folderIds.toSet()
         val newFolderIds = folderIds.toSet()
         val updated = voicing.copy(folderIds = folderIds)
-        prefs.edit().putString(updated.key, serialize(updated)).apply()
+        val items = getAll().toMutableList()
+        val index = items.indexOfFirst { it.key == updated.key }
+        if (index >= 0) items[index] = updated
+        persistVoicings(items)
 
-        // Append voicing key to newly added folders' ordering
         val addedTo = newFolderIds - oldFolderIds
         val removedFrom = oldFolderIds - newFolderIds
-        val allFolders = getAllFolders()
-        allFolders.forEach { folder ->
+        val allFolders = getAllFolders().toMutableList()
+        var foldersChanged = false
+        allFolders.forEachIndexed { i, folder ->
             when (folder.id) {
                 in addedTo -> {
                     if (voicing.key !in folder.voicingOrder) {
-                        saveFolder(folder.copy(voicingOrder = folder.voicingOrder + voicing.key))
+                        allFolders[i] = folder.copy(voicingOrder = folder.voicingOrder + voicing.key)
+                        foldersChanged = true
                     }
                 }
                 in removedFrom -> {
                     if (voicing.key in folder.voicingOrder) {
-                        saveFolder(folder.copy(voicingOrder = folder.voicingOrder - voicing.key))
+                        allFolders[i] = folder.copy(voicingOrder = folder.voicingOrder - voicing.key)
+                        foldersChanged = true
                     }
                 }
             }
         }
+        if (foldersChanged) persistFolders(allFolders)
     }
 
     // ── Folder management ───────────────────────────────────────────
 
-    private val folderPrefs: SharedPreferences =
-        context.getSharedPreferences(FOLDER_PREFS_NAME, Context.MODE_PRIVATE)
-
     fun getAllFolders(): List<FavoriteFolder> {
-        return folderPrefs.all.entries
-            .mapNotNull { (_, value) -> deserializeFolder(value as? String) }
-            .sortedBy { it.name }
+        val raw = folderPrefs.getString(KEY_FOLDERS, null)
+        if (raw != null) {
+            return tryParseFolders(raw)
+                ?: tryParseFolders(folderPrefs.getString(BACKUP_KEY_FOLDERS, null))
+                ?: migrateLegacyFolders()
+        }
+        return migrateLegacyFolders()
     }
 
     fun saveFolder(folder: FavoriteFolder) {
-        folderPrefs.edit().putString(folder.id, serializeFolder(folder)).apply()
+        val items = getAllFolders().toMutableList()
+        val index = items.indexOfFirst { it.id == folder.id }
+        if (index >= 0) items[index] = folder else items.add(folder)
+        persistFolders(items)
     }
 
     fun renameFolder(folderId: String, newName: String) {
-        val folder = getAllFolders().firstOrNull { it.id == folderId } ?: return
-        saveFolder(folder.copy(name = newName))
+        val folders = getAllFolders().toMutableList()
+        val index = folders.indexOfFirst { it.id == folderId }
+        if (index < 0) return
+        folders[index] = folders[index].copy(name = newName)
+        persistFolders(folders)
     }
 
     fun deleteFolder(folderId: String) {
-        folderPrefs.edit().remove(folderId).apply()
-        // Remove this folder ID from all voicings that reference it
-        getAll().filter { folderId in it.folderIds }.forEach { voicing ->
-            val updated = voicing.copy(folderIds = voicing.folderIds - folderId)
-            prefs.edit().putString(updated.key, serialize(updated)).apply()
+        persistFolders(getAllFolders().filter { it.id != folderId })
+        val voicings = getAll()
+        val updated = voicings.map { v ->
+            if (folderId in v.folderIds) v.copy(folderIds = v.folderIds - folderId) else v
         }
+        if (updated != voicings) persistVoicings(updated)
     }
 
     /**
      * Overwrites the voicing ordering for a folder.
      */
     fun reorderVoicingsInFolder(folderId: String, orderedKeys: List<String>) {
-        val folder = getAllFolders().firstOrNull { it.id == folderId } ?: return
-        saveFolder(folder.copy(voicingOrder = orderedKeys))
+        val folders = getAllFolders().toMutableList()
+        val index = folders.indexOfFirst { it.id == folderId }
+        if (index < 0) return
+        folders[index] = folders[index].copy(voicingOrder = orderedKeys)
+        persistFolders(folders)
     }
 
-    // ── Folder serialization ────────────────────────────────────────
+    // ── Import (backup/restore) ─────────────────────────────────────
 
-    private fun serializeFolder(folder: FavoriteFolder): String {
-        val orderStr = folder.voicingOrder.joinToString(";")
-        return "${folder.id}|||${folder.name}|||${folder.createdAt}|||$orderStr"
+    /**
+     * Merges the given list of favorites into local storage using merge-by-ID.
+     * Keeps the existing version when a voicing exists in both.
+     */
+    fun importAll(favorites: List<FavoriteVoicing>) {
+        val merged = mergeKeepExisting(
+            existing = getAll(),
+            incoming = favorites,
+            idOf = { it.key },
+        )
+        persistVoicings(merged)
     }
 
-    private fun deserializeFolder(value: String?): FavoriteFolder? {
-        if (value == null) return null
-        val parts = value.split("|||")
-        if (parts.size < 3) return null
+    /**
+     * Merges the given list of folders into local storage.
+     * Only adds folders that are not already present.
+     */
+    fun importFolders(folders: List<FavoriteFolder>) {
+        val merged = mergeKeepExisting(
+            existing = getAllFolders(),
+            incoming = folders,
+            idOf = { it.id },
+        )
+        persistFolders(merged)
+    }
+
+    // ── JSON persistence ────────────────────────────────────────────
+
+    private fun persistVoicings(items: List<FavoriteVoicing>) {
+        val raw = json.encodeToString(ListSerializer(FavoriteVoicing.serializer()), items)
+        val previousGood = prefs.getString(KEY_FAVORITES, null)
+        prefs.edit()
+            .putString(BACKUP_KEY_FAVORITES, previousGood ?: raw)
+            .putString(KEY_FAVORITES, raw)
+            .apply()
+    }
+
+    private fun persistFolders(items: List<FavoriteFolder>) {
+        val raw = json.encodeToString(ListSerializer(FavoriteFolder.serializer()), items)
+        val previousGood = folderPrefs.getString(KEY_FOLDERS, null)
+        folderPrefs.edit()
+            .putString(BACKUP_KEY_FOLDERS, previousGood ?: raw)
+            .putString(KEY_FOLDERS, raw)
+            .apply()
+    }
+
+    private fun tryParseVoicings(raw: String?): List<FavoriteVoicing>? {
+        if (raw == null) return null
         return try {
-            val order = if (parts.size >= 4 && parts[3].isNotEmpty()) {
-                parts[3].split(";")
-            } else {
-                emptyList()
-            }
-            FavoriteFolder(
-                id = parts[0],
-                name = parts[1],
-                createdAt = parts[2].toLong(),
-                voicingOrder = order,
-            )
-        } catch (_: Exception) { null }
+            json.decodeFromString(ListSerializer(FavoriteVoicing.serializer()), raw)
+        } catch (_: Exception) {
+            null
+        }
     }
 
-    // ── Voicing serialization ───────────────────────────────────────
-
-    private fun serialize(voicing: FavoriteVoicing): String {
-        val folderStr = voicing.folderIds.joinToString(";")
-        return "${voicing.rootPitchClass}|${voicing.chordSymbol}|${voicing.frets.joinToString(",")}|${voicing.addedAt}|$folderStr"
+    private fun tryParseFolders(raw: String?): List<FavoriteFolder>? {
+        if (raw == null) return null
+        return try {
+            json.decodeFromString(ListSerializer(FavoriteFolder.serializer()), raw)
+        } catch (_: Exception) {
+            null
+        }
     }
 
-    private fun deserialize(value: String?): FavoriteVoicing? {
+    // ── Legacy pipe-delimited migration ─────────────────────────────
+
+    private fun migrateLegacyVoicings(): List<FavoriteVoicing> {
+        val entries = prefs.all.entries
+            .filter { it.key != KEY_FAVORITES && it.key != BACKUP_KEY_FAVORITES }
+            .mapNotNull { (_, value) -> deserializeLegacyVoicing(value as? String) }
+            .sortedByDescending { it.addedAt }
+        if (entries.isNotEmpty()) {
+            persistVoicings(entries)
+            val editor = prefs.edit()
+            prefs.all.keys
+                .filter { it != KEY_FAVORITES && it != BACKUP_KEY_FAVORITES }
+                .forEach { editor.remove(it) }
+            editor.apply()
+        }
+        return entries
+    }
+
+    private fun migrateLegacyFolders(): List<FavoriteFolder> {
+        val entries = folderPrefs.all.entries
+            .filter { it.key != KEY_FOLDERS && it.key != BACKUP_KEY_FOLDERS }
+            .mapNotNull { (_, value) -> deserializeLegacyFolder(value as? String) }
+            .sortedBy { it.name }
+        if (entries.isNotEmpty()) {
+            persistFolders(entries)
+            val editor = folderPrefs.edit()
+            folderPrefs.all.keys
+                .filter { it != KEY_FOLDERS && it != BACKUP_KEY_FOLDERS }
+                .forEach { editor.remove(it) }
+            editor.apply()
+        }
+        return entries
+    }
+
+    private fun deserializeLegacyVoicing(value: String?): FavoriteVoicing? {
         if (value == null) return null
         val parts = value.split("|")
         if (parts.size < 4) return null
         return try {
-            // Backward compat: old format had single folderId, new format has semicolon-joined list
             val folderField = parts.getOrNull(4)?.ifEmpty { null }
             val folderIds = if (folderField != null) {
                 if (";" in folderField) {
                     folderField.split(";")
                 } else {
-                    listOf(folderField) // single old-format folderId
+                    listOf(folderField)
                 }
             } else {
                 emptyList()
@@ -191,42 +285,37 @@ class FavoritesRepository(context: Context) {
         }
     }
 
-    /**
-     * Merges the given list of favorites into local storage using merge-by-ID.
-     * Keeps the newer version (by addedAt) when a voicing exists in both.
-     */
-    fun importAll(favorites: List<FavoriteVoicing>) {
-        val merged = mergeKeepExisting(
-            existing = getAll(),
-            incoming = favorites,
-            idOf = { it.key },
-        )
-        val editor = prefs.edit()
-        for (voicing in merged) {
-            editor.putString(voicing.key, serialize(voicing))
+    private fun deserializeLegacyFolder(value: String?): FavoriteFolder? {
+        if (value == null) return null
+        val parts = value.split("|||")
+        if (parts.size < 3) return null
+        return try {
+            val order = if (parts.size >= 4 && parts[3].isNotEmpty()) {
+                parts[3].split(";")
+            } else {
+                emptyList()
+            }
+            FavoriteFolder(
+                id = parts[0],
+                name = parts[1],
+                createdAt = parts[2].toLong(),
+                voicingOrder = order,
+            )
+        } catch (_: Exception) {
+            null
         }
-        editor.apply()
     }
 
-    /**
-     * Merges the given list of folders into local storage.
-     * Only adds folders that are not already present.
-     */
-    fun importFolders(folders: List<FavoriteFolder>) {
-        val merged = mergeKeepExisting(
-            existing = getAllFolders(),
-            incoming = folders,
-            idOf = { it.id },
-        )
-        val editor = folderPrefs.edit()
-        for (folder in merged) {
-            editor.putString(folder.id, serializeFolder(folder))
-        }
-        editor.apply()
+    private fun saveFolderInternal(folder: FavoriteFolder, allFolders: List<FavoriteFolder>) {
+        persistFolders(allFolders)
     }
 
     companion object {
         private const val PREFS_NAME = "chord_favorites"
+        private const val KEY_FAVORITES = "favorites_json"
+        private const val BACKUP_KEY_FAVORITES = "favorites_json_backup"
         private const val FOLDER_PREFS_NAME = "favorite_folders"
+        private const val KEY_FOLDERS = "folders_json"
+        private const val BACKUP_KEY_FOLDERS = "folders_json_backup"
     }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/RepositorySerializationTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/RepositorySerializationTest.kt
@@ -104,6 +104,75 @@ class RepositorySerializationTest {
         assertEquals("Existing", all.first { it.id == "f1" }.name)
     }
 
+    @Test
+    fun favoritesLegacyPipeMigration() {
+        val prefs = context.getSharedPreferences("chord_favorites", 0)
+        prefs.edit()
+            .putString("0|m7|0,2,3,3", "0|m7|0,2,3,3|1000|f1;f2")
+            .putString("4|m|0,4,3,2", "4|m|0,4,3,2|2000|")
+            .apply()
+
+        val repo = FavoritesRepository(context)
+        val all = repo.getAll()
+        assertEquals(2, all.size)
+        val v1 = all.first { it.rootPitchClass == 0 }
+        assertEquals("m7", v1.chordSymbol)
+        assertEquals(listOf(0, 2, 3, 3), v1.frets)
+        assertEquals(1000L, v1.addedAt)
+        assertEquals(listOf("f1", "f2"), v1.folderIds)
+        val v2 = all.first { it.rootPitchClass == 4 }
+        assertTrue(v2.folderIds.isEmpty())
+
+        assertTrue(
+            "Legacy keys should be removed after migration",
+            !prefs.contains("0|m7|0,2,3,3"),
+        )
+        assertTrue(
+            "JSON key should exist after migration",
+            prefs.contains("favorites_json"),
+        )
+    }
+
+    @Test
+    fun favoritesLegacyFolderPipeMigration() {
+        val prefs = context.getSharedPreferences("favorite_folders", 0)
+        prefs.edit()
+            .putString("folder-1", "folder-1|||Jazz Chords|||2000|||0|m7|0,2,3,3;4|m|0,4,3,2")
+            .apply()
+
+        val repo = FavoritesRepository(context)
+        val folders = repo.getAllFolders()
+        assertEquals(1, folders.size)
+        assertEquals("folder-1", folders[0].id)
+        assertEquals("Jazz Chords", folders[0].name)
+        assertEquals(2000L, folders[0].createdAt)
+        assertEquals(2, folders[0].voicingOrder.size)
+
+        assertTrue(
+            "Legacy keys should be removed after migration",
+            !prefs.contains("folder-1"),
+        )
+        assertTrue(
+            "JSON key should exist after migration",
+            prefs.contains("folders_json"),
+        )
+    }
+
+    @Test
+    fun favoritesCorruptJsonFallsBackToBackup() {
+        val repo = FavoritesRepository(context)
+        val voicing = FavoriteVoicing(0, "maj", listOf(0, 0, 0, 3), 100L)
+        repo.add(voicing)
+        assertEquals(1, repo.getAll().size)
+
+        val prefs = context.getSharedPreferences("chord_favorites", 0)
+        prefs.edit().putString("favorites_json", "CORRUPTED").apply()
+
+        val recovered = repo.getAll()
+        assertEquals("Backup key should provide recovery", 1, recovered.size)
+        assertEquals(0, recovered[0].rootPitchClass)
+    }
+
     // ── ChordSheetRepository ─────────────────────────────────────────
 
     @Test

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/FavoriteVoicing.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/FavoriteVoicing.kt
@@ -2,6 +2,8 @@ package com.baijum.ukufretboard.data
 
 import com.baijum.ukufretboard.platform.currentTimeMillis
 import com.baijum.ukufretboard.platform.generateUuid
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * A saved chord voicing in the favorites list.
@@ -12,6 +14,7 @@ import com.baijum.ukufretboard.platform.generateUuid
  * @property addedAt Timestamp when the voicing was saved.
  * @property folderIds IDs of the folders this voicing belongs to. Empty = unfiled.
  */
+@Serializable
 data class FavoriteVoicing(
     val rootPitchClass: Int,
     val chordSymbol: String,
@@ -22,7 +25,8 @@ data class FavoriteVoicing(
     /**
      * A unique key for deduplication: root + symbol + frets.
      */
-    val key: String get() = "$rootPitchClass|$chordSymbol|${frets.joinToString(",")}"
+    @Transient
+    val key: String = "$rootPitchClass|$chordSymbol|${frets.joinToString(",")}"
 }
 
 /**
@@ -33,6 +37,7 @@ data class FavoriteVoicing(
  * @property createdAt Timestamp when the folder was created.
  * @property voicingOrder Ordered list of voicing keys defining display order within the folder.
  */
+@Serializable
 data class FavoriteFolder(
     val id: String = generateUuid(),
     val name: String,


### PR DESCRIPTION
## Summary

Fixes #404

- **Add `@Serializable`** to `FavoriteVoicing` and `FavoriteFolder` in the shared KMP module, aligning them with every other persisted data class
- **Rewrite `FavoritesRepository`** to store favorites and folders as single JSON arrays (with backup keys for data-loss prevention), matching the `JsonListRepository` pattern used by `ChordSheetRepository`, `SetlistRepository`, `CustomStrumPatternRepository`, etc.
- **Add transparent migration** from the legacy per-entry pipe-delimited format: on first read, detect old entries, deserialize, re-persist as JSON, and remove legacy keys
- **Add tests** for legacy pipe-delimited migration (voicings + folders) and corrupt-JSON backup recovery

### Why

`FavoritesRepository` was the last holdout using `|`/`,`/`;` delimited strings for persistence. This made the backup system carry two serialization formats for the same data (the backup already uses JSON via `BackupFavorite`). Migrating to JSON:
- Eliminates delimiter-collision risks (e.g. chord symbols containing `|`)
- Unifies the persistence pattern across all repositories
- Simplifies future maintenance

## Test plan

- [x] `./gradlew compileDebugKotlin` passes
- [x] `./gradlew testDebugUnitTest` passes (all existing + 3 new migration tests)
- [ ] Manual: install old version with pipe-delimited favorites, upgrade to this build, verify favorites and folders appear correctly
- [ ] Manual: verify backup/restore round-trip still works


Made with [Cursor](https://cursor.com)