### PR TITLE
Docs: document ktlint, preflight, and AI-agent guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,10 @@ Skills in `.cursor/skills/` provide step-by-step workflows for common tasks:
 ./gradlew testDebugUnitTest                    # Run unit tests
 ./gradlew connectedAndroidTest                 # Run instrumented tests
 
+# Quality gates (run before submitting)
+scripts/preflight.sh                           # ktlint ratchet + shared tests + unit tests + lint
+scripts/ktlint.sh                              # ktlint check only (-F to auto-format)
+
 # iOS (requires Xcode)
 xcodebuild -project iosApp/UkuleleCompanion.xcodeproj \
   -scheme UkuleleCompanion \
@@ -120,6 +124,9 @@ xcodebuild -project iosApp/UkuleleCompanion.xcodeproj \
 **CI** (GitHub Actions on push/PR to `main`):
 - **Android** (`android.yml`): JDK 17, lint (debug + release), unit tests, shared module tests, debug APK, release APK + R8 mapping, APK size report, instrumented tests (API 26/33/35)
 - **iOS** (`ios.yml`): JDK 17 + Xcode 16.4, shared KMP framework (debug + release), iOS build (debug + release), unit tests
+- **ktlint** (`ktlint.yml`): baseline-aware ratchet on Kotlin changes — fails only on violations beyond `ktlint-baseline.xml`
+
+**Local guardrails (Claude Code):** `.claude/settings.json` wires PreToolUse hooks (`scripts/hooks/`) that block network/analytics/secrets and platform imports in `commonMain`, plus a PostToolUse ktlint-style nudge. Slash commands: `/extract-to-shared`, `/preflight`, `/add-string`. Subagent: `accessibility-reviewer`. These activate at session start; if a hook blocks an edit, it explains why.
 
 **Commit format:**
 ```
@@ -132,6 +139,7 @@ Types: `Add`, `Fix`, `Update`, `Refactor`, `Test`, `Docs`, `Chore`
 ## Pre-Submission Checklist
 
 ### Both platforms
+- [ ] `scripts/preflight.sh` passes (or run the individual gates below)
 - [ ] Shared module builds (`./gradlew :shared:build`)
 - [ ] Both High-G and Low-G tuning work (if chord/note logic changed)
 - [ ] Left-handed mode not broken (if fretboard UI changed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,30 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 - **Pure Domain Logic**: The shared `domain/` package has no platform dependencies, making it easy to test
 - **No Network**: The app is fully offline — do not add network dependencies
 
+### Linting & Pre-Submission Checks
+
+Kotlin style is enforced by **ktlint** through a standalone runner (no Gradle plugin,
+so no impact on dependency locking):
+
+```bash
+scripts/ktlint.sh        # check shared/ + app/ Kotlin sources
+scripts/ktlint.sh -F     # auto-format in place
+```
+
+ktlint uses a **baseline ratchet** (`ktlint-baseline.xml`): pre-existing style findings
+are accepted, so only *new* violations fail. CI runs this check on any PR that touches
+Kotlin. Keep diffs focused — don't reformat unrelated code.
+
+Before opening a PR, run the one-shot pre-submission script:
+
+```bash
+scripts/preflight.sh     # ktlint ratchet + shared KMP tests + Android unit tests + lint
+```
+
+It runs the automated gates (matching CI) and then prints the manual checklist (tuning
+modes, left-handed mode, reduce motion, TalkBack/VoiceOver, themes). iOS build and
+VoiceOver are **not** covered — verify those in Xcode separately.
+
 ## How to Contribute
 
 ### Areas Where Help Is Needed
@@ -153,6 +177,27 @@ When using AI-generated code:
 4. **Adapt it to the codebase** — Ensure it follows the existing patterns (see [Code Guidelines](#code-guidelines))
 5. **Mention AI usage** — You're welcome to note in your PR if AI tools helped, but it's not required
 
+### How This Repo Supports AI Agents
+
+This repository is configured so AI coding agents stay within the project's hard
+constraints automatically:
+
+- **[AGENTS.md](AGENTS.md)** — project-level instructions and constraints (read by Cursor,
+  Copilot, Codex). Claude Code reads it via the `CLAUDE.md` symlink.
+- **`.cursor/rules/*.mdc`** — the canonical, area-scoped coding rules (KMP purity,
+  Compose/SwiftUI accessibility, ViewModels, testing). They auto-attach in Cursor; Claude
+  Code loads them through directory-scoped `CLAUDE.md` pointer files.
+- **Claude Code hooks** (`.claude/settings.json` + `scripts/hooks/`) — block edits that add
+  network/analytics/secrets or platform imports in `commonMain`, and nudge on style. When a
+  hook blocks an edit it explains why.
+- **Slash commands** (`.claude/commands/`) — `/extract-to-shared` (test-first KMP extraction),
+  `/preflight`, `/add-string` (all 16 locales).
+- **`accessibility-reviewer` subagent** — reviews UI diffs against the TalkBack/VoiceOver rules.
+- **CodeRabbit** auto-reviews every PR.
+
+If you use a different AI tool, open the relevant `.cursor/rules/*.mdc` for the area you're
+editing — that's where the detailed rules live.
+
 ## Accessibility Guidelines
 
 This app is actively used by blind and visually impaired musicians with screen readers. **Every code change must preserve accessibility.** See also [AGENTS.md](AGENTS.md) for AI-specific rules.
@@ -193,6 +238,7 @@ This app is actively used by blind and visually impaired musicians with screen r
 - Use **meaningful names** for variables, functions, and classes
 - Prefer **immutable** data (`val`, `data class`, `List` over `MutableList` in public APIs)
 - Use **Kotlin idioms** (`let`, `apply`, `also`, `when`, etc.) where they improve readability
+- Style is checked by **ktlint** — run `scripts/ktlint.sh -F` to auto-format (see [Linting & Pre-Submission Checks](#linting--pre-submission-checks))
 
 ### Jetpack Compose
 
@@ -271,6 +317,7 @@ Docs: Add contributing guidelines
 
 Before submitting, verify:
 
+- [ ] `scripts/preflight.sh` passes (ktlint ratchet, shared + Android unit tests, lint)
 - [ ] Code builds without errors (`./gradlew assembleDebug`)
 - [ ] Changes work on a device or emulator
 - [ ] No new warnings introduced

--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ The Android debug APK will be at `app/build/outputs/apk/debug/app-debug.apk`.
 
 The project includes **property-based tests** using [Kotest](https://kotest.io/docs/proptest/property-based-testing.html) that generate thousands of random inputs to verify invariants in the domain logic (chord detection, transposition, FFT, pitch detection, and more). These run automatically as part of `testDebugUnitTest` and in CI on every push and PR.
 
+### Lint & Pre-Submission
+
+```bash
+scripts/ktlint.sh           # Kotlin style check (-F to auto-format)
+scripts/preflight.sh        # one-shot gate: ktlint + shared tests + unit tests + lint
+```
+
+ktlint runs as a **baseline ratchet** — only violations beyond `ktlint-baseline.xml` fail, and
+CI enforces it on Kotlin changes. Run `scripts/preflight.sh` before opening a PR.
+
 ### Release Build
 
 **Android:**
@@ -299,6 +309,7 @@ We actively encourage contributors to use **AI coding tools** to accelerate thei
 - **Leverage AI for code reviews** — before submitting a PR, ask an AI assistant to review your changes for consistency with the project's patterns.
 - **Use AI to write tests** — expand the existing test suite with new unit tests, property-based fuzz tests, or UI tests.
 - **AI-powered documentation** — use AI tools to help write clear commit messages, PR descriptions, and inline documentation.
+- **Built-in AI guardrails** — `AGENTS.md` and `.cursor/rules/` carry the coding rules, and Claude Code hooks automatically block edits that violate the offline / no-analytics / no-secrets constraints. See [How This Repo Supports AI Agents](CONTRIBUTING.md#how-this-repo-supports-ai-agents).
 
 > **Tip:** This project uses standard Kotlin + Jetpack Compose patterns on Android and SwiftUI on iOS, with shared domain logic via Kotlin Multiplatform. AI tools work exceptionally well with the codebase because it follows consistent conventions throughout.
 
@@ -309,6 +320,7 @@ We actively encourage contributors to use **AI coding tools** to accelerate thei
 - **iOS UI**: SwiftUI
 - **Android state**: ViewModel + StateFlow
 - **iOS state**: ObservableObject + @Published
+- **Linting**: Kotlin style enforced by ktlint via `scripts/ktlint.sh` (baseline ratchet)
 - Follow existing patterns in the codebase — consistency is valued
 
 ### Architecture at a Glance


### PR DESCRIPTION
## What & why

Documents the developer tooling added in #422 (AI-agent maintainability harness) so
contributors — human and AI — can discover it. Docs-only; no code changes.

## Changes

**CONTRIBUTING.md**
- New **Linting & Pre-Submission Checks**: `scripts/ktlint.sh` (baseline ratchet, `-F` to format) and `scripts/preflight.sh` (one-shot gate)
- New **How This Repo Supports AI Agents**: AGENTS.md, `.cursor/rules`, Claude Code hooks/commands/`accessibility-reviewer` subagent, CodeRabbit
- ktlint in Code Guidelines; `scripts/preflight.sh` in the PR checklist

**AGENTS.md**
- `scripts/preflight.sh` + `scripts/ktlint.sh` in build commands; `ktlint.yml` in the CI list; a Local guardrails note; preflight in the checklist

**README.md**
- Lint & Pre-Submission snippet; ktlint in Code Style; AI-guardrails bullet under AI-Assisted Contributing

## Verification
67 insertions, 0 deletions (additive). All internal anchor links resolve; every referenced script/path exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines with detailed linting and pre-submission check instructions to ensure code quality
  * Added comprehensive documentation for AI-assisted development workflows, guardrails, and available commands
  * Enhanced PR submission checklist with explicit pre-submission verification requirements
  * Added lint and pre-submission command references in primary project documentation
  * Clarified baseline ratchet linting approach used in CI/CD pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->