### PR TITLE
Chore: drop API 26 from instrumented test matrix

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -227,7 +227,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        api-level: [26, 33, 35]
+        # API 26 (minSdk) instrumented tests removed: the legacy emulator boots too
+        # slowly on the CI runners and repeatedly exceeded the job timeout. Unit tests
+        # and lint still cover minSdk; instrumented/UI coverage runs on 33 and 35.
+        api-level: [33, 35]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ xcodebuild -project iosApp/UkuleleCompanion.xcodeproj \
 ```
 
 **CI** (GitHub Actions on push/PR to `main`):
-- **Android** (`android.yml`): JDK 17, lint (debug + release), unit tests, shared module tests, debug APK, release APK + R8 mapping, APK size report, instrumented tests (API 26/33/35)
+- **Android** (`android.yml`): JDK 17, lint (debug + release), unit tests, shared module tests, debug APK, release APK + R8 mapping, APK size report, instrumented tests (API 33/35)
 - **iOS** (`ios.yml`): JDK 17 + Xcode 16.4, shared KMP framework (debug + release), iOS build (debug + release), unit tests
 - **ktlint** (`ktlint.yml`): baseline-aware ratchet on Kotlin changes — fails only on violations beyond `ktlint-baseline.xml`
 


### PR DESCRIPTION
## What & why

The API 26 instrumented-test leg has been failing by **timeout, not by test failure**: the legacy API 26 emulator boots too slowly on the CI runners and repeatedly exceeds the 15-minute job timeout (canceled mid-run). API 33 and 35 run the same tests and pass in ~3.5 min each. Most recently this hit PR #424 (a mechanical change that couldn't have broken instrumented tests).

This drops API 26 from the instrumented matrix so it stops being a flaky time-sink.

## Changes
- `android.yml`: `api-level: [26, 33, 35]` → `[33, 35]`, with a comment explaining why.
- `AGENTS.md`: CI description updated to "instrumented tests (API 33/35)".

## Trade-off
`minSdk = 26`, so we lose **instrumented/UI** coverage on the minimum API. Mitigated by: unit tests + Android lint still run against minSdk, and instrumented/UI behavior is covered on API 33/35. The dev-setup "API 26+" device requirement in CONTRIBUTING.md is unchanged (the app still supports API 26+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
