### PR TITLE
Refactor: deduplicate inversion calculation between ChordInfo and ChordNameParser

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
@@ -256,23 +256,22 @@ object ChordInfo {
     ): Inversion {
         val bassPc = bassPitchClass(frets, tuning)
         val interval = (bassPc - rootPitchClass + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
+        return inversionForInterval(interval, formula)
+    }
 
+    /**
+     * Maps a bass interval (semitones above root) to the corresponding [Inversion].
+     *
+     * @param interval Semitone interval from root to bass (0–11).
+     * @param formula The chord formula (used to validate 3rd inversion for 7th chords).
+     */
+    fun inversionForInterval(interval: Int, formula: ChordFormula): Inversion {
         if (interval == 0) return Inversion.ROOT
-
-        // Check if bass interval is a 3rd (minor 3rd = 3, major 3rd = 4)
         if (interval == 3 || interval == 4) return Inversion.FIRST
-
-        // Check if bass interval is a 5th (diminished 5th = 6, perfect 5th = 7, augmented 5th = 8)
         if (interval == 6 || interval == 7 || interval == 8) return Inversion.SECOND
-
-        // Check if bass interval is a 7th (minor 7th = 10, major 7th = 11)
-        // Only valid for 7th chords (formula has intervals beyond the triad)
         if ((interval == 10 || interval == 11) && formula.intervals.any { it >= 10 }) {
             return Inversion.THIRD
         }
-
-        // Fallback: if interval is in the formula but not a standard inversion,
-        // treat as root position (e.g., sus2 with 2nd in bass)
         return Inversion.ROOT
     }
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordInfo.kt
@@ -265,7 +265,10 @@ object ChordInfo {
      * @param interval Semitone interval from root to bass (0–11).
      * @param formula The chord formula (used to validate 3rd inversion for 7th chords).
      */
-    fun inversionForInterval(interval: Int, formula: ChordFormula): Inversion {
+    fun inversionForInterval(
+        interval: Int,
+        formula: ChordFormula,
+    ): Inversion {
         if (interval == 0) return Inversion.ROOT
         if (interval == 3 || interval == 4) return Inversion.FIRST
         if (interval == 6 || interval == 7 || interval == 8) return Inversion.SECOND

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordNameParser.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordNameParser.kt
@@ -258,5 +258,4 @@ object ChordNameParser {
 
         return results
     }
-
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordNameParser.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordNameParser.kt
@@ -87,7 +87,7 @@ object ChordNameParser {
             val bassPc = resolveNoteName(bassPart) ?: return null
             val interval = (bassPc - rootPc + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
             if (interval !in formula.intervals || interval == 0) return null
-            val inversion = inversionForInterval(interval, formula)
+            val inversion = ChordInfo.inversionForInterval(interval, formula)
             val bassName = Notes.pitchClassToName(bassPc)
             return ChordSearchResult(
                 displayName = "$canonicalRoot${formula.symbol}/$bassName",
@@ -242,7 +242,7 @@ object ChordNameParser {
                 bassNameFlat.startsWith(bassQuery, ignoreCase = true)
 
             if (matchesBass) {
-                val inversion = inversionForInterval(interval, formula)
+                val inversion = ChordInfo.inversionForInterval(interval, formula)
                 results.add(
                     ChordSearchResult(
                         displayName = "$canonicalRoot${formula.symbol}/$bassName",
@@ -259,18 +259,4 @@ object ChordNameParser {
         return results
     }
 
-    /**
-     * Maps a bass interval to the corresponding [ChordInfo.Inversion],
-     * using the same logic as [ChordInfo.determineInversion].
-     */
-    private fun inversionForInterval(
-        interval: Int,
-        formula: ChordFormula,
-    ): ChordInfo.Inversion = when {
-        interval == 3 || interval == 4 -> ChordInfo.Inversion.FIRST
-        interval == 6 || interval == 7 || interval == 8 -> ChordInfo.Inversion.SECOND
-        (interval == 10 || interval == 11) && formula.intervals.any { it >= 10 } ->
-            ChordInfo.Inversion.THIRD
-        else -> ChordInfo.Inversion.ROOT
-    }
 }


### PR DESCRIPTION
## Summary

- Extract `ChordInfo.inversionForInterval()` as the single source of truth for mapping bass intervals (semitones above root) to `Inversion` enum values
- Simplify `ChordInfo.determineInversion()` to delegate to this new method after computing the interval
- Remove the duplicate private `inversionForInterval()` from `ChordNameParser` and call `ChordInfo.inversionForInterval()` instead

## Test plan

- [x] Shared module builds (`./gradlew :shared:build`)
- [x] Shared module JVM tests pass (`./gradlew :shared:jvmTest`)
- [x] Android unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] CI checks pass

Fixes #416

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated chord inversion determination logic into a shared utility function for improved code maintainability and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->