### PR TITLE
Refactor: extract normalizePitchClass() utility to Notes.kt

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/KeySignatures.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/KeySignatures.kt
@@ -168,7 +168,7 @@ object KeySignatures {
     fun closelyRelatedKeys(pitchClass: Int): Pair<Int, Int> {
         val index = CIRCLE_ORDER.indexOf(pitchClass)
         if (index < 0) return Pair(pitchClass, pitchClass)
-        val ccw = CIRCLE_ORDER[(index - 1 + 12) % 12]
+        val ccw = CIRCLE_ORDER[Notes.normalizePitchClass(index - 1)]
         val cw = CIRCLE_ORDER[(index + 1) % 12]
         return Pair(ccw, cw)
     }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
@@ -8,26 +8,47 @@ package com.baijum.ukufretboard.data
  * tones of the Western chromatic scale.
  */
 object Notes {
-
     /**
      * Note names indexed by pitch class, using sharps for accidentals.
      *
      * Index 0 = C, 1 = C#, 2 = D, ... 11 = B.
      */
-    val NOTE_NAMES_SHARP: List<String> = listOf(
-        "C", "C#", "D", "D#", "E", "F",
-        "F#", "G", "G#", "A", "A#", "B"
-    )
+    val NOTE_NAMES_SHARP: List<String> =
+        listOf(
+            "C",
+            "C#",
+            "D",
+            "D#",
+            "E",
+            "F",
+            "F#",
+            "G",
+            "G#",
+            "A",
+            "A#",
+            "B",
+        )
 
     /**
      * Note names indexed by pitch class, using flats for accidentals.
      *
      * Index 0 = C, 1 = Db, 2 = D, ... 11 = B.
      */
-    val NOTE_NAMES_FLAT: List<String> = listOf(
-        "C", "Db", "D", "Eb", "E", "F",
-        "Gb", "G", "Ab", "A", "Bb", "B"
-    )
+    val NOTE_NAMES_FLAT: List<String> =
+        listOf(
+            "C",
+            "Db",
+            "D",
+            "Eb",
+            "E",
+            "F",
+            "Gb",
+            "G",
+            "Ab",
+            "A",
+            "Bb",
+            "B",
+        )
 
     /**
      * Standard note names using the most common enharmonic spelling for
@@ -36,10 +57,21 @@ object Notes {
      * Sharps for C# and F#; flats for Eb, Ab, and Bb.
      * Used as the default when no musical key context is available.
      */
-    val NOTE_NAMES_STANDARD: List<String> = listOf(
-        "C", "C#", "D", "Eb", "E", "F",
-        "F#", "G", "Ab", "A", "Bb", "B"
-    )
+    val NOTE_NAMES_STANDARD: List<String> =
+        listOf(
+            "C",
+            "C#",
+            "D",
+            "Eb",
+            "E",
+            "F",
+            "F#",
+            "G",
+            "Ab",
+            "A",
+            "Bb",
+            "B",
+        )
 
     /**
      * Alias for [NOTE_NAMES_SHARP] to maintain backward compatibility.
@@ -55,8 +87,7 @@ object Notes {
      * Unlike plain `% PITCH_CLASS_COUNT`, this is safe for negative inputs
      * (e.g. transposition by negative semitones, subtraction of pitch classes).
      */
-    fun normalizePitchClass(value: Int): Int =
-        ((value % PITCH_CLASS_COUNT) + PITCH_CLASS_COUNT) % PITCH_CLASS_COUNT
+    fun normalizePitchClass(value: Int): Int = ((value % PITCH_CLASS_COUNT) + PITCH_CLASS_COUNT) % PITCH_CLASS_COUNT
 
     /**
      * Converts a pitch class integer to its human-readable note name
@@ -65,8 +96,7 @@ object Notes {
      * @param pitchClass An integer from 0 to 11 representing a pitch class.
      * @return The note name (e.g., "C", "F#", "Bb"), or "?" if out of range.
      */
-    fun pitchClassToName(pitchClass: Int): String =
-        NOTE_NAMES_STANDARD.getOrElse(pitchClass) { "?" }
+    fun pitchClassToName(pitchClass: Int): String = NOTE_NAMES_STANDARD.getOrElse(pitchClass) { "?" }
 
     /**
      * Key roots (pitch classes) whose major scales use flats.
@@ -104,11 +134,12 @@ object Notes {
     ): String {
         if (keyRoot == null) return pitchClassToName(pitchClass)
 
-        val keyUsesFlats = if (isMinor) {
-            keyRoot in FLAT_MINOR_KEY_ROOTS
-        } else {
-            keyRoot in FLAT_KEY_ROOTS
-        }
+        val keyUsesFlats =
+            if (isMinor) {
+                keyRoot in FLAT_MINOR_KEY_ROOTS
+            } else {
+                keyRoot in FLAT_KEY_ROOTS
+            }
         return if (keyUsesFlats) NOTE_NAMES_FLAT[pitchClass] else NOTE_NAMES_SHARP[pitchClass]
     }
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/Notes.kt
@@ -50,6 +50,15 @@ object Notes {
     const val PITCH_CLASS_COUNT = 12
 
     /**
+     * Normalizes any integer to a pitch class in [0, [PITCH_CLASS_COUNT]).
+     *
+     * Unlike plain `% PITCH_CLASS_COUNT`, this is safe for negative inputs
+     * (e.g. transposition by negative semitones, subtraction of pitch classes).
+     */
+    fun normalizePitchClass(value: Int): Int =
+        ((value % PITCH_CLASS_COUNT) + PITCH_CLASS_COUNT) % PITCH_CLASS_COUNT
+
+    /**
      * Converts a pitch class integer to its human-readable note name
      * using the standard enharmonic spellings ([NOTE_NAMES_STANDARD]).
      *

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.data.Notes
 import kotlin.math.log2
 import kotlin.math.roundToInt
 
@@ -57,7 +58,7 @@ object Chromagram {
             // Map frequency → pitch class using equal temperament.
             // pitchClass = round(12 * log2(freq / C0)) mod 12
             val semitones = (12.0 * log2(freq.toDouble() / C0_HZ)).toFloat()
-            val pitchClass = ((semitones.roundToInt() % 12) + 12) % 12
+            val pitchClass = Notes.normalizePitchClass(semitones.roundToInt())
 
             // Accumulate squared magnitude for better energy representation.
             chroma[pitchClass] += magnitudes[bin] * magnitudes[bin]

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
@@ -17,7 +17,6 @@ import kotlin.math.roundToInt
  * match against chord interval formulas.
  */
 object Chromagram {
-
     /** Reference frequency for C0 in Hz, used as the base for pitch-class mapping. */
     private const val C0_HZ = 16.3516f
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchMonitorStateMachine.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchMonitorStateMachine.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.data.Notes
 import kotlin.math.log2
 import kotlin.math.roundToInt
 
@@ -236,7 +237,7 @@ class PitchMonitorStateMachine(arpeggioWindowMs: Long = 3_000L) {
         // --- Arpeggio detection -------------------------------------------------
         if (smoothedHz != null) {
             val midiNote = 69.0 + 12.0 * log2(smoothedHz / 440.0)
-            val pitchClass = ((midiNote.roundToInt() % 12) + 12) % 12
+            val pitchClass = Notes.normalizePitchClass(midiNote.roundToInt())
             arpeggioDetector.addNote(timestampMs, pitchClass)
         }
         val arpeggioResult = arpeggioDetector.detect(timestampMs)

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchMonitorStateMachine.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchMonitorStateMachine.kt
@@ -86,8 +86,9 @@ sealed class FrameGateResult {
  *
  * @see NeuralArbitrator for the precedent shared audio state machine pattern
  */
-class PitchMonitorStateMachine(arpeggioWindowMs: Long = 3_000L) {
-
+class PitchMonitorStateMachine(
+    arpeggioWindowMs: Long = 3_000L,
+) {
     companion object {
         /** How many recent frequency readings to keep for median smoothing. */
         const val SMOOTHING_WINDOW = 5
@@ -223,16 +224,17 @@ class PitchMonitorStateMachine(arpeggioWindowMs: Long = 3_000L) {
         timestampMs: Long,
     ): PitchMonitorFrame {
         // --- Frequency smoothing ------------------------------------------------
-        val smoothedHz = if (pitchHz != null) {
-            smoothingBuffer.addLast(pitchHz)
-            if (smoothingBuffer.size > SMOOTHING_WINDOW) {
-                smoothingBuffer.removeFirst()
+        val smoothedHz =
+            if (pitchHz != null) {
+                smoothingBuffer.addLast(pitchHz)
+                if (smoothingBuffer.size > SMOOTHING_WINDOW) {
+                    smoothingBuffer.removeFirst()
+                }
+                medianFrequency()
+            } else {
+                smoothingBuffer.clear()
+                null
             }
-            medianFrequency()
-        } else {
-            smoothingBuffer.clear()
-            null
-        }
 
         // --- Arpeggio detection -------------------------------------------------
         if (smoothedHz != null) {

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ScaleChordBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ScaleChordBuilder.kt
@@ -56,8 +56,8 @@ object ScaleChordBuilder {
             val thirdPc = scaleNotes[(index + 2) % scaleNotes.size]
             val fifthPc = scaleNotes[(index + 4) % scaleNotes.size]
 
-            val thirdInterval = (thirdPc - notePc + 12) % 12
-            val fifthInterval = (fifthPc - notePc + 12) % 12
+            val thirdInterval = Notes.normalizePitchClass(thirdPc - notePc)
+            val fifthInterval = Notes.normalizePitchClass(fifthPc - notePc)
 
             val (quality, symbol) = determineTriadQuality(thirdInterval, fifthInterval)
             val numeral = when (quality) {

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ScaleChords.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ScaleChords.kt
@@ -58,8 +58,8 @@ object ScaleChords {
             val fifthInterval = intervals[fifthIndex]
 
             // Calculate semitone distances from chord root
-            val thirdSemitones = ((thirdInterval - rootInterval) + 12) % 12
-            val fifthSemitones = ((fifthInterval - rootInterval) + 12) % 12
+            val thirdSemitones = Notes.normalizePitchClass(thirdInterval - rootInterval)
+            val fifthSemitones = Notes.normalizePitchClass(fifthInterval - rootInterval)
 
             val (quality, qualityName) = classifyTriad(thirdSemitones, fifthSemitones)
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapper.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapper.kt
@@ -49,7 +49,6 @@ data class StringMatch(
  * four tunings (High-G, Low-G, Baritone, D-Tuning).
  */
 object TunerNoteMapper {
-
     /** Default concert pitch A4 = 440 Hz. */
     const val DEFAULT_A4_HZ = 440.0
 
@@ -62,7 +61,10 @@ object TunerNoteMapper {
      * @param a4Reference Reference frequency for A4 (default 440.0 Hz).
      * @return A [NoteInfo] describing the nearest note, or `null` if [hz] ≤ 0.
      */
-    fun mapFrequency(hz: Double, a4Reference: Double = DEFAULT_A4_HZ): NoteInfo? {
+    fun mapFrequency(
+        hz: Double,
+        a4Reference: Double = DEFAULT_A4_HZ,
+    ): NoteInfo? {
         if (hz <= 0.0) return null
 
         // MIDI note number (fractional) relative to A4 = 69.
@@ -76,7 +78,9 @@ object TunerNoteMapper {
         val pitchClass = Notes.normalizePitchClass(midiRounded)
         val octave = (midiRounded / 12) - 1
 
-        val noteName = com.baijum.ukufretboard.data.Notes.pitchClassToName(pitchClass)
+        val noteName =
+            com.baijum.ukufretboard.data.Notes
+                .pitchClassToName(pitchClass)
 
         return NoteInfo(
             noteName = noteName,
@@ -119,11 +123,12 @@ object TunerNoteMapper {
         var bestCents = Double.MAX_VALUE
 
         for (i in tuning.pitchClasses.indices) {
-            val targetHz = targetFrequency(
-                tuning.pitchClasses[i],
-                tuning.octaves[i],
-                a4Reference,
-            )
+            val targetHz =
+                targetFrequency(
+                    tuning.pitchClasses[i],
+                    tuning.octaves[i],
+                    a4Reference,
+                )
             val centsDiff = 1200.0 * log2(noteInfo.frequencyHz / targetHz)
 
             if (abs(centsDiff) < abs(bestCents)) {
@@ -156,14 +161,16 @@ object TunerNoteMapper {
         switchHysteresisCents: Double,
         a4Reference: Double = DEFAULT_A4_HZ,
     ): StringMatch {
-        val centsDiffs = tuning.pitchClasses.indices.map { i ->
-            val targetHz = targetFrequency(
-                tuning.pitchClasses[i],
-                tuning.octaves[i],
-                a4Reference,
-            )
-            1200.0 * log2(noteInfo.frequencyHz / targetHz)
-        }
+        val centsDiffs =
+            tuning.pitchClasses.indices.map { i ->
+                val targetHz =
+                    targetFrequency(
+                        tuning.pitchClasses[i],
+                        tuning.octaves[i],
+                        a4Reference,
+                    )
+                1200.0 * log2(noteInfo.frequencyHz / targetHz)
+            }
 
         var bestIndex = 0
         var bestAbs = Double.MAX_VALUE
@@ -175,15 +182,19 @@ object TunerNoteMapper {
             }
         }
 
-        val chosenIndex = if (previousStringIndex != null &&
-            previousStringIndex in centsDiffs.indices
-        ) {
-            val previousAbs = abs(centsDiffs[previousStringIndex])
-            if (previousAbs <= bestAbs + switchHysteresisCents) previousStringIndex
-            else bestIndex
-        } else {
-            bestIndex
-        }
+        val chosenIndex =
+            if (previousStringIndex != null &&
+                previousStringIndex in centsDiffs.indices
+            ) {
+                val previousAbs = abs(centsDiffs[previousStringIndex])
+                if (previousAbs <= bestAbs + switchHysteresisCents) {
+                    previousStringIndex
+                } else {
+                    bestIndex
+                }
+            } else {
+                bestIndex
+            }
 
         return StringMatch(
             stringIndex = chosenIndex,

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapper.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/TunerNoteMapper.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.UkuleleTuning
 import kotlin.math.abs
 import kotlin.math.log2
@@ -72,7 +73,7 @@ object TunerNoteMapper {
         val cents = (midiExact - midiRounded) * 100.0
 
         // Pitch class and octave from the rounded MIDI note.
-        val pitchClass = ((midiRounded % 12) + 12) % 12  // ensure positive
+        val pitchClass = Notes.normalizePitchClass(midiRounded)
         val octave = (midiRounded / 12) - 1
 
         val noteName = com.baijum.ukufretboard.data.Notes.pitchClassToName(pitchClass)


### PR DESCRIPTION
## Summary

- Add `Notes.normalizePitchClass(value: Int)` as the canonical utility for normalizing any integer to a pitch class in `[0, 12)`, handling negative inputs correctly
- Replace 3 verbose safe patterns (`((x % 12) + 12) % 12`) in Chromagram, PitchMonitorStateMachine, and TunerNoteMapper
- Replace 4 partially-safe patterns (`(x + 12) % 12`) in ScaleChordBuilder, ScaleChords, and KeySignatures
- The 14 plain `% 12` sites where inputs are guaranteed non-negative are left as-is

## Test plan

- [x] Shared module builds and all tests pass (`./gradlew :shared:build`)
- [x] Android unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] CI checks pass

Fixes #417

Made with [Cursor](https://cursor.com)