### PR TITLE
Refactor: consolidate iOS repository boilerplate into a generic base class

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		A10308 /* CustomPatternsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10308 /* CustomPatternsRepository.swift */; };
 		A10309 /* PracticeTimerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10309 /* PracticeTimerRepository.swift */; };
 		A10310 /* ScalePracticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10310 /* ScalePracticeRepository.swift */; };
+		A10311 /* JSONStorageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10311 /* JSONStorageRepository.swift */; };
 		A10070 /* PatternPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10070 /* PatternPlayer.swift */; };
 		A10071 /* FullScreenFretboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10071 /* FullScreenFretboardView.swift */; };
 		A10072 /* PracticeTimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10072 /* PracticeTimerViewModelTests.swift */; };
@@ -262,6 +263,7 @@
 		B10308 /* CustomPatternsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPatternsRepository.swift; sourceTree = "<group>"; };
 		B10309 /* PracticeTimerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerRepository.swift; sourceTree = "<group>"; };
 		B10310 /* ScalePracticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalePracticeRepository.swift; sourceTree = "<group>"; };
+		B10311 /* JSONStorageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStorageRepository.swift; sourceTree = "<group>"; };
 		B10070 /* PatternPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternPlayer.swift; sourceTree = "<group>"; };
 		B10071 /* FullScreenFretboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenFretboardView.swift; sourceTree = "<group>"; };
 		B10072 /* PracticeTimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerViewModelTests.swift; sourceTree = "<group>"; };
@@ -532,6 +534,7 @@
 				B10308 /* CustomPatternsRepository.swift */,
 				B10309 /* PracticeTimerRepository.swift */,
 				B10310 /* ScalePracticeRepository.swift */,
+				B10311 /* JSONStorageRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -830,6 +833,7 @@
 				A10308 /* CustomPatternsRepository.swift in Sources */,
 				A10309 /* PracticeTimerRepository.swift in Sources */,
 				A10310 /* ScalePracticeRepository.swift in Sources */,
+				A10311 /* JSONStorageRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/UkuleleCompanion/Repositories/CustomPatternsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/CustomPatternsRepository.swift
@@ -1,35 +1,27 @@
 import Foundation
 
 final class CustomPatternsRepository {
-    private let strumKey = "custom_strum_patterns"
-    private let fingerpickKey = "custom_fingerpicking_patterns"
+    private let strumStorage = JSONStorageRepository<CustomStrumPatternData>(key: "custom_strum_patterns")
+    private let fingerpickStorage = JSONStorageRepository<CustomFingerpickingData>(key: "custom_fingerpicking_patterns")
 
     // MARK: - Strum Patterns
 
     func getAllStrum() -> [CustomStrumPatternData] {
-        guard let data = UserDefaults.standard.data(forKey: strumKey),
-              let decoded = try? JSONDecoder().decode([CustomStrumPatternData].self, from: data)
-        else { return [] }
-        return decoded
+        strumStorage.getAll()
     }
 
     func saveStrum(_ patterns: [CustomStrumPatternData]) {
-        guard let data = try? JSONEncoder().encode(patterns) else { return }
-        UserDefaults.standard.set(data, forKey: strumKey)
+        strumStorage.save(patterns)
     }
 
     // MARK: - Fingerpicking Patterns
 
     func getAllFingerpicking() -> [CustomFingerpickingData] {
-        guard let data = UserDefaults.standard.data(forKey: fingerpickKey),
-              let decoded = try? JSONDecoder().decode([CustomFingerpickingData].self, from: data)
-        else { return [] }
-        return decoded
+        fingerpickStorage.getAll()
     }
 
     func saveFingerpicking(_ patterns: [CustomFingerpickingData]) {
-        guard let data = try? JSONEncoder().encode(patterns) else { return }
-        UserDefaults.standard.set(data, forKey: fingerpickKey)
+        fingerpickStorage.save(patterns)
     }
 
     // MARK: - Export/Import

--- a/iosApp/UkuleleCompanion/Repositories/JSONStorageRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/JSONStorageRepository.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Generic base class for UserDefaults-backed JSON array storage.
+///
+/// Provides `getAll()`, `save(_:)`, and `exportData(_:)` with a single
+/// implementation. Subclasses only need to implement merge logic in
+/// `importData(_:into:)`.
+class JSONStorageRepository<T: Codable> {
+    let userDefaultsKey: String
+    private let defaults: UserDefaults
+
+    init(key: String, defaults: UserDefaults = .standard) {
+        self.userDefaultsKey = key
+        self.defaults = defaults
+    }
+
+    func getAll() -> [T] {
+        guard let data = defaults.data(forKey: userDefaultsKey),
+              let decoded = try? JSONDecoder().decode([T].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func save(_ items: [T]) {
+        guard let data = try? JSONEncoder().encode(items) else { return }
+        defaults.set(data, forKey: userDefaultsKey)
+    }
+
+    func exportData(_ items: [T]) -> [[String: Any]] {
+        let encoder = JSONEncoder()
+        return items.compactMap { item in
+            guard let data = try? encoder.encode(item),
+                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return dict
+        }
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/MelodyRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/MelodyRepository.swift
@@ -1,28 +1,8 @@
 import Foundation
 
-final class MelodyRepository {
-    private let userDefaultsKey = "melodies"
-
-    func getAll() -> [MelodyData] {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([MelodyData].self, from: data)
-        else { return [] }
-        return decoded
-    }
-
-    func save(_ melodies: [MelodyData]) {
-        guard let data = try? JSONEncoder().encode(melodies) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
-    }
-
-    func exportData(_ melodies: [MelodyData]) -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return melodies.compactMap { melody in
-            guard let data = try? encoder.encode(melody),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
+final class MelodyRepository: JSONStorageRepository<MelodyData> {
+    init() {
+        super.init(key: "melodies")
     }
 
     func importData(_ incoming: [[String: Any]], into melodies: inout [MelodyData]) {

--- a/iosApp/UkuleleCompanion/Repositories/ProgressionsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/ProgressionsRepository.swift
@@ -1,28 +1,8 @@
 import Foundation
 
-final class ProgressionsRepository {
-    private let userDefaultsKey = "custom_progressions"
-
-    func getAll() -> [CustomProgression] {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([CustomProgression].self, from: data)
-        else { return [] }
-        return decoded
-    }
-
-    func save(_ progressions: [CustomProgression]) {
-        guard let data = try? JSONEncoder().encode(progressions) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
-    }
-
-    func exportData(_ progressions: [CustomProgression]) -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return progressions.compactMap { prog in
-            guard let data = try? encoder.encode(prog),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
+final class ProgressionsRepository: JSONStorageRepository<CustomProgression> {
+    init() {
+        super.init(key: "custom_progressions")
     }
 
     func importData(_ incoming: [[String: Any]], into progressions: inout [CustomProgression]) {

--- a/iosApp/UkuleleCompanion/Repositories/SetlistRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SetlistRepository.swift
@@ -1,28 +1,8 @@
 import Foundation
 
-final class SetlistRepository {
-    private let userDefaultsKey = "setlists"
-
-    func getAll() -> [StoredSetlist] {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([StoredSetlist].self, from: data)
-        else { return [] }
-        return decoded
-    }
-
-    func save(_ setlists: [StoredSetlist]) {
-        guard let data = try? JSONEncoder().encode(setlists) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
-    }
-
-    func exportData(_ setlists: [StoredSetlist]) -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return setlists.compactMap { setlist in
-            guard let data = try? encoder.encode(setlist),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
+final class SetlistRepository: JSONStorageRepository<StoredSetlist> {
+    init() {
+        super.init(key: "setlists")
     }
 
     func importData(_ incoming: [[String: Any]], into setlists: inout [StoredSetlist]) {

--- a/iosApp/UkuleleCompanion/Repositories/SongbookRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SongbookRepository.swift
@@ -1,28 +1,8 @@
 import Foundation
 
-final class SongbookRepository {
-    private let userDefaultsKey = "chord_sheets"
-
-    func getAll() -> [StoredSong] {
-        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([StoredSong].self, from: data)
-        else { return [] }
-        return decoded
-    }
-
-    func save(_ songs: [StoredSong]) {
-        guard let data = try? JSONEncoder().encode(songs) else { return }
-        UserDefaults.standard.set(data, forKey: userDefaultsKey)
-    }
-
-    func exportData(_ songs: [StoredSong]) -> [[String: Any]] {
-        let encoder = JSONEncoder()
-        return songs.compactMap { song in
-            guard let data = try? encoder.encode(song),
-                  let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return nil }
-            return dict
-        }
+final class SongbookRepository: JSONStorageRepository<StoredSong> {
+    init() {
+        super.init(key: "chord_sheets")
     }
 
     func importData(_ incoming: [[String: Any]], into songs: inout [StoredSong]) {


### PR DESCRIPTION
## Summary

- Create `JSONStorageRepository<T: Codable>` base class with shared `getAll()`, `save(_:)`, and `exportData(_:)` implementations
- Refactor `SongbookRepository`, `SetlistRepository`, `ProgressionsRepository`, and `MelodyRepository` to inherit from the base (each only implements `importData` with its merge strategy)
- Refactor `CustomPatternsRepository` to use composition with two base-class instances for storage, keeping custom export/import logic
- Net reduction: ~46 lines of duplicated encode/decode boilerplate

## Test plan

- [x] iOS app builds successfully on simulator (`xcodebuild build`)
- [ ] CI checks pass (Android unaffected, iOS build validates)

Fixes #418

Made with [Cursor](https://cursor.com)