### PR TITLE
Add Git pre-commit hooks (ktlint + gitleaks)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,11 @@ Skills in `.cursor/skills/` provide step-by-step workflows for common tasks:
 scripts/preflight.sh                           # ktlint ratchet + shared tests + unit tests + lint
 scripts/ktlint.sh                              # ktlint check only (-F to auto-format)
 
+# Git hooks (install once)
+./gradlew installGitHooks                      # copies pre-commit hook to .git/hooks/
+# Or manually: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Pre-commit runs: ktlint on staged .kt files + gitleaks (if installed)
+
 # iOS (requires Xcode)
 xcodebuild -project iosApp/UkuleleCompanion.xcodeproj \
   -scheme UkuleleCompanion \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,3 +6,11 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kover) apply false
 }
+
+tasks.register<Copy>("installGitHooks") {
+    description = "Installs the pre-commit hook from scripts/pre-commit"
+    group = "git hooks"
+    from("scripts/pre-commit")
+    into(".git/hooks")
+    filePermissions { unix("rwxr-xr-x") }
+}

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Git pre-commit hook: runs ktlint on staged .kt files and gitleaks on the diff.
+# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or run: ./gradlew installGitHooks
+#
+set -euo pipefail
+
+# --- ktlint on staged Kotlin files ---
+STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.kt$' || true)
+
+if [[ -n "$STAGED_KT" ]]; then
+    echo "pre-commit: running ktlint on staged .kt files..."
+    if ! scripts/ktlint.sh --baseline=ktlint-baseline.xml $STAGED_KT; then
+        echo ""
+        echo "❌ ktlint check failed. Run 'scripts/ktlint.sh -F' to auto-format."
+        exit 1
+    fi
+fi
+
+# --- gitleaks on staged changes ---
+if command -v gitleaks &>/dev/null; then
+    echo "pre-commit: running gitleaks on staged changes..."
+    if ! gitleaks git --pre-commit --staged --no-banner 2>/dev/null; then
+        echo ""
+        echo "❌ gitleaks detected secrets in staged changes."
+        echo "   Remove the secret and try again."
+        exit 1
+    fi
+else
+    # gitleaks not installed — skip silently (CI will catch secrets)
+    :
+fi
+
+echo "pre-commit: ✓ all checks passed"


### PR DESCRIPTION
## Summary

- Add `scripts/pre-commit` hook that runs ktlint on staged `.kt` files and gitleaks on staged changes
- Add `installGitHooks` Gradle task for easy one-command installation
- Document the hook in `AGENTS.md`

The hook is fast (~2 seconds) and gitleaks is optional (skipped if not installed; CI catches secrets).

## Test plan

- [x] `./gradlew installGitHooks` installs the hook to `.git/hooks/`
- [x] Hook is executable and runs correctly
- [ ] CI checks pass

Fixes #426

Made with [Cursor](https://cursor.com)