### PR TITLE
Add Cursor hooks for post-edit lint feedback

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/ktlint-check.sh",
+        "matcher": "Write"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/ktlint-check.sh
+++ b/.cursor/hooks/ktlint-check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Post-edit hook: runs ktlint on the edited file if it's a .kt file.
+# Returns additional_context so the agent sees lint errors immediately.
+set -euo pipefail
+
+input=$(cat)
+file_path=$(echo "$input" | python3 -c "import sys,json; print(json.load(sys.stdin).get('path',''))" 2>/dev/null || true)
+
+# Only check Kotlin files
+if [[ "$file_path" != *.kt ]]; then
+    exit 0
+fi
+
+# Skip if ktlint isn't available
+if [[ ! -f "scripts/ktlint.sh" ]]; then
+    exit 0
+fi
+
+# Run ktlint on just this file (with baseline)
+output=$(scripts/ktlint.sh --baseline=ktlint-baseline.xml "$file_path" 2>&1 || true)
+
+if [[ -n "$output" && "$output" == *".kt:"* ]]; then
+    # Feed lint errors back as context for the agent
+    cat <<EOF
+{
+  "additional_context": "ktlint violations in $file_path:\n$output\nPlease fix these formatting issues."
+}
+EOF
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .cursor/*
 !.cursor/skills/
 !.cursor/rules/
+!.cursor/hooks.json
+!.cursor/hooks/
 .claude/settings.local.json
 .DS_Store
 /build


### PR DESCRIPTION
## Summary

- Add `.cursor/hooks.json` with an `afterFileEdit` hook for ktlint feedback
- Add `.cursor/hooks/ktlint-check.sh` that runs ktlint on edited `.kt` files and feeds errors back to the agent
- Un-ignore `.cursor/hooks.json` and `.cursor/hooks/` in `.gitignore`

This brings Cursor to parity with Claude Code's `style-check.py` PostToolUse hook.

## Test plan

- [x] Hook script is executable and exits cleanly
- [ ] CI checks pass

Fixes #430

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to enable automated Kotlin code formatting checks during file edits.
  * Updated build configuration to properly manage development tool directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->