### PR TITLE
Refactor: collapse iOS BackupRestoreManager symmetric build/extract pairs

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -25,6 +25,16 @@ enum BackupError: LocalizedError {
     }
 }
 
+private enum BackupTimestamp {
+    static func toMillis(_ seconds: Double) -> Int64 { Int64(seconds * 1000) }
+    static func toSeconds(_ millis: Int64) -> Double { Double(millis) / 1000.0 }
+    static func fromAny(_ value: Any?) -> Int64 {
+        if let d = value as? Double { return Int64(d) }
+        if let i = value as? Int { return Int64(i) }
+        return 0
+    }
+}
+
 @MainActor
 final class BackupRestoreManager: ObservableObject {
     @Published var lastBackupDate: String?
@@ -90,18 +100,18 @@ final class BackupRestoreManager: ObservableObject {
         let backup = BackupData(
             version: BackupData.companion.CURRENT_VERSION,
             exportedAt: Int64(Date().timeIntervalSince1970 * 1000),
-            favorites: buildFavorites(favs),
-            favoriteFolders: buildFolders(folders),
-            chordSheets: buildChordSheets(songbookVM.exportData()),
-            customProgressions: buildProgressions(progressionsVM.exportData()),
-            customStrumPatterns: buildStrumPatterns(customPatternsVM.exportStrumData()),
-            customFingerpickingPatterns: buildFingerpickPatterns(customPatternsVM.exportFingerpickData()),
-            setlists: buildSetlists(setlistVM.exportData()),
-            melodies: buildMelodies(melodyVM.exportData()),
-            learningProgress: buildLearningProgress(learnData),
-            settings: buildSettings(settingsVM.exportSettings()),
-            achievements: buildAchievements(learnData),
-            practiceTimer: buildPracticeTimer(practiceTimerVM.exportData())
+            favorites: FavoriteCoder.build(favs),
+            favoriteFolders: FolderCoder.build(folders),
+            chordSheets: ChordSheetCoder.build(songbookVM.exportData()),
+            customProgressions: ProgressionCoder.build(progressionsVM.exportData()),
+            customStrumPatterns: StrumPatternCoder.build(customPatternsVM.exportStrumData()),
+            customFingerpickingPatterns: FingerpickPatternCoder.build(customPatternsVM.exportFingerpickData()),
+            setlists: SetlistCoder.build(setlistVM.exportData()),
+            melodies: MelodyCoder.build(melodyVM.exportData()),
+            learningProgress: LearningProgressCoder.build(learnData),
+            settings: SettingsCoder.build(settingsVM.exportSettings()),
+            achievements: AchievementCoder.build(learnData),
+            practiceTimer: PracticeTimerCoder.build(practiceTimerVM.exportData())
         )
 
         let jsonString = BackupCodec.shared.encode(data: backup)
@@ -145,35 +155,35 @@ final class BackupRestoreManager: ObservableObject {
         // --- Favorites ---
         if !backup.favorites.isEmpty || !backup.favoriteFolders.isEmpty {
             favoritesVM.importData(
-                favorites: extractFavorites(backup.favorites),
-                folders: extractFolders(backup.favoriteFolders)
+                favorites: FavoriteCoder.extract(backup.favorites),
+                folders: FolderCoder.extract(backup.favoriteFolders)
             )
             importedAny = true
         }
 
         // --- Settings ---
-        let settings = extractSettings(backup.settings)
+        let settings = SettingsCoder.extract(backup.settings)
         if !settings.isEmpty {
             settingsVM.importSettings(settings)
             importedAny = true
         }
 
         // --- Chord sheets ---
-        let sheets = extractChordSheets(backup.chordSheets)
+        let sheets = ChordSheetCoder.extract(backup.chordSheets)
         if !sheets.isEmpty {
             songbookVM.importData(sheets)
             importedAny = true
         }
 
         // --- Melodies ---
-        let melodies = extractMelodies(backup.melodies)
+        let melodies = MelodyCoder.extract(backup.melodies)
         if !melodies.isEmpty {
             melodyVM.importData(melodies)
             importedAny = true
         }
 
         // --- Custom progressions ---
-        let progs = extractProgressions(backup.customProgressions)
+        let progs = ProgressionCoder.extract(backup.customProgressions)
         if !progs.isEmpty {
             progressionsVM.importData(progs)
             importedAny = true
@@ -182,7 +192,7 @@ final class BackupRestoreManager: ObservableObject {
         // --- Learning progress ---
         let entries = backup.learningProgress.entries as? [String: String] ?? [:]
         if !entries.isEmpty {
-            learnVM.importProgress(extractLearnProgress(entries))
+            learnVM.importProgress(LearningProgressCoder.extract(entries))
             importedAny = true
         }
         let achievements = backup.achievements as? [String: Any] ?? [:]
@@ -193,28 +203,28 @@ final class BackupRestoreManager: ObservableObject {
         }
 
         // --- Practice timer ---
-        let timer = extractPracticeTimer(backup.practiceTimer)
+        let timer = PracticeTimerCoder.extract(backup.practiceTimer)
         if !timer.isEmpty {
             practiceTimerVM.importData(timer)
             importedAny = true
         }
 
         // --- Custom strum patterns ---
-        let strumPatterns = extractStrumPatterns(backup.customStrumPatterns)
+        let strumPatterns = StrumPatternCoder.extract(backup.customStrumPatterns)
         if !strumPatterns.isEmpty {
             customPatternsVM.importStrumData(strumPatterns)
             importedAny = true
         }
 
         // --- Custom fingerpicking patterns ---
-        let fpPatterns = extractFingerpickPatterns(backup.customFingerpickingPatterns)
+        let fpPatterns = FingerpickPatternCoder.extract(backup.customFingerpickingPatterns)
         if !fpPatterns.isEmpty {
             customPatternsVM.importFingerpickData(fpPatterns)
             importedAny = true
         }
 
         // --- Setlists ---
-        let setlists = extractSetlists(backup.setlists)
+        let setlists = SetlistCoder.extract(backup.setlists)
         if !setlists.isEmpty {
             setlistVM.importData(setlists)
             importedAny = true
@@ -231,224 +241,31 @@ final class BackupRestoreManager: ObservableObject {
         formatter.timeStyle = .short
         lastBackupDate = formatter.string(from: Date())
     }
+}
 
-    // MARK: - Build KMP objects from iOS VM data (export)
+// MARK: - Backup Coders (build KMP ↔ extract iOS dict)
 
-    private func buildFavorites(_ favs: [[String: Any]]) -> [BackupFavorite] {
+private enum FavoriteCoder {
+    static func build(_ favs: [[String: Any]]) -> [BackupFavorite] {
         favs.map { f in
-            let addedAt = f["addedAt"] as? Double ?? 0
-            return BackupFavorite(
+            BackupFavorite(
                 rootPitchClass: Int32(f["rootPitchClass"] as? Int ?? 0),
                 chordSymbol: f["chordSymbol"] as? String ?? "",
                 frets: (f["frets"] as? [Int] ?? []).map { KotlinInt(int: Int32($0)) },
-                addedAt: Int64(addedAt * 1000),
+                addedAt: BackupTimestamp.toMillis(f["addedAt"] as? Double ?? 0),
                 folderId: nil,
                 folderIds: f["folderIds"] as? [String] ?? []
             )
         }
     }
 
-    private func buildFolders(_ folders: [[String: Any]]) -> [BackupFavoriteFolder] {
-        folders.map { f in
-            let createdAt = f["createdAt"] as? Double ?? 0
-            return BackupFavoriteFolder(
-                id: f["id"] as? String ?? UUID().uuidString,
-                name: f["name"] as? String ?? "",
-                createdAt: Int64(createdAt * 1000),
-                voicingOrder: f["voicingOrder"] as? [String] ?? []
-            )
-        }
-    }
-
-    private func buildChordSheets(_ sheets: [[String: Any]]) -> [BackupChordSheet] {
-        sheets.map { s in
-            BackupChordSheet(
-                id: s["id"] as? String ?? UUID().uuidString,
-                title: s["title"] as? String ?? "",
-                subtitle: s["subtitle"] as? String ?? "",
-                artist: s["artist"] as? String ?? "",
-                content: s["content"] as? String ?? "",
-                key: s["key"] as? String ?? "",
-                capo: Int32(s["capo"] as? Int ?? 0),
-                strumPatternName: s["strumPatternName"] as? String ?? "",
-                labels: s["labels"] as? [String] ?? [],
-                createdAt: millisFromAny(s["createdAt"]),
-                updatedAt: millisFromAny(s["updatedAt"]),
-                viewCount: Int32(s["viewCount"] as? Int ?? 0),
-                lastViewedAt: millisFromAny(s["lastViewedAt"]),
-                totalViewTimeMs: millisFromAny(s["totalViewTimeMs"])
-            )
-        }
-    }
-
-    private func buildProgressions(_ progs: [[String: Any]]) -> [BackupProgression] {
-        progs.compactMap { p -> BackupProgression? in
-            var degrees: [BackupChordDegree] = []
-            if let intervals = p["degreeIntervals"] as? [Int],
-               let qualities = p["degreeQualities"] as? [String],
-               let numerals = p["degreeNumerals"] as? [String] {
-                let count = min(intervals.count, qualities.count, numerals.count)
-                for i in 0..<count {
-                    degrees.append(BackupChordDegree(
-                        interval: Int32(intervals[i]),
-                        quality: qualities[i],
-                        numeral: numerals[i]
-                    ))
-                }
-            }
-            guard !degrees.isEmpty else { return nil }
-            let createdAt = p["createdAt"] as? Double ?? Date().timeIntervalSince1970
-            return BackupProgression(
-                id: p["id"] as? String ?? UUID().uuidString,
-                name: p["name"] as? String ?? "",
-                description: p["description"] as? String ?? "",
-                scaleType: p["scaleType"] as? String ?? "MAJOR",
-                degrees: degrees,
-                createdAt: Int64(createdAt * 1000)
-            )
-        }
-    }
-
-    private func buildStrumPatterns(_ patterns: [[String: Any]]) -> [BackupStrumPattern] {
-        patterns.map { p in
-            let beats: [BackupStrumBeat] = (p["beats"] as? [[String: Any]] ?? []).map { b in
-                BackupStrumBeat(
-                    direction: b["direction"] as? String ?? "DOWN",
-                    emphasis: b["emphasis"] as? Bool ?? false
-                )
-            }
-            let createdAt = p["createdAt"] as? Double ?? 0
-            return BackupStrumPattern(
-                id: p["id"] as? String ?? UUID().uuidString,
-                name: p["name"] as? String ?? "",
-                beats: beats,
-                createdAt: Int64(createdAt * 1000),
-                timeSignature: p["timeSignature"] as? String ?? "4/4"
-            )
-        }
-    }
-
-    private func buildFingerpickPatterns(_ patterns: [[String: Any]]) -> [BackupFingerpickingPattern] {
-        patterns.map { p in
-            let steps: [BackupFingerpickStep] = (p["steps"] as? [[String: Any]] ?? []).map { s in
-                let finger = s["finger"] as? String ?? "T"
-                return BackupFingerpickStep(
-                    finger: Self.fingerToKMP[finger] ?? finger,
-                    stringIndex: Int32(s["stringIndex"] as? Int ?? 0),
-                    emphasis: s["emphasis"] as? Bool ?? false
-                )
-            }
-            let createdAt = p["createdAt"] as? Double ?? 0
-            return BackupFingerpickingPattern(
-                id: p["id"] as? String ?? UUID().uuidString,
-                name: p["name"] as? String ?? "",
-                steps: steps,
-                createdAt: Int64(createdAt * 1000),
-                timeSignature: p["timeSignature"] as? String ?? "4/4"
-            )
-        }
-    }
-
-    private func buildSetlists(_ setlists: [[String: Any]]) -> [BackupSetlist] {
-        setlists.map { sl in
-            BackupSetlist(
-                id: sl["id"] as? String ?? UUID().uuidString,
-                name: sl["name"] as? String ?? "",
-                songIds: sl["songIds"] as? [String] ?? [],
-                createdAt: millisFromAny(sl["createdAt"]),
-                updatedAt: millisFromAny(sl["updatedAt"])
-            )
-        }
-    }
-
-    private func buildMelodies(_ melodies: [[String: Any]]) -> [BackupMelody] {
-        melodies.map { m in
-            let notes: [BackupMelodyNote] = (m["notes"] as? [[String: Any]] ?? []).map { n in
-                let pc = n["pitchClass"] as? Int
-                let dur = n["duration"] as? String ?? "QUARTER"
-                return BackupMelodyNote(
-                    pitchClass: pc.map { KotlinInt(int: Int32($0)) },
-                    octave: Int32(n["octave"] as? Int ?? 4),
-                    duration: Self.durationToKMP[dur] ?? dur,
-                    stringIndex: nil,
-                    fret: nil
-                )
-            }
-            let createdAt = m["createdAt"] as? Double ?? 0
-            return BackupMelody(
-                id: m["id"] as? String ?? UUID().uuidString,
-                name: m["name"] as? String ?? "",
-                notes: notes,
-                bpm: Int32(m["bpm"] as? Int ?? 120),
-                createdAt: Int64(createdAt * 1000)
-            )
-        }
-    }
-
-    private func buildLearningProgress(_ data: [String: Any]) -> BackupLearningProgress {
-        var entries: [String: String] = [:]
-        for (key, value) in data where key != "unlocked_achievements" {
-            entries[key] = "\(value)"
-        }
-        return BackupLearningProgress(entries: entries)
-    }
-
-    private func buildAchievements(_ data: [String: Any]) -> [String: KotlinLong] {
-        guard let list = data["unlocked_achievements"] as? [String] else { return [:] }
-        var map: [String: KotlinLong] = [:]
-        for id in list {
-            map[id] = KotlinLong(value: 0)
-        }
-        return map
-    }
-
-    private func buildPracticeTimer(_ timer: [String: Any]) -> BackupPracticeTimer {
-        let lastSessionTime = timer["lastSessionTime"] as? Double ?? 0
-        let dailyMinutes = timer["dailyMinutes"] as? [String: Int] ?? [:]
-        var kmpDaily: [String: KotlinInt] = [:]
-        for (key, value) in dailyMinutes {
-            kmpDaily[key] = KotlinInt(int: Int32(value))
-        }
-        return BackupPracticeTimer(
-            totalMinutes: Int32(timer["totalMinutes"] as? Int ?? 0),
-            totalSessions: Int32(timer["totalSessions"] as? Int ?? 0),
-            longestSession: Int32(timer["longestSession"] as? Int ?? 0),
-            lastSessionTime: Int64(lastSessionTime * 1000),
-            dailyGoal: Int32(timer["dailyGoal"] as? Int ?? 15),
-            dailyMinutes: kmpDaily
-        )
-    }
-
-    private func buildSettings(_ settings: [String: Any]) -> BackupSettings {
-        let themeLabel = settings["theme_mode"] as? String ?? "System"
-        let tuningLabel = settings["selected_tuning"] as? String ?? "High-G (Standard)"
-        return BackupSettings(
-            soundEnabled: settings["sound_enabled"] as? Bool ?? true,
-            volume: Float(settings["volume"] as? Double ?? 0.7),
-            noteDurationMs: Int32(settings["note_duration_ms"] as? Int ?? 600),
-            strumDelayMs: Int32(settings["strum_delay_ms"] as? Int ?? 50),
-            strumDown: settings["strum_down"] as? Bool ?? true,
-            playOnTap: settings["play_on_tap"] as? Bool ?? false,
-            themeMode: Self.themeToKMP[themeLabel] ?? "SYSTEM",
-            showExplorerTips: settings["show_tips"] as? Bool ?? true,
-            showLearnSection: settings["show_learn_tab"] as? Bool ?? true,
-            showReferenceSection: settings["show_reference_tab"] as? Bool ?? true,
-            tuning: Self.tuningToKMP[tuningLabel] ?? "HIGH_G",
-            leftHanded: settings["left_handed"] as? Bool ?? false,
-            lastFret: Int32(settings["last_fret"] as? Int ?? 12),
-            showNoteNames: settings["show_note_names"] as? Bool ?? true
-        )
-    }
-
-    // MARK: - Extract iOS VM data from KMP objects (import)
-
-    private func extractFavorites(_ favs: [BackupFavorite]) -> [[String: Any]] {
+    static func extract(_ favs: [BackupFavorite]) -> [[String: Any]] {
         favs.map { f in
             var out: [String: Any] = [
                 "rootPitchClass": Int(f.rootPitchClass),
                 "chordSymbol": f.chordSymbol,
                 "frets": f.frets.asInts,
-                "addedAt": Double(f.addedAt) / 1000.0,
+                "addedAt": BackupTimestamp.toSeconds(f.addedAt),
             ]
             let folderIds = f.folderIds.asStrings
             if !folderIds.isEmpty {
@@ -461,62 +278,245 @@ final class BackupRestoreManager: ObservableObject {
             return out
         }
     }
+}
 
-    private func extractFolders(_ folders: [BackupFavoriteFolder]) -> [[String: Any]] {
+private enum FolderCoder {
+    static func build(_ folders: [[String: Any]]) -> [BackupFavoriteFolder] {
         folders.map { f in
-            [
-                "id": f.id,
-                "name": f.name,
-                "createdAt": Double(f.createdAt) / 1000.0,
-                "voicingOrder": f.voicingOrder.asStrings,
-            ] as [String: Any]
+            BackupFavoriteFolder(
+                id: f["id"] as? String ?? UUID().uuidString,
+                name: f["name"] as? String ?? "",
+                createdAt: BackupTimestamp.toMillis(f["createdAt"] as? Double ?? 0),
+                voicingOrder: f["voicingOrder"] as? [String] ?? []
+            )
         }
     }
 
-    private func extractChordSheets(_ sheets: [BackupChordSheet]) -> [[String: Any]] {
+    static func extract(_ folders: [BackupFavoriteFolder]) -> [[String: Any]] {
+        folders.map { [
+            "id": $0.id, "name": $0.name,
+            "createdAt": BackupTimestamp.toSeconds($0.createdAt),
+            "voicingOrder": $0.voicingOrder.asStrings,
+        ] as [String: Any] }
+    }
+}
+
+private enum ChordSheetCoder {
+    static func build(_ sheets: [[String: Any]]) -> [BackupChordSheet] {
+        sheets.map { s in
+            BackupChordSheet(
+                id: s["id"] as? String ?? UUID().uuidString,
+                title: s["title"] as? String ?? "",
+                subtitle: s["subtitle"] as? String ?? "",
+                artist: s["artist"] as? String ?? "",
+                content: s["content"] as? String ?? "",
+                key: s["key"] as? String ?? "",
+                capo: Int32(s["capo"] as? Int ?? 0),
+                strumPatternName: s["strumPatternName"] as? String ?? "",
+                labels: s["labels"] as? [String] ?? [],
+                createdAt: BackupTimestamp.fromAny(s["createdAt"]),
+                updatedAt: BackupTimestamp.fromAny(s["updatedAt"]),
+                viewCount: Int32(s["viewCount"] as? Int ?? 0),
+                lastViewedAt: BackupTimestamp.fromAny(s["lastViewedAt"]),
+                totalViewTimeMs: BackupTimestamp.fromAny(s["totalViewTimeMs"])
+            )
+        }
+    }
+
+    static func extract(_ sheets: [BackupChordSheet]) -> [[String: Any]] {
         sheets.map { s in
             [
-                "id": s.id,
-                "title": s.title,
-                "subtitle": s.subtitle,
-                "artist": s.artist,
-                "content": s.content,
-                "key": s.key,
+                "id": s.id, "title": s.title, "subtitle": s.subtitle,
+                "artist": s.artist, "content": s.content, "key": s.key,
                 "capo": Int(s.capo),
                 "strumPatternName": s.strumPatternName,
                 "labels": s.labels.asStrings,
-                "createdAt": Double(s.createdAt),
-                "updatedAt": Double(s.updatedAt),
+                "createdAt": Double(s.createdAt), "updatedAt": Double(s.updatedAt),
                 "viewCount": Int(s.viewCount),
                 "lastViewedAt": Double(s.lastViewedAt),
                 "totalViewTimeMs": Double(s.totalViewTimeMs),
             ] as [String: Any]
         }
     }
+}
 
-    private func extractProgressions(_ progs: [BackupProgression]) -> [[String: Any]] {
+private enum ProgressionCoder {
+    static func build(_ progs: [[String: Any]]) -> [BackupProgression] {
+        progs.compactMap { p -> BackupProgression? in
+            guard let intervals = p["degreeIntervals"] as? [Int],
+                  let qualities = p["degreeQualities"] as? [String],
+                  let numerals = p["degreeNumerals"] as? [String] else { return nil }
+            let count = min(intervals.count, qualities.count, numerals.count)
+            let degrees = (0..<count).map { i in
+                BackupChordDegree(interval: Int32(intervals[i]), quality: qualities[i], numeral: numerals[i])
+            }
+            guard !degrees.isEmpty else { return nil }
+            return BackupProgression(
+                id: p["id"] as? String ?? UUID().uuidString,
+                name: p["name"] as? String ?? "",
+                description: p["description"] as? String ?? "",
+                scaleType: p["scaleType"] as? String ?? "MAJOR",
+                degrees: degrees,
+                createdAt: BackupTimestamp.toMillis(p["createdAt"] as? Double ?? Date().timeIntervalSince1970)
+            )
+        }
+    }
+
+    static func extract(_ progs: [BackupProgression]) -> [[String: Any]] {
         progs.map { p in
             let degrees = p.degrees.asArray(of: BackupChordDegree.self)
             return [
-                "id": p.id,
-                "name": p.name,
+                "id": p.id, "name": p.name,
                 "description": p.description_,
                 "scaleType": p.scaleType,
                 "degreeIntervals": degrees.map { Int($0.interval) },
                 "degreeQualities": degrees.map { $0.quality },
                 "degreeNumerals": degrees.map { $0.numeral },
-                "createdAt": Double(p.createdAt) / 1000.0,
+                "createdAt": BackupTimestamp.toSeconds(p.createdAt),
             ] as [String: Any]
         }
     }
+}
 
-    private func extractMelodies(_ melodies: [BackupMelody]) -> [[String: Any]] {
+private enum StrumPatternCoder {
+    static func build(_ patterns: [[String: Any]]) -> [BackupStrumPattern] {
+        patterns.map { p in
+            let beats = (p["beats"] as? [[String: Any]] ?? []).map { b in
+                BackupStrumBeat(
+                    direction: b["direction"] as? String ?? "DOWN",
+                    emphasis: b["emphasis"] as? Bool ?? false
+                )
+            }
+            return BackupStrumPattern(
+                id: p["id"] as? String ?? UUID().uuidString,
+                name: p["name"] as? String ?? "",
+                beats: beats,
+                createdAt: BackupTimestamp.toMillis(p["createdAt"] as? Double ?? 0),
+                timeSignature: p["timeSignature"] as? String ?? "4/4"
+            )
+        }
+    }
+
+    static func extract(_ patterns: [BackupStrumPattern]) -> [[String: Any]] {
+        patterns.map { p in
+            let beats: [[String: Any]] = p.beats.asArray(of: BackupStrumBeat.self).map {
+                ["direction": $0.direction, "emphasis": $0.emphasis] as [String: Any]
+            }
+            return [
+                "id": p.id, "name": p.name, "beats": beats,
+                "createdAt": BackupTimestamp.toSeconds(p.createdAt),
+                "timeSignature": p.timeSignature,
+            ] as [String: Any]
+        }
+    }
+}
+
+private enum FingerpickPatternCoder {
+    private static let fingerToKMP: [String: String] = [
+        "T": "THUMB", "I": "INDEX", "M": "MIDDLE", "R": "RING", "P": "PINKY",
+    ]
+    private static let fingerFromKMP: [String: String] = {
+        Dictionary(uniqueKeysWithValues: fingerToKMP.map { ($0.value, $0.key) })
+    }()
+
+    static func build(_ patterns: [[String: Any]]) -> [BackupFingerpickingPattern] {
+        patterns.map { p in
+            let steps = (p["steps"] as? [[String: Any]] ?? []).map { s in
+                let finger = s["finger"] as? String ?? "T"
+                return BackupFingerpickStep(
+                    finger: fingerToKMP[finger] ?? finger,
+                    stringIndex: Int32(s["stringIndex"] as? Int ?? 0),
+                    emphasis: s["emphasis"] as? Bool ?? false
+                )
+            }
+            return BackupFingerpickingPattern(
+                id: p["id"] as? String ?? UUID().uuidString,
+                name: p["name"] as? String ?? "",
+                steps: steps,
+                createdAt: BackupTimestamp.toMillis(p["createdAt"] as? Double ?? 0),
+                timeSignature: p["timeSignature"] as? String ?? "4/4"
+            )
+        }
+    }
+
+    static func extract(_ patterns: [BackupFingerpickingPattern]) -> [[String: Any]] {
+        patterns.map { p in
+            let steps: [[String: Any]] = p.steps.asArray(of: BackupFingerpickStep.self).map {
+                [
+                    "finger": fingerFromKMP[$0.finger] ?? $0.finger,
+                    "stringIndex": Int($0.stringIndex),
+                    "emphasis": $0.emphasis,
+                ] as [String: Any]
+            }
+            return [
+                "id": p.id, "name": p.name, "steps": steps,
+                "createdAt": BackupTimestamp.toSeconds(p.createdAt),
+                "timeSignature": p.timeSignature,
+            ] as [String: Any]
+        }
+    }
+}
+
+private enum SetlistCoder {
+    static func build(_ setlists: [[String: Any]]) -> [BackupSetlist] {
+        setlists.map { sl in
+            BackupSetlist(
+                id: sl["id"] as? String ?? UUID().uuidString,
+                name: sl["name"] as? String ?? "",
+                songIds: sl["songIds"] as? [String] ?? [],
+                createdAt: BackupTimestamp.fromAny(sl["createdAt"]),
+                updatedAt: BackupTimestamp.fromAny(sl["updatedAt"])
+            )
+        }
+    }
+
+    static func extract(_ setlists: [BackupSetlist]) -> [[String: Any]] {
+        setlists.map { [
+            "id": $0.id, "name": $0.name,
+            "songIds": $0.songIds.asStrings,
+            "createdAt": Double($0.createdAt), "updatedAt": Double($0.updatedAt),
+        ] as [String: Any] }
+    }
+}
+
+private enum MelodyCoder {
+    private static let durationToKMP: [String: String] = [
+        "\u{1D15D}": "WHOLE", "\u{1D15E}": "HALF",
+        "\u{2669}": "QUARTER", "\u{266A}": "EIGHTH",
+        "\u{1D163}": "SIXTEENTH",
+    ]
+    private static let durationFromKMP: [String: String] = {
+        Dictionary(uniqueKeysWithValues: durationToKMP.map { ($0.value, $0.key) })
+    }()
+
+    static func build(_ melodies: [[String: Any]]) -> [BackupMelody] {
+        melodies.map { m in
+            let notes: [BackupMelodyNote] = (m["notes"] as? [[String: Any]] ?? []).map { n in
+                let dur = n["duration"] as? String ?? "QUARTER"
+                return BackupMelodyNote(
+                    pitchClass: (n["pitchClass"] as? Int).map { KotlinInt(int: Int32($0)) },
+                    octave: Int32(n["octave"] as? Int ?? 4),
+                    duration: durationToKMP[dur] ?? dur,
+                    stringIndex: nil, fret: nil
+                )
+            }
+            return BackupMelody(
+                id: m["id"] as? String ?? UUID().uuidString,
+                name: m["name"] as? String ?? "",
+                notes: notes,
+                bpm: Int32(m["bpm"] as? Int ?? 120),
+                createdAt: BackupTimestamp.toMillis(m["createdAt"] as? Double ?? 0)
+            )
+        }
+    }
+
+    static func extract(_ melodies: [BackupMelody]) -> [[String: Any]] {
         melodies.map { m in
             let notes: [[String: Any]] = m.notes.asArray(of: BackupMelodyNote.self).map { n in
                 var note: [String: Any] = [
                     "id": UUID().uuidString,
                     "octave": Int(n.octave),
-                    "duration": Self.durationFromKMP[n.duration] ?? n.duration,
+                    "duration": durationFromKMP[n.duration] ?? n.duration,
                 ]
                 if let pc = n.pitchClass?.intValue {
                     note["pitchClass"] = Int(pc)
@@ -527,97 +527,119 @@ final class BackupRestoreManager: ObservableObject {
                 return note
             }
             return [
-                "id": m.id,
-                "name": m.name,
-                "notes": notes,
+                "id": m.id, "name": m.name, "notes": notes,
                 "bpm": Int(m.bpm),
-                "createdAt": Double(m.createdAt) / 1000.0,
+                "createdAt": BackupTimestamp.toSeconds(m.createdAt),
             ] as [String: Any]
         }
     }
+}
 
-    private func extractStrumPatterns(_ patterns: [BackupStrumPattern]) -> [[String: Any]] {
-        patterns.map { p in
-            let beats: [[String: Any]] = p.beats.asArray(of: BackupStrumBeat.self).map { b in
-                ["direction": b.direction, "emphasis": b.emphasis] as [String: Any]
-            }
-            return [
-                "id": p.id,
-                "name": p.name,
-                "beats": beats,
-                "createdAt": Double(p.createdAt) / 1000.0,
-                "timeSignature": p.timeSignature,
-            ] as [String: Any]
+private enum LearningProgressCoder {
+    static func build(_ data: [String: Any]) -> BackupLearningProgress {
+        var entries: [String: String] = [:]
+        for (key, value) in data where key != "unlocked_achievements" {
+            entries[key] = "\(value)"
         }
+        return BackupLearningProgress(entries: entries)
     }
 
-    private func extractFingerpickPatterns(_ patterns: [BackupFingerpickingPattern]) -> [[String: Any]] {
-        patterns.map { p in
-            let steps: [[String: Any]] = p.steps.asArray(of: BackupFingerpickStep.self).map { s in
-                [
-                    "finger": Self.fingerFromKMP[s.finger] ?? s.finger,
-                    "stringIndex": Int(s.stringIndex),
-                    "emphasis": s.emphasis,
-                ] as [String: Any]
-            }
-            return [
-                "id": p.id,
-                "name": p.name,
-                "steps": steps,
-                "createdAt": Double(p.createdAt) / 1000.0,
-                "timeSignature": p.timeSignature,
-            ] as [String: Any]
-        }
-    }
-
-    private func extractSetlists(_ setlists: [BackupSetlist]) -> [[String: Any]] {
-        setlists.map { sl in
-            [
-                "id": sl.id,
-                "name": sl.name,
-                "songIds": sl.songIds.asStrings,
-                "createdAt": Double(sl.createdAt),
-                "updatedAt": Double(sl.updatedAt),
-            ] as [String: Any]
-        }
-    }
-
-    private func extractLearnProgress(_ entries: [String: String]) -> [String: Any] {
+    static func extract(_ entries: [String: String]) -> [String: Any] {
         var out: [String: Any] = [:]
         for (key, value) in entries {
-            if value == "true" {
-                out[key] = true
-            } else if value == "false" {
-                out[key] = false
-            } else if let intVal = Int(value) {
-                out[key] = intVal
-            } else {
-                out[key] = value
-            }
+            if value == "true" { out[key] = true }
+            else if value == "false" { out[key] = false }
+            else if let intVal = Int(value) { out[key] = intVal }
+            else { out[key] = value }
         }
         return out
     }
+}
 
-    private func extractPracticeTimer(_ timer: BackupPracticeTimer) -> [String: Any] {
+private enum AchievementCoder {
+    static func build(_ data: [String: Any]) -> [String: KotlinLong] {
+        guard let list = data["unlocked_achievements"] as? [String] else { return [:] }
+        var map: [String: KotlinLong] = [:]
+        for id in list { map[id] = KotlinLong(value: 0) }
+        return map
+    }
+}
+
+private enum PracticeTimerCoder {
+    static func build(_ timer: [String: Any]) -> BackupPracticeTimer {
+        let dailyMinutes = timer["dailyMinutes"] as? [String: Int] ?? [:]
+        var kmpDaily: [String: KotlinInt] = [:]
+        for (key, value) in dailyMinutes {
+            kmpDaily[key] = KotlinInt(int: Int32(value))
+        }
+        return BackupPracticeTimer(
+            totalMinutes: Int32(timer["totalMinutes"] as? Int ?? 0),
+            totalSessions: Int32(timer["totalSessions"] as? Int ?? 0),
+            longestSession: Int32(timer["longestSession"] as? Int ?? 0),
+            lastSessionTime: BackupTimestamp.toMillis(timer["lastSessionTime"] as? Double ?? 0),
+            dailyGoal: Int32(timer["dailyGoal"] as? Int ?? 15),
+            dailyMinutes: kmpDaily
+        )
+    }
+
+    static func extract(_ timer: BackupPracticeTimer) -> [String: Any] {
         var dailyMinutes: [String: Int] = [:]
         if let kmpDaily = timer.dailyMinutes as? [String: Any] {
             for (key, value) in kmpDaily {
-                if let num = value as? NSNumber {
-                    dailyMinutes[key] = num.intValue
-                }
+                if let num = value as? NSNumber { dailyMinutes[key] = num.intValue }
             }
         }
         return [
             "totalMinutes": Int(timer.totalMinutes),
             "totalSessions": Int(timer.totalSessions),
             "longestSession": Int(timer.longestSession),
-            "lastSessionTime": Double(timer.lastSessionTime) / 1000.0,
+            "lastSessionTime": BackupTimestamp.toSeconds(timer.lastSessionTime),
             "dailyGoal": Int(timer.dailyGoal),
             "dailyMinutes": dailyMinutes,
         ]
     }
+}
 
-    private func extractSettings(_ settings: BackupSettings) -> [String: Any] {
+private enum SettingsCoder {
+    private static let themeToKMP: [String: String] = [
+        "Light": "LIGHT", "Dark": "DARK",
+        "System": "SYSTEM", "High Contrast": "HIGH_CONTRAST",
+    ]
+    private static let themeFromKMP: [String: String] = {
+        Dictionary(uniqueKeysWithValues: themeToKMP.map { ($0.value, $0.key) })
+    }()
+    private static let tuningToKMP: [String: String] = [
+        "High-G (Standard)": "HIGH_G", "Low-G": "LOW_G",
+        "Baritone (DGBE)": "BARITONE", "D-Tuning (ADF#B)": "D_TUNING",
+        "Slack Key (GCEG)": "SLACK_KEY", "Open A (AC#EA)": "OPEN_A",
+        "Low A (GCEa)": "LOW_A", "Half-Step Down": "HALF_STEP_DOWN",
+    ]
+    private static let tuningFromKMP: [String: String] = {
+        Dictionary(uniqueKeysWithValues: tuningToKMP.map { ($0.value, $0.key) })
+    }()
+
+    static func build(_ settings: [String: Any]) -> BackupSettings {
+        let themeLabel = settings["theme_mode"] as? String ?? "System"
+        let tuningLabel = settings["selected_tuning"] as? String ?? "High-G (Standard)"
+        return BackupSettings(
+            soundEnabled: settings["sound_enabled"] as? Bool ?? true,
+            volume: Float(settings["volume"] as? Double ?? 0.7),
+            noteDurationMs: Int32(settings["note_duration_ms"] as? Int ?? 600),
+            strumDelayMs: Int32(settings["strum_delay_ms"] as? Int ?? 50),
+            strumDown: settings["strum_down"] as? Bool ?? true,
+            playOnTap: settings["play_on_tap"] as? Bool ?? false,
+            themeMode: themeToKMP[themeLabel] ?? "SYSTEM",
+            showExplorerTips: settings["show_tips"] as? Bool ?? true,
+            showLearnSection: settings["show_learn_tab"] as? Bool ?? true,
+            showReferenceSection: settings["show_reference_tab"] as? Bool ?? true,
+            tuning: tuningToKMP[tuningLabel] ?? "HIGH_G",
+            leftHanded: settings["left_handed"] as? Bool ?? false,
+            lastFret: Int32(settings["last_fret"] as? Int ?? 12),
+            showNoteNames: settings["show_note_names"] as? Bool ?? true
+        )
+    }
+
+    static func extract(_ settings: BackupSettings) -> [String: Any] {
         [
             "sound_enabled": settings.soundEnabled,
             "volume": Double(settings.volume),
@@ -625,75 +647,16 @@ final class BackupRestoreManager: ObservableObject {
             "strum_delay_ms": Int(settings.strumDelayMs),
             "strum_down": settings.strumDown,
             "play_on_tap": settings.playOnTap,
-            "theme_mode": Self.themeFromKMP[settings.themeMode] ?? "System",
+            "theme_mode": themeFromKMP[settings.themeMode] ?? "System",
             "show_tips": settings.showExplorerTips,
             "show_learn_tab": settings.showLearnSection,
             "show_reference_tab": settings.showReferenceSection,
-            "selected_tuning": Self.tuningFromKMP[settings.tuning] ?? "High-G (Standard)",
+            "selected_tuning": tuningFromKMP[settings.tuning] ?? "High-G (Standard)",
             "left_handed": settings.leftHanded,
             "last_fret": Int(settings.lastFret),
             "show_note_names": settings.showNoteNames,
         ]
     }
-
-    // MARK: - Helpers
-
-    private func millisFromAny(_ value: Any?) -> Int64 {
-        if let d = value as? Double {
-            return Int64(d)
-        } else if let i = value as? Int {
-            return Int64(i)
-        }
-        return 0
-    }
-
-    // MARK: - Domain mappings (iOS ↔ KMP)
-
-    private static let durationToKMP: [String: String] = [
-        "\u{1D15D}": "WHOLE",
-        "\u{1D15E}": "HALF",
-        "\u{2669}": "QUARTER",
-        "\u{266A}": "EIGHTH",
-        "\u{1D163}": "SIXTEENTH",
-    ]
-
-    private static let durationFromKMP: [String: String] = {
-        Dictionary(uniqueKeysWithValues: durationToKMP.map { ($0.value, $0.key) })
-    }()
-
-    private static let fingerToKMP: [String: String] = [
-        "T": "THUMB", "I": "INDEX", "M": "MIDDLE", "R": "RING", "P": "PINKY",
-    ]
-
-    private static let fingerFromKMP: [String: String] = {
-        Dictionary(uniqueKeysWithValues: fingerToKMP.map { ($0.value, $0.key) })
-    }()
-
-    private static let tuningToKMP: [String: String] = [
-        "High-G (Standard)": "HIGH_G",
-        "Low-G": "LOW_G",
-        "Baritone (DGBE)": "BARITONE",
-        "D-Tuning (ADF#B)": "D_TUNING",
-        "Slack Key (GCEG)": "SLACK_KEY",
-        "Open A (AC#EA)": "OPEN_A",
-        "Low A (GCEa)": "LOW_A",
-        "Half-Step Down": "HALF_STEP_DOWN",
-    ]
-
-    private static let tuningFromKMP: [String: String] = {
-        Dictionary(uniqueKeysWithValues: tuningToKMP.map { ($0.value, $0.key) })
-    }()
-
-    private static let themeToKMP: [String: String] = [
-        "Light": "LIGHT",
-        "Dark": "DARK",
-        "System": "SYSTEM",
-        "High Contrast": "HIGH_CONTRAST",
-    ]
-
-    private static let themeFromKMP: [String: String] = {
-        Dictionary(uniqueKeysWithValues: themeToKMP.map { ($0.value, $0.key) })
-    }()
 }
 
 struct BackupDocument: FileDocument {


### PR DESCRIPTION
## Summary

- Added `BackupTimestamp` helper centralizing all `toMillis`/`toSeconds` conversions
- Collapsed 23 scattered private `build*`/`extract*` methods into 11 co-located coder enums (e.g. `FavoriteCoder`, `StrumPatternCoder`, `MelodyCoder`)
- Relocated domain mapping dictionaries (`durationToKMP`/`From`, `fingerToKMP`/`From`, theme/tuning maps) into their respective coders
- Slimmed `BackupRestoreManager` to only properties, init, and public API methods

## Impact

- **716 → 678 lines** (net -38 lines, 321 deletions / 284 insertions)
- Adding a new data type requires one coder enum instead of two symmetric functions
- Timestamp unit conversion centralized (reduces seconds/millis confusion risk)
- All behavior preserved exactly

## Test plan

- [x] iOS build succeeds (`xcodebuild build`)
- [ ] CI: iOS Build & Test workflow

Fixes #453

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal architecture of backup and restore functionality to enhance maintainability and alignment with multi-platform systems. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->