### PR TITLE
Fix: make backup import atomic with snapshot-based rollback

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt
@@ -42,160 +42,181 @@ class BackupRestoreManager(
     private val setlistRepo by lazy { SetlistRepository(context) }
     private val achievementRepo by lazy { AchievementRepository(context) }
     private val practiceTimerRepo by lazy { PracticeTimerRepository(context) }
+
     /**
      * Collects all user data from all repositories and serializes to JSON.
      *
      * @return The complete backup as a JSON string.
      */
     fun exportBackup(): String {
-        val backup = BackupData(
-            version = BackupData.CURRENT_VERSION,
-            exportedAt = System.currentTimeMillis(),
-            favorites = favoritesRepo.getAll().map { fav ->
-                BackupFavorite(
-                    rootPitchClass = fav.rootPitchClass,
-                    chordSymbol = fav.chordSymbol,
-                    frets = fav.frets,
-                    addedAt = fav.addedAt,
-                    folderIds = fav.folderIds,
-                )
-            },
-            favoriteFolders = favoritesRepo.getAllFolders().map { folder ->
-                BackupFavoriteFolder(
-                    id = folder.id,
-                    name = folder.name,
-                    createdAt = folder.createdAt,
-                    voicingOrder = folder.voicingOrder,
-                )
-            },
-            chordSheets = chordSheetRepo.getAll().map { sheet ->
-                BackupChordSheet(
-                    id = sheet.id,
-                    title = sheet.title,
-                    subtitle = sheet.subtitle,
-                    artist = sheet.artist,
-                    content = sheet.content,
-                    key = sheet.key,
-                    capo = sheet.capo,
-                    strumPatternName = sheet.strumPatternName,
-                    labels = sheet.labels,
-                    createdAt = sheet.createdAt,
-                    updatedAt = sheet.updatedAt,
-                    viewCount = sheet.viewCount,
-                    lastViewedAt = sheet.lastViewedAt,
-                    totalViewTimeMs = sheet.totalViewTimeMs,
-                )
-            },
-            customProgressions = progressionRepo.getAll().map { cp ->
-                BackupProgression(
-                    id = cp.id,
-                    name = cp.progression.name,
-                    description = cp.progression.description,
-                    scaleType = cp.progression.scaleType.name,
-                    degrees = cp.progression.degrees.map { d ->
-                        BackupChordDegree(
-                            interval = d.interval,
-                            quality = d.quality,
-                            numeral = d.numeral,
+        val backup =
+            BackupData(
+                version = BackupData.CURRENT_VERSION,
+                exportedAt = System.currentTimeMillis(),
+                favorites =
+                    favoritesRepo.getAll().map { fav ->
+                        BackupFavorite(
+                            rootPitchClass = fav.rootPitchClass,
+                            chordSymbol = fav.chordSymbol,
+                            frets = fav.frets,
+                            addedAt = fav.addedAt,
+                            folderIds = fav.folderIds,
                         )
                     },
-                    createdAt = cp.createdAt,
-                )
-            },
-            customStrumPatterns = strumPatternRepo.getAll().map { csp ->
-                BackupStrumPattern(
-                    id = csp.id,
-                    name = csp.pattern.name,
-                    beats = csp.pattern.beats.map { b ->
-                        BackupStrumBeat(
-                            direction = b.direction.name,
-                            emphasis = b.emphasis,
+                favoriteFolders =
+                    favoritesRepo.getAllFolders().map { folder ->
+                        BackupFavoriteFolder(
+                            id = folder.id,
+                            name = folder.name,
+                            createdAt = folder.createdAt,
+                            voicingOrder = folder.voicingOrder,
                         )
                     },
-                    createdAt = csp.createdAt,
-                    timeSignature = csp.pattern.timeSignature,
-                )
-            },
-            customFingerpickingPatterns = fingerpickingRepo.getAll().map { cfp ->
-                BackupFingerpickingPattern(
-                    id = cfp.id,
-                    name = cfp.pattern.name,
-                    steps = cfp.pattern.steps.map { s ->
-                        BackupFingerpickStep(
-                            finger = s.finger.name,
-                            stringIndex = s.stringIndex,
-                            emphasis = s.emphasis,
+                chordSheets =
+                    chordSheetRepo.getAll().map { sheet ->
+                        BackupChordSheet(
+                            id = sheet.id,
+                            title = sheet.title,
+                            subtitle = sheet.subtitle,
+                            artist = sheet.artist,
+                            content = sheet.content,
+                            key = sheet.key,
+                            capo = sheet.capo,
+                            strumPatternName = sheet.strumPatternName,
+                            labels = sheet.labels,
+                            createdAt = sheet.createdAt,
+                            updatedAt = sheet.updatedAt,
+                            viewCount = sheet.viewCount,
+                            lastViewedAt = sheet.lastViewedAt,
+                            totalViewTimeMs = sheet.totalViewTimeMs,
                         )
                     },
-                    createdAt = cfp.createdAt,
-                    timeSignature = cfp.pattern.timeSignature,
-                )
-            },
-            melodies = melodyRepo.getAll().map { melody ->
-                BackupMelody(
-                    id = melody.id,
-                    name = melody.name,
-                    notes = melody.notes.map { n ->
-                        BackupMelodyNote(
-                            pitchClass = n.pitchClass,
-                            octave = n.octave,
-                            duration = n.duration.name,
-                            stringIndex = n.stringIndex,
-                            fret = n.fret,
+                customProgressions =
+                    progressionRepo.getAll().map { cp ->
+                        BackupProgression(
+                            id = cp.id,
+                            name = cp.progression.name,
+                            description = cp.progression.description,
+                            scaleType = cp.progression.scaleType.name,
+                            degrees =
+                                cp.progression.degrees.map { d ->
+                                    BackupChordDegree(
+                                        interval = d.interval,
+                                        quality = d.quality,
+                                        numeral = d.numeral,
+                                    )
+                                },
+                            createdAt = cp.createdAt,
                         )
                     },
-                    bpm = melody.bpm,
-                    createdAt = melody.createdAt,
-                )
-            },
-            learningProgress = BackupLearningProgress(
-                entries = learningProgressRepo.exportAll(),
-            ),
-            setlists = setlistRepo.getAll().map { sl ->
-                BackupSetlist(
-                    id = sl.id,
-                    name = sl.name,
-                    songIds = sl.songIds,
-                    createdAt = sl.createdAt,
-                    updatedAt = sl.updatedAt,
-                )
-            },
-            achievements = achievementRepo.exportAll(),
-            practiceTimer = practiceTimerRepo.exportAll().let { pt ->
-                BackupPracticeTimer(
-                    totalMinutes = pt.totalMinutes,
-                    totalSessions = pt.totalSessions,
-                    longestSession = pt.longestSession,
-                    lastSessionTime = pt.lastSessionTime,
-                    dailyGoal = pt.dailyGoal,
-                    dailyMinutes = pt.dailyMinutes,
-                )
-            },
-            settings = settingsViewModel.exportSettings().let { s ->
-                BackupSettings(
-                    soundEnabled = s.sound.enabled,
-                    volume = s.sound.volume,
-                    noteDurationMs = s.sound.noteDurationMs,
-                    strumDelayMs = s.sound.strumDelayMs,
-                    strumDown = s.sound.strumDown,
-                    playOnTap = s.sound.playOnTap,
-                    themeMode = s.display.themeMode.name,
-                    showExplorerTips = s.display.showExplorerTips,
-                    showLearnSection = s.display.showLearnSection,
-                    showReferenceSection = s.display.showReferenceSection,
-                    tuning = s.tuning.tuning.name,
-                    leftHanded = s.fretboard.leftHanded,
-                    lastFret = s.fretboard.lastFret,
-                    showNoteNames = s.fretboard.showNoteNames,
-                )
-            },
-        )
+                customStrumPatterns =
+                    strumPatternRepo.getAll().map { csp ->
+                        BackupStrumPattern(
+                            id = csp.id,
+                            name = csp.pattern.name,
+                            beats =
+                                csp.pattern.beats.map { b ->
+                                    BackupStrumBeat(
+                                        direction = b.direction.name,
+                                        emphasis = b.emphasis,
+                                    )
+                                },
+                            createdAt = csp.createdAt,
+                            timeSignature = csp.pattern.timeSignature,
+                        )
+                    },
+                customFingerpickingPatterns =
+                    fingerpickingRepo.getAll().map { cfp ->
+                        BackupFingerpickingPattern(
+                            id = cfp.id,
+                            name = cfp.pattern.name,
+                            steps =
+                                cfp.pattern.steps.map { s ->
+                                    BackupFingerpickStep(
+                                        finger = s.finger.name,
+                                        stringIndex = s.stringIndex,
+                                        emphasis = s.emphasis,
+                                    )
+                                },
+                            createdAt = cfp.createdAt,
+                            timeSignature = cfp.pattern.timeSignature,
+                        )
+                    },
+                melodies =
+                    melodyRepo.getAll().map { melody ->
+                        BackupMelody(
+                            id = melody.id,
+                            name = melody.name,
+                            notes =
+                                melody.notes.map { n ->
+                                    BackupMelodyNote(
+                                        pitchClass = n.pitchClass,
+                                        octave = n.octave,
+                                        duration = n.duration.name,
+                                        stringIndex = n.stringIndex,
+                                        fret = n.fret,
+                                    )
+                                },
+                            bpm = melody.bpm,
+                            createdAt = melody.createdAt,
+                        )
+                    },
+                learningProgress =
+                    BackupLearningProgress(
+                        entries = learningProgressRepo.exportAll(),
+                    ),
+                setlists =
+                    setlistRepo.getAll().map { sl ->
+                        BackupSetlist(
+                            id = sl.id,
+                            name = sl.name,
+                            songIds = sl.songIds,
+                            createdAt = sl.createdAt,
+                            updatedAt = sl.updatedAt,
+                        )
+                    },
+                achievements = achievementRepo.exportAll(),
+                practiceTimer =
+                    practiceTimerRepo.exportAll().let { pt ->
+                        BackupPracticeTimer(
+                            totalMinutes = pt.totalMinutes,
+                            totalSessions = pt.totalSessions,
+                            longestSession = pt.longestSession,
+                            lastSessionTime = pt.lastSessionTime,
+                            dailyGoal = pt.dailyGoal,
+                            dailyMinutes = pt.dailyMinutes,
+                        )
+                    },
+                settings =
+                    settingsViewModel.exportSettings().let { s ->
+                        BackupSettings(
+                            soundEnabled = s.sound.enabled,
+                            volume = s.sound.volume,
+                            noteDurationMs = s.sound.noteDurationMs,
+                            strumDelayMs = s.sound.strumDelayMs,
+                            strumDown = s.sound.strumDown,
+                            playOnTap = s.sound.playOnTap,
+                            themeMode = s.display.themeMode.name,
+                            showExplorerTips = s.display.showExplorerTips,
+                            showLearnSection = s.display.showLearnSection,
+                            showReferenceSection = s.display.showReferenceSection,
+                            tuning = s.tuning.tuning.name,
+                            leftHanded = s.fretboard.leftHanded,
+                            lastFret = s.fretboard.lastFret,
+                            showNoteNames = s.fretboard.showNoteNames,
+                        )
+                    },
+            )
 
         return BackupCodec.encode(backup)
     }
 
     /**
      * Deserializes a JSON backup string and imports all data into local storage.
+     *
+     * **Atomicity guarantee:** If any category fails to import (due to serialization
+     * errors, disk issues, etc.), ALL changes are rolled back and the user's data
+     * remains exactly as it was before the import was attempted.
      *
      * Merge strategy:
      * - Favorites, folders, chord sheets, progressions, patterns, setlists: union merge
@@ -207,17 +228,65 @@ class BackupRestoreManager(
      *   onboarding, etc.) are preserved at their current values.
      *
      * @param jsonContent The JSON string from a backup file.
+     * @throws Exception if the backup is invalid (no data is modified).
      */
     fun importBackup(jsonContent: String) {
         val backup = BackupCodec.decode(jsonContent)
 
-        // --- Favorites ---
-        favoritesRepo.importAll(backup.favorites.mapNotNull { f ->
+        // ── Phase 1: Prepare all domain objects in memory (no writes) ──
+        val preparedFavorites = prepareFavorites(backup.favorites)
+        val preparedFolders = prepareFolders(backup.favoriteFolders)
+        val preparedSheets = prepareChordSheets(backup.chordSheets)
+        val preparedProgressions = prepareProgressions(backup.customProgressions)
+        val preparedStrumPatterns = prepareStrumPatterns(backup.customStrumPatterns)
+        val preparedFingerpicking = prepareFingerpickingPatterns(backup.customFingerpickingPatterns)
+        val preparedMelodies = prepareMelodies(backup.melodies)
+        val preparedSetlists = prepareSetlists(backup.setlists)
+        val preparedPracticeTimer =
+            com.baijum.ukufretboard.data.PracticeTimerExport(
+                totalMinutes = backup.practiceTimer.totalMinutes,
+                totalSessions = backup.practiceTimer.totalSessions,
+                longestSession = backup.practiceTimer.longestSession,
+                lastSessionTime = backup.practiceTimer.lastSessionTime,
+                dailyGoal = backup.practiceTimer.dailyGoal,
+                dailyMinutes = backup.practiceTimer.dailyMinutes,
+            )
+        val preparedSettings = prepareSettings(backup.settings)
+
+        // ── Phase 2: Snapshot current state for rollback ──
+        val snapshot = snapshotAllPrefs()
+        val settingsSnapshot = settingsViewModel.exportSettings()
+
+        // ── Phase 3: Apply all writes; rollback on any failure ──
+        try {
+            favoritesRepo.importAll(preparedFavorites)
+            favoritesRepo.importFolders(preparedFolders)
+            chordSheetRepo.importAll(preparedSheets)
+            progressionRepo.importAll(preparedProgressions)
+            strumPatternRepo.importAll(preparedStrumPatterns)
+            fingerpickingRepo.importAll(preparedFingerpicking)
+            melodyRepo.importAll(preparedMelodies)
+            learningProgressRepo.importAll(backup.learningProgress.entries)
+            setlistRepo.importAll(preparedSetlists)
+            achievementRepo.importAll(backup.achievements)
+            practiceTimerRepo.importAll(preparedPracticeTimer)
+            settingsViewModel.replaceAll(preparedSettings)
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            e: Exception,
+        ) {
+            restoreSnapshot(snapshot)
+            settingsViewModel.replaceAll(settingsSnapshot)
+            throw e
+        }
+    }
+
+    // ── Phase 1 helpers: prepare domain objects without writing ──────
+
+    private fun prepareFavorites(items: List<BackupFavorite>): List<FavoriteVoicing> =
+        items.mapNotNull { f ->
             if (f.rootPitchClass !in 0..11) return@mapNotNull null
-            // Backward compat: if folderIds is empty but old folderId is present, migrate
-            val ids = f.folderIds.ifEmpty {
-                listOfNotNull(f.folderId)
-            }
+            val ids = f.folderIds.ifEmpty { listOfNotNull(f.folderId) }
             FavoriteVoicing(
                 rootPitchClass = f.rootPitchClass,
                 chordSymbol = f.chordSymbol,
@@ -225,20 +294,20 @@ class BackupRestoreManager(
                 addedAt = f.addedAt,
                 folderIds = ids,
             )
-        })
+        }
 
-        // --- Favorite folders ---
-        favoritesRepo.importFolders(backup.favoriteFolders.map { f ->
+    private fun prepareFolders(items: List<BackupFavoriteFolder>): List<FavoriteFolder> =
+        items.map { f ->
             FavoriteFolder(
                 id = f.id,
                 name = f.name,
                 createdAt = f.createdAt,
                 voicingOrder = f.voicingOrder,
             )
-        })
+        }
 
-        // --- Chord sheets ---
-        chordSheetRepo.importAll(backup.chordSheets.map { s ->
+    private fun prepareChordSheets(items: List<BackupChordSheet>): List<com.baijum.ukufretboard.data.ChordSheet> =
+        items.map { s ->
             com.baijum.ukufretboard.data.ChordSheet(
                 id = s.id,
                 title = s.title,
@@ -255,25 +324,10 @@ class BackupRestoreManager(
                 lastViewedAt = s.lastViewedAt,
                 totalViewTimeMs = s.totalViewTimeMs,
             )
-        })
+        }
 
-        // --- Custom progressions ---
-        importProgressions(backup.customProgressions)
-
-        // --- Custom strum patterns ---
-        importStrumPatterns(backup.customStrumPatterns)
-
-        // --- Custom fingerpicking patterns ---
-        importFingerpickingPatterns(backup.customFingerpickingPatterns)
-
-        // --- Melodies ---
-        importMelodies(backup.melodies)
-
-        // --- Learning progress ---
-        learningProgressRepo.importAll(backup.learningProgress.entries)
-
-        // --- Setlists ---
-        setlistRepo.importAll(backup.setlists.map { sl ->
+    private fun prepareSetlists(items: List<BackupSetlist>): List<Setlist> =
+        items.map { sl ->
             Setlist(
                 id = sl.id,
                 name = sl.name,
@@ -281,30 +335,13 @@ class BackupRestoreManager(
                 createdAt = sl.createdAt,
                 updatedAt = sl.updatedAt,
             )
-        })
+        }
 
-        // --- Achievements ---
-        achievementRepo.importAll(backup.achievements)
-
-        // --- Practice timer ---
-        practiceTimerRepo.importAll(
-            com.baijum.ukufretboard.data.PracticeTimerExport(
-                totalMinutes = backup.practiceTimer.totalMinutes,
-                totalSessions = backup.practiceTimer.totalSessions,
-                longestSession = backup.practiceTimer.longestSession,
-                lastSessionTime = backup.practiceTimer.lastSessionTime,
-                dailyGoal = backup.practiceTimer.dailyGoal,
-                dailyMinutes = backup.practiceTimer.dailyMinutes,
-            )
-        )
-
-        // --- Settings (merge into current -- backup only covers a subset of
-        //     AppSettings, so we must preserve fields that were never exported) ---
+    private fun prepareSettings(bs: BackupSettings): com.baijum.ukufretboard.data.AppSettings {
         val current = settingsViewModel.exportSettings()
-        val bs = backup.settings
-        settingsViewModel.replaceAll(
-            current.copy(
-                sound = current.sound.copy(
+        return current.copy(
+            sound =
+                current.sound.copy(
                     enabled = bs.soundEnabled,
                     volume = bs.volume,
                     noteDurationMs = bs.noteDurationMs,
@@ -312,145 +349,216 @@ class BackupRestoreManager(
                     strumDown = bs.strumDown,
                     playOnTap = bs.playOnTap,
                 ),
-                display = current.display.copy(
-                    themeMode = try {
-                        ThemeMode.valueOf(bs.themeMode)
-                    } catch (_: Exception) {
-                        current.display.themeMode
-                    },
+            display =
+                current.display.copy(
+                    themeMode =
+                        try {
+                            ThemeMode.valueOf(bs.themeMode)
+                        } catch (_: Exception) {
+                            current.display.themeMode
+                        },
                     showExplorerTips = bs.showExplorerTips,
                     showLearnSection = bs.showLearnSection,
                     showReferenceSection = bs.showReferenceSection,
                 ),
-                tuning = current.tuning.copy(
-                    tuning = try {
-                        UkuleleTuning.valueOf(bs.tuning)
-                    } catch (_: Exception) {
-                        current.tuning.tuning
-                    },
+            tuning =
+                current.tuning.copy(
+                    tuning =
+                        try {
+                            UkuleleTuning.valueOf(bs.tuning)
+                        } catch (_: Exception) {
+                            current.tuning.tuning
+                        },
                 ),
-                fretboard = current.fretboard.copy(
+            fretboard =
+                current.fretboard.copy(
                     leftHanded = bs.leftHanded,
                     lastFret = bs.lastFret,
                     showNoteNames = bs.showNoteNames,
                 ),
-            )
         )
     }
 
-    // --- Helpers for importing domain objects that need reconstruction ---
+    // ── Snapshot / rollback ─────────────────────────────────────────
 
-    private fun importProgressions(items: List<BackupProgression>) {
-        val domainItems = items.mapNotNull { bp ->
+    private fun snapshotAllPrefs(): List<PrefsSnapshot> =
+        AFFECTED_PREFS.map { prefsName ->
+            val prefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+            PrefsSnapshot(prefsName, prefs.all.toMap())
+        }
+
+    private fun restoreSnapshot(snapshots: List<PrefsSnapshot>) {
+        for (snapshot in snapshots) {
+            val prefs = context.getSharedPreferences(snapshot.prefsName, Context.MODE_PRIVATE)
+            val editor = prefs.edit().clear()
+            for ((key, value) in snapshot.entries) {
+                when (value) {
+                    is String -> {
+                        editor.putString(key, value)
+                    }
+
+                    is Int -> {
+                        editor.putInt(key, value)
+                    }
+
+                    is Long -> {
+                        editor.putLong(key, value)
+                    }
+
+                    is Float -> {
+                        editor.putFloat(key, value)
+                    }
+
+                    is Boolean -> {
+                        editor.putBoolean(key, value)
+                    }
+
+                    is Set<*> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        editor.putStringSet(key, value as Set<String>)
+                    }
+                }
+            }
+            editor.commit()
+        }
+    }
+
+    private data class PrefsSnapshot(
+        val prefsName: String,
+        val entries: Map<String, Any?>,
+    )
+
+    // ── Helpers for reconstructing domain objects from backup format ──
+
+    private fun prepareProgressions(
+        items: List<BackupProgression>,
+    ): List<com.baijum.ukufretboard.data.CustomProgression> =
+        items.mapNotNull { bp ->
             try {
                 com.baijum.ukufretboard.data.CustomProgression(
                     id = bp.id,
-                    progression = com.baijum.ukufretboard.data.Progression(
-                        name = bp.name,
-                        description = bp.description,
-                        degrees = bp.degrees.map { d ->
-                            com.baijum.ukufretboard.data.ChordDegree(
-                                interval = d.interval,
-                                quality = d.quality,
-                                numeral = d.numeral,
-                            )
-                        },
-                        scaleType = com.baijum.ukufretboard.data.ScaleType.valueOf(bp.scaleType),
-                    ),
+                    progression =
+                        com.baijum.ukufretboard.data.Progression(
+                            name = bp.name,
+                            description = bp.description,
+                            degrees =
+                                bp.degrees.map { d ->
+                                    com.baijum.ukufretboard.data.ChordDegree(
+                                        interval = d.interval,
+                                        quality = d.quality,
+                                        numeral = d.numeral,
+                                    )
+                                },
+                            scaleType =
+                                com.baijum.ukufretboard.data.ScaleType
+                                    .valueOf(bp.scaleType),
+                        ),
                     createdAt = bp.createdAt,
                 )
             } catch (_: Exception) {
                 null
             }
         }
-        progressionRepo.importAll(domainItems)
-    }
 
-    private fun importStrumPatterns(items: List<BackupStrumPattern>) {
-        val domainItems = items.mapNotNull { bsp ->
+    private fun prepareStrumPatterns(
+        items: List<BackupStrumPattern>,
+    ): List<com.baijum.ukufretboard.data.CustomStrumPattern> =
+        items.mapNotNull { bsp ->
             try {
-                val beats = bsp.beats.map { b ->
-                    com.baijum.ukufretboard.data.StrumBeat(
-                        direction = com.baijum.ukufretboard.data.StrumDirection.valueOf(b.direction),
-                        emphasis = b.emphasis,
-                    )
-                }
-                val notation = beats.joinToString(" ") { b ->
-                    if (b.emphasis) b.direction.symbol.uppercase()
-                    else b.direction.symbol
-                }
+                val beats =
+                    bsp.beats.map { b ->
+                        com.baijum.ukufretboard.data.StrumBeat(
+                            direction =
+                                com.baijum.ukufretboard.data.StrumDirection
+                                    .valueOf(b.direction),
+                            emphasis = b.emphasis,
+                        )
+                    }
+                val notation =
+                    beats.joinToString(" ") { b ->
+                        if (b.emphasis) {
+                            b.direction.symbol.uppercase()
+                        } else {
+                            b.direction.symbol
+                        }
+                    }
                 com.baijum.ukufretboard.data.CustomStrumPattern(
                     id = bsp.id,
-                    pattern = com.baijum.ukufretboard.data.StrumPattern(
-                        name = bsp.name,
-                        description = "Custom pattern",
-                        difficulty = com.baijum.ukufretboard.data.Difficulty.BEGINNER,
-                        timeSignature = bsp.timeSignature,
-                        beats = beats,
-                        notation = notation,
-                        suggestedBpm = 80..120,
-                    ),
+                    pattern =
+                        com.baijum.ukufretboard.data.StrumPattern(
+                            name = bsp.name,
+                            description = "Custom pattern",
+                            difficulty = com.baijum.ukufretboard.data.Difficulty.BEGINNER,
+                            timeSignature = bsp.timeSignature,
+                            beats = beats,
+                            notation = notation,
+                            suggestedBpm = 80..120,
+                        ),
                     createdAt = bsp.createdAt,
                 )
             } catch (_: Exception) {
                 null
             }
         }
-        strumPatternRepo.importAll(domainItems)
-    }
 
-    private fun importFingerpickingPatterns(items: List<BackupFingerpickingPattern>) {
-        val domainItems = items.mapNotNull { bfp ->
+    private fun prepareFingerpickingPatterns(
+        items: List<BackupFingerpickingPattern>,
+    ): List<com.baijum.ukufretboard.data.CustomFingerpickingPattern> =
+        items.mapNotNull { bfp ->
             try {
                 val validRange = 0 until com.baijum.ukufretboard.data.FingerpickingPatterns.STRING_NAMES.size
-                val steps = bfp.steps.mapNotNull { s ->
-                    if (s.stringIndex !in validRange) return@mapNotNull null
-                    com.baijum.ukufretboard.data.FingerpickStep(
-                        finger = com.baijum.ukufretboard.data.Finger.valueOf(s.finger),
-                        stringIndex = s.stringIndex,
-                        emphasis = s.emphasis,
-                    )
-                }
+                val steps =
+                    bfp.steps.mapNotNull { s ->
+                        if (s.stringIndex !in validRange) return@mapNotNull null
+                        com.baijum.ukufretboard.data.FingerpickStep(
+                            finger =
+                                com.baijum.ukufretboard.data.Finger
+                                    .valueOf(s.finger),
+                            stringIndex = s.stringIndex,
+                            emphasis = s.emphasis,
+                        )
+                    }
                 if (steps.isEmpty()) return@mapNotNull null
-                val notation = steps.joinToString(" ") { s ->
-                    val stringName = com.baijum.ukufretboard.data.FingerpickingPatterns.STRING_NAMES[s.stringIndex]
-                    "${s.finger.label}($stringName)"
-                }
+                val notation =
+                    steps.joinToString(" ") { s ->
+                        val stringName = com.baijum.ukufretboard.data.FingerpickingPatterns.STRING_NAMES[s.stringIndex]
+                        "${s.finger.label}($stringName)"
+                    }
                 com.baijum.ukufretboard.data.CustomFingerpickingPattern(
                     id = bfp.id,
-                    pattern = com.baijum.ukufretboard.data.FingerpickingPattern(
-                        name = bfp.name,
-                        description = "Custom pattern",
-                        difficulty = com.baijum.ukufretboard.data.Difficulty.BEGINNER,
-                        timeSignature = bfp.timeSignature,
-                        steps = steps,
-                        notation = notation,
-                        suggestedBpm = 60..100,
-                    ),
+                    pattern =
+                        com.baijum.ukufretboard.data.FingerpickingPattern(
+                            name = bfp.name,
+                            description = "Custom pattern",
+                            difficulty = com.baijum.ukufretboard.data.Difficulty.BEGINNER,
+                            timeSignature = bfp.timeSignature,
+                            steps = steps,
+                            notation = notation,
+                            suggestedBpm = 60..100,
+                        ),
                     createdAt = bfp.createdAt,
                 )
             } catch (_: Exception) {
                 null
             }
         }
-        fingerpickingRepo.importAll(domainItems)
-    }
 
-    private fun importMelodies(items: List<BackupMelody>) {
-        val domainItems = items.mapNotNull { bm ->
+    private fun prepareMelodies(items: List<BackupMelody>): List<Melody> =
+        items.mapNotNull { bm ->
             try {
                 Melody(
                     id = bm.id,
                     name = bm.name,
-                    notes = bm.notes.map { n ->
-                        MelodyNote(
-                            pitchClass = n.pitchClass?.takeIf { it in 0..11 },
-                            octave = n.octave.coerceIn(3, 5),
-                            duration = NoteDuration.valueOf(n.duration),
-                            stringIndex = n.stringIndex?.takeIf { it in 0..3 },
-                            fret = n.fret,
-                        )
-                    },
+                    notes =
+                        bm.notes.map { n ->
+                            MelodyNote(
+                                pitchClass = n.pitchClass?.takeIf { it in 0..11 },
+                                octave = n.octave.coerceIn(3, 5),
+                                duration = NoteDuration.valueOf(n.duration),
+                                stringIndex = n.stringIndex?.takeIf { it in 0..3 },
+                                fret = n.fret,
+                            )
+                        },
                     bpm = bm.bpm,
                     createdAt = bm.createdAt,
                 )
@@ -458,7 +566,23 @@ class BackupRestoreManager(
                 null
             }
         }
-        melodyRepo.importAll(domainItems)
-    }
 
+    companion object {
+        /** All SharedPreferences files that importBackup may write to. */
+        private val AFFECTED_PREFS =
+            listOf(
+                "chord_favorites",
+                "favorite_folders",
+                "chord_sheets",
+                "custom_progressions",
+                "custom_strum_patterns",
+                "custom_fingerpicking_patterns",
+                "melodies",
+                "learn_section_progress",
+                "setlists",
+                "achievements",
+                "practice_timer",
+                "app_settings",
+            )
+    }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/sync/BackupRestoreManagerTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/sync/BackupRestoreManagerTest.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -28,7 +29,6 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class BackupRestoreManagerTest {
-
     private lateinit var app: Application
     private lateinit var settingsVM: SettingsViewModel
     private lateinit var manager: BackupRestoreManager
@@ -48,7 +48,10 @@ class BackupRestoreManagerTest {
         val root = Json.parseToJsonElement(json).jsonObject
         assertEquals("3", root["version"]?.jsonPrimitive?.content)
         assertNotNull(root["exportedAt"])
-        assertTrue(root["favorites"]!!.toString().contains("[]") || root["favorites"]!!.toString() == "[\n]" || root["favorites"]!!.toString().trim().let { it == "[]" || it == "[\n\n]" || it.startsWith("[") })
+        assertTrue(
+            root["favorites"]!!.toString().contains("[]") || root["favorites"]!!.toString() == "[\n]" ||
+                root["favorites"]!!.toString().trim().let { it == "[]" || it == "[\n\n]" || it.startsWith("[") },
+        )
     }
 
     @Test
@@ -69,10 +72,15 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesFavorites() {
-        val backup = buildMinimalBackup(
-            favorites = """[{"rootPitchClass":0,"chordSymbol":"m7","frets":[0,2,3,3],"addedAt":5000,"folderIds":["f1"]}]""",
-            favoriteFolders = """[{"id":"f1","name":"Jazz","createdAt":6000,"voicingOrder":["0|m7|0,2,3,3"]}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                favorites =
+                    """[{"rootPitchClass":0,"chordSymbol":"m7",""" +
+                        """"frets":[0,2,3,3],"addedAt":5000,"folderIds":["f1"]}]""",
+                favoriteFolders =
+                    """[{"id":"f1","name":"Jazz","createdAt":6000,""" +
+                        """"voicingOrder":["0|m7|0,2,3,3"]}]""",
+            )
         manager.importBackup(backup)
         val favRepo = FavoritesRepository(app)
         val all = favRepo.getAll()
@@ -87,9 +95,16 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesChordSheets() {
-        val backup = buildMinimalBackup(
-            chordSheets = """[{"id":"s1","title":"Rainbow","artist":"IZ","content":"[C]Over","key":"C","capo":2,"strumPatternName":"","labels":["Hawaiian"],"createdAt":100,"updatedAt":200,"viewCount":5,"lastViewedAt":150,"totalViewTimeMs":9000}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                chordSheets =
+                    """[{"id":"s1","title":"Rainbow","artist":"IZ",""" +
+                        """"content":"[C]Over","key":"C","capo":2,""" +
+                        """"strumPatternName":"",""" +
+                        """"labels":["Hawaiian"],"createdAt":100,""" +
+                        """"updatedAt":200,"viewCount":5,""" +
+                        """"lastViewedAt":150,"totalViewTimeMs":9000}]""",
+            )
         manager.importBackup(backup)
         val repo = ChordSheetRepository(app)
         val sheet = repo.get("s1")
@@ -103,9 +118,14 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesMelodies() {
-        val backup = buildMinimalBackup(
-            melodies = """[{"id":"m1","name":"Scale","notes":[{"pitchClass":0,"octave":4,"duration":"QUARTER","stringIndex":2,"fret":3}],"bpm":100,"createdAt":7000}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                melodies =
+                    """[{"id":"m1","name":"Scale","notes":""" +
+                        """[{"pitchClass":0,"octave":4,""" +
+                        """"duration":"QUARTER","stringIndex":2,""" +
+                        """"fret":3}],"bpm":100,"createdAt":7000}]""",
+            )
         manager.importBackup(backup)
         val repo = MelodyRepository(app)
         val melody = repo.get("m1")
@@ -118,9 +138,10 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesSetlists() {
-        val backup = buildMinimalBackup(
-            setlists = """[{"id":"sl1","name":"Friday","songIds":["s1","s2"],"createdAt":100,"updatedAt":200}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                setlists = """[{"id":"sl1","name":"Friday","songIds":["s1","s2"],"createdAt":100,"updatedAt":200}]""",
+            )
         manager.importBackup(backup)
         val repo = SetlistRepository(app)
         val all = repo.getAll()
@@ -141,9 +162,13 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesPracticeTimer() {
-        val backup = buildMinimalBackup(
-            practiceTimer = """{"totalMinutes":60,"totalSessions":10,"longestSession":15,"lastSessionTime":9999,"dailyGoal":20,"dailyMinutes":{"2025-01-01":10}}""",
-        )
+        val backup =
+            buildMinimalBackup(
+                practiceTimer =
+                    """{"totalMinutes":60,"totalSessions":10,""" +
+                        """"longestSession":15,"lastSessionTime":9999,""" +
+                        """"dailyGoal":20,"dailyMinutes":{"2025-01-01":10}}""",
+            )
         manager.importBackup(backup)
         val repo = PracticeTimerRepository(app)
         assertEquals(60, repo.totalMinutes())
@@ -154,9 +179,10 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importExportRoundTripPreservesLearningProgress() {
-        val backup = buildMinimalBackup(
-            learningProgress = """{"entries":{"lesson_done_basics":"true","quiz_total_ALL":"5"}}""",
-        )
+        val backup =
+            buildMinimalBackup(
+                learningProgress = """{"entries":{"lesson_done_basics":"true","quiz_total_ALL":"5"}}""",
+            )
         manager.importBackup(backup)
         val repo = LearningProgressRepository(app)
         assertTrue(repo.isLessonCompleted("basics"))
@@ -168,12 +194,13 @@ class BackupRestoreManagerTest {
     fun importMergesWithExistingFavorites() {
         val favRepo = FavoritesRepository(app)
         favRepo.add(FavoriteVoicing(0, "maj", listOf(0, 0, 0, 3), 1000L))
-        val backup = buildMinimalBackup(
-            favorites = """[
+        val backup =
+            buildMinimalBackup(
+                favorites = """[
                 {"rootPitchClass":0,"chordSymbol":"maj","frets":[0,0,0,3],"addedAt":2000,"folderIds":[]},
                 {"rootPitchClass":4,"chordSymbol":"m","frets":[0,4,3,2],"addedAt":3000,"folderIds":[]}
             ]""",
-        )
+            )
         manager.importBackup(backup)
         val all = favRepo.getAll()
         assertEquals(2, all.size)
@@ -183,9 +210,10 @@ class BackupRestoreManagerTest {
     fun importChordSheetUpdatedAtWins() {
         val repo = ChordSheetRepository(app)
         repo.save(ChordSheet(id = "s1", title = "Old", content = "", createdAt = 100L, updatedAt = 200L))
-        val backup = buildMinimalBackup(
-            chordSheets = """[{"id":"s1","title":"New","content":"","createdAt":100,"updatedAt":300}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                chordSheets = """[{"id":"s1","title":"New","content":"","createdAt":100,"updatedAt":300}]""",
+            )
         manager.importBackup(backup)
         assertEquals("New", repo.get("s1")!!.title)
     }
@@ -194,9 +222,13 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importMigratesOldFolderIdToFolderIds() {
-        val backup = buildMinimalBackup(
-            favorites = """[{"rootPitchClass":0,"chordSymbol":"","frets":[0,0,0,0],"addedAt":1000,"folderId":"old-folder","folderIds":[]}]""",
-        )
+        val backup =
+            buildMinimalBackup(
+                favorites =
+                    """[{"rootPitchClass":0,"chordSymbol":"",""" +
+                        """"frets":[0,0,0,0],"addedAt":1000,""" +
+                        """"folderId":"old-folder","folderIds":[]}]""",
+            )
         manager.importBackup(backup)
         val favRepo = FavoritesRepository(app)
         val loaded = favRepo.getAll().first()
@@ -207,23 +239,24 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importNormalizesIosTimestamps() {
-        val iosBackup = """
-        {
-            "version": 3,
-            "timestamp": 1700000000.0,
-            "favorites": [{"rootPitchClass":0,"chordSymbol":"","frets":[0,0,0,0],"addedAt":1700000000.0,"folderIds":[]}],
-            "folders": [],
-            "chord_sheets": [],
-            "custom_progressions": [],
-            "custom_strum_patterns": [],
-            "custom_fingerpicking_patterns": [],
-            "setlists": [],
-            "melodies": [],
-            "learn_progress": {},
-            "practice_timer": {},
-            "settings": {}
-        }
-        """.trimIndent()
+        val iosBackup =
+            """
+            {
+                "version": 3,
+                "timestamp": 1700000000.0,
+                "favorites": [{"rootPitchClass":0,"chordSymbol":"","frets":[0,0,0,0],"addedAt":1700000000.0,"folderIds":[]}],
+                "folders": [],
+                "chord_sheets": [],
+                "custom_progressions": [],
+                "custom_strum_patterns": [],
+                "custom_fingerpicking_patterns": [],
+                "setlists": [],
+                "melodies": [],
+                "learn_progress": {},
+                "practice_timer": {},
+                "settings": {}
+            }
+            """.trimIndent()
         manager.importBackup(iosBackup)
         val favRepo = FavoritesRepository(app)
         val fav = favRepo.getAll().first()
@@ -232,25 +265,26 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importNormalizesIosFingerNames() {
-        val iosBackup = """
-        {
-            "version": 3,
-            "timestamp": 1700000000.0,
-            "favorites": [],
-            "folders": [],
-            "chord_sheets": [],
-            "custom_progressions": [],
-            "custom_strum_patterns": [],
-            "custom_fingerpicking_patterns": [
-                {"id":"fp1","name":"Test","steps":[{"finger":"T","stringIndex":0,"emphasis":true},{"finger":"I","stringIndex":2,"emphasis":false}],"createdAt":1000,"timeSignature":"4/4"}
-            ],
-            "setlists": [],
-            "melodies": [],
-            "learn_progress": {},
-            "practice_timer": {},
-            "settings": {}
-        }
-        """.trimIndent()
+        val iosBackup =
+            """
+            {
+                "version": 3,
+                "timestamp": 1700000000.0,
+                "favorites": [],
+                "folders": [],
+                "chord_sheets": [],
+                "custom_progressions": [],
+                "custom_strum_patterns": [],
+                "custom_fingerpicking_patterns": [
+                    {"id":"fp1","name":"Test","steps":[{"finger":"T","stringIndex":0,"emphasis":true},{"finger":"I","stringIndex":2,"emphasis":false}],"createdAt":1000,"timeSignature":"4/4"}
+                ],
+                "setlists": [],
+                "melodies": [],
+                "learn_progress": {},
+                "practice_timer": {},
+                "settings": {}
+            }
+            """.trimIndent()
         manager.importBackup(iosBackup)
         val repo = CustomFingerpickingPatternRepository(app)
         val all = repo.getAll()
@@ -260,23 +294,24 @@ class BackupRestoreManagerTest {
 
     @Test
     fun importNormalizesIosMelodyDurations() {
-        val iosBackup = """
-        {
-            "version": 3,
-            "timestamp": 1700000000.0,
-            "favorites": [],
-            "folders": [],
-            "chord_sheets": [],
-            "custom_progressions": [],
-            "custom_strum_patterns": [],
-            "custom_fingerpicking_patterns": [],
-            "setlists": [],
-            "melodies": [{"id":"m1","name":"Test","notes":[{"pitchClass":0,"octave":4,"duration":"♩"}],"bpm":120,"createdAt":1000}],
-            "learn_progress": {},
-            "practice_timer": {},
-            "settings": {}
-        }
-        """.trimIndent()
+        val iosBackup =
+            """
+            {
+                "version": 3,
+                "timestamp": 1700000000.0,
+                "favorites": [],
+                "folders": [],
+                "chord_sheets": [],
+                "custom_progressions": [],
+                "custom_strum_patterns": [],
+                "custom_fingerpicking_patterns": [],
+                "setlists": [],
+                "melodies": [{"id":"m1","name":"Test","notes":[{"pitchClass":0,"octave":4,"duration":"♩"}],"bpm":120,"createdAt":1000}],
+                "learn_progress": {},
+                "practice_timer": {},
+                "settings": {}
+            }
+            """.trimIndent()
         manager.importBackup(iosBackup)
         val repo = MelodyRepository(app)
         val melody = repo.get("m1")
@@ -284,11 +319,91 @@ class BackupRestoreManagerTest {
         assertEquals("QUARTER", melody!!.notes[0].duration.name)
     }
 
-    // ── Error handling ───────────────────────────────────────────────
+    // ── Error handling & atomicity ───────────────────────────────────
 
     @Test(expected = Exception::class)
     fun importInvalidJsonThrows() {
         manager.importBackup("not valid json {{{")
+    }
+
+    @Test
+    fun importInvalidJsonDoesNotModifyExistingData() {
+        val favRepo = FavoritesRepository(app)
+        favRepo.add(FavoriteVoicing(0, "maj", listOf(0, 0, 0, 3), 1000L))
+        val sheetRepo = ChordSheetRepository(app)
+        sheetRepo.save(
+            ChordSheet(id = "s1", title = "My Song", content = "[C]Hello", createdAt = 100L, updatedAt = 200L),
+        )
+
+        try {
+            manager.importBackup("not valid json {{{")
+        } catch (_: Exception) {
+            // expected
+        }
+
+        assertEquals(1, favRepo.getAll().size)
+        assertEquals("maj", favRepo.getAll()[0].chordSymbol)
+        assertEquals("My Song", sheetRepo.get("s1")!!.title)
+    }
+
+    @Test
+    fun importBadMelodiesDoesNotAffectOtherCategories() {
+        val favRepo = FavoritesRepository(app)
+        favRepo.add(FavoriteVoicing(0, "maj", listOf(0, 0, 0, 3), 1000L))
+
+        val badMelody =
+            """[{"id":"m1","name":"Bad","notes":""" +
+                """[{"pitchClass":0,"octave":4,""" +
+                """"duration":"NONEXISTENT_DURATION"}],""" +
+                """"bpm":100,"createdAt":5000}]"""
+        val backup =
+            buildMinimalBackup(
+                favorites =
+                    """[{"rootPitchClass":4,"chordSymbol":"m",""" +
+                        """"frets":[0,4,3,2],"addedAt":3000,""" +
+                        """"folderIds":[]}]""",
+                chordSheets =
+                    """[{"id":"s1","title":"Song",""" +
+                        """"content":"[C]lyrics",""" +
+                        """"createdAt":100,"updatedAt":200}]""",
+                melodies = badMelody,
+            )
+        manager.importBackup(backup)
+
+        assertEquals(2, favRepo.getAll().size)
+        val sheetRepo = ChordSheetRepository(app)
+        assertNotNull(sheetRepo.get("s1"))
+        val melodyRepo = MelodyRepository(app)
+        assertEquals(0, melodyRepo.getAll().size)
+    }
+
+    @Test
+    fun importWithAllBadProgressionsStillImportsOtherCategories() {
+        val backup =
+            buildMinimalBackup(
+                favorites =
+                    """[{"rootPitchClass":7,"chordSymbol":"7",""" +
+                        """"frets":[0,2,1,2],"addedAt":1000,""" +
+                        """"folderIds":[]}]""",
+                customProgressions =
+                    """[{"id":"p1","name":"Bad",""" +
+                        """"description":"",""" +
+                        """"scaleType":"INVALID_SCALE",""" +
+                        """"degrees":[],"createdAt":1000}]""",
+                setlists =
+                    """[{"id":"sl1","name":"Gig",""" +
+                        """"songIds":["s1"],""" +
+                        """"createdAt":100,"updatedAt":200}]""",
+            )
+        manager.importBackup(backup)
+
+        val favRepo = FavoritesRepository(app)
+        assertEquals(1, favRepo.getAll().size)
+        assertEquals("7", favRepo.getAll()[0].chordSymbol)
+        val progressionRepo = CustomProgressionRepository(app)
+        assertEquals(0, progressionRepo.getAll().size)
+        val setlistRepo = SetlistRepository(app)
+        assertEquals(1, setlistRepo.getAll().size)
     }
 
     // ── Settings ─────────────────────────────────────────────────────
@@ -296,9 +411,19 @@ class BackupRestoreManagerTest {
     @Test
     fun importPreservesSettingsNotInBackup() {
         settingsVM.updateTuner { it.copy(spokenFeedback = true) }
-        val backup = buildMinimalBackup(
-            settings = """{"soundEnabled":false,"volume":0.5,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"DARK","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"LOW_G","leftHanded":true,"lastFret":15,"showNoteNames":false}""",
-        )
+        val backup =
+            buildMinimalBackup(
+                settings =
+                    """{"soundEnabled":false,"volume":0.5,""" +
+                        """"noteDurationMs":600,"strumDelayMs":50,""" +
+                        """"strumDown":true,"playOnTap":false,""" +
+                        """"themeMode":"DARK",""" +
+                        """"showExplorerTips":true,""" +
+                        """"showLearnSection":true,""" +
+                        """"showReferenceSection":true,""" +
+                        """"tuning":"LOW_G","leftHanded":true,""" +
+                        """"lastFret":15,"showNoteNames":false}""",
+            )
         manager.importBackup(backup)
         val s = settingsVM.exportSettings()
         assertEquals(false, s.sound.enabled)
@@ -312,6 +437,7 @@ class BackupRestoreManagerTest {
 
     // ── Helper ───────────────────────────────────────────────────────
 
+    @Suppress("LongParameterList")
     private fun buildMinimalBackup(
         favorites: String = "[]",
         favoriteFolders: String = "[]",
@@ -323,9 +449,22 @@ class BackupRestoreManagerTest {
         melodies: String = "[]",
         learningProgress: String = """{"entries":{}}""",
         achievements: String = "{}",
-        practiceTimer: String = """{"totalMinutes":0,"totalSessions":0,"longestSession":0,"lastSessionTime":0,"dailyGoal":15,"dailyMinutes":{}}""",
-        settings: String = """{"soundEnabled":true,"volume":0.7,"noteDurationMs":600,"strumDelayMs":50,"strumDown":true,"playOnTap":false,"themeMode":"SYSTEM","showExplorerTips":true,"showLearnSection":true,"showReferenceSection":true,"tuning":"HIGH_G","leftHanded":false,"lastFret":12,"showNoteNames":true}""",
-    ): String = """
+        practiceTimer: String =
+            """{"totalMinutes":0,"totalSessions":0,""" +
+                """"longestSession":0,"lastSessionTime":0,""" +
+                """"dailyGoal":15,"dailyMinutes":{}}""",
+        settings: String =
+            """{"soundEnabled":true,"volume":0.7,""" +
+                """"noteDurationMs":600,"strumDelayMs":50,""" +
+                """"strumDown":true,"playOnTap":false,""" +
+                """"themeMode":"SYSTEM",""" +
+                """"showExplorerTips":true,""" +
+                """"showLearnSection":true,""" +
+                """"showReferenceSection":true,""" +
+                """"tuning":"HIGH_G","leftHanded":false,""" +
+                """"lastFret":12,"showNoteNames":true}""",
+    ): String =
+        """
         {
             "version": 3,
             "exportedAt": ${System.currentTimeMillis()},
@@ -342,5 +481,5 @@ class BackupRestoreManagerTest {
             "practiceTimer": $practiceTimer,
             "settings": $settings
         }
-    """.trimIndent()
+        """.trimIndent()
 }


### PR DESCRIPTION
## Summary

- Restructures `BackupRestoreManager.importBackup()` into three phases: prepare (in-memory validation), snapshot (capture current SharedPreferences state), and commit (apply writes with rollback on failure)
- Eliminates the risk of partially-applied backup data when an error occurs mid-import — either all categories import successfully or nothing changes
- Adds tests verifying that invalid data in one category doesn't corrupt other categories

## Test plan

- [x] All existing `BackupRestoreManagerTest` tests pass (round-trip, merge semantics, iOS normalization, settings preservation)
- [x] New atomicity tests pass: invalid JSON leaves existing data intact, bad melody enums don't affect other categories, invalid progression scale types don't prevent other imports
- [x] `lintDebug` passes
- [ ] CI checks pass

Fixes #459

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup restore safety with automatic data integrity protection—when importing a backup file, the system now validates all content before making any changes. If any error occurs during the import process, your previous data is automatically restored, preventing accidental corruption or data loss from invalid or corrupted backup files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->