### PR TITLE
Fix: eliminate FrameGate.awaitEnter busy-spin that blocks main thread

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/domain/FrameGateExt.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/domain/FrameGateExt.kt
@@ -1,0 +1,25 @@
+package com.baijum.ukufretboard.domain
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val DEFAULT_TIMEOUT_MS = 500L
+
+/**
+ * Suspends until the gate is free, then enters. Safe to call from the main
+ * thread — yields between attempts via [delay] instead of busy-spinning.
+ *
+ * Returns true if the gate was entered, false if the timeout elapsed.
+ * The default 500ms timeout is generous for a single DSP frame (typically <50ms).
+ */
+suspend fun FrameGate.awaitEnterSuspending(timeoutMs: Long = DEFAULT_TIMEOUT_MS): Boolean {
+    if (tryEnter()) return true
+    val result =
+        withTimeoutOrNull(timeoutMs) {
+            while (!tryEnter()) {
+                delay(1)
+            }
+            true
+        }
+    return result == true
+}

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -11,10 +11,11 @@ import com.baijum.ukufretboard.data.MelodyRepository
 import com.baijum.ukufretboard.data.NoteDuration
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.SoundSettings
+import com.baijum.ukufretboard.domain.FrameGate
 import com.baijum.ukufretboard.domain.NoteInfo
 import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.TunerNoteMapper
-import com.baijum.ukufretboard.domain.FrameGate
+import com.baijum.ukufretboard.domain.awaitEnterSuspending
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,10 +79,10 @@ data class MelodyUiState(
  * and microphone-based note recording using the existing pitch detection pipeline.
  */
 class MelodyViewModel : ViewModel() {
-
     companion object {
         private const val MIN_OCTAVE = 3
         private const val MAX_OCTAVE = 6
+
         /**
          * Frames of consistent detection required before accepting a note (~250ms).
          * At ~43 frames/sec (23ms per frame), 11 frames ≈ 253ms.
@@ -133,13 +134,17 @@ class MelodyViewModel : ViewModel() {
 
     // --- Note composition ---
 
-    fun addNote(pitchClass: Int, octave: Int? = null) {
+    fun addNote(
+        pitchClass: Int,
+        octave: Int? = null,
+    ) {
         val state = _uiState.value
-        val note = MelodyNote(
-            pitchClass = pitchClass,
-            octave = octave ?: state.currentOctave,
-            duration = state.selectedDuration,
-        )
+        val note =
+            MelodyNote(
+                pitchClass = pitchClass,
+                octave = octave ?: state.currentOctave,
+                duration = state.selectedDuration,
+            )
         _uiState.update {
             it.copy(
                 notes = it.notes + note,
@@ -233,14 +238,18 @@ class MelodyViewModel : ViewModel() {
         _uiState.update { it.copy(isStepSequencerMode = !it.isStepSequencerMode) }
     }
 
-    fun setStep(index: Int, pitchClass: Int) {
+    fun setStep(
+        index: Int,
+        pitchClass: Int,
+    ) {
         val state = _uiState.value
         if (index !in state.steps.indices) return
-        val note = MelodyNote(
-            pitchClass = pitchClass,
-            octave = state.currentOctave,
-            duration = state.selectedDuration,
-        )
+        val note =
+            MelodyNote(
+                pitchClass = pitchClass,
+                octave = state.currentOctave,
+                duration = state.selectedDuration,
+            )
         _uiState.update {
             it.copy(
                 steps = it.steps.toMutableList().apply { set(index, note) },
@@ -264,11 +273,12 @@ class MelodyViewModel : ViewModel() {
     fun expandSteps() {
         _uiState.update { state ->
             val currentSize = state.steps.size
-            val newSize = if (currentSize >= MelodyUiState.STEP_COUNT_16) {
-                MelodyUiState.STEP_COUNT_8
-            } else {
-                MelodyUiState.STEP_COUNT_16
-            }
+            val newSize =
+                if (currentSize >= MelodyUiState.STEP_COUNT_16) {
+                    MelodyUiState.STEP_COUNT_8
+                } else {
+                    MelodyUiState.STEP_COUNT_16
+                }
             if (newSize > currentSize) {
                 state.copy(steps = state.steps + List(newSize - currentSize) { null })
             } else {
@@ -330,7 +340,10 @@ class MelodyViewModel : ViewModel() {
         _uiState.update { it.copy(isPlaying = false, playingIndex = -1) }
     }
 
-    private fun playNote(pitchClass: Int, octave: Int) {
+    private fun playNote(
+        pitchClass: Int,
+        octave: Int,
+    ) {
         if (!soundSettings.enabled) return
         viewModelScope.launch {
             ToneGenerator.playNote(
@@ -347,17 +360,22 @@ class MelodyViewModel : ViewModel() {
     fun saveMelody(name: String) {
         val repo = repository ?: return
         val state = _uiState.value
-        val melody = Melody(
-            id = state.loadedMelodyId ?: java.util.UUID.randomUUID().toString(),
-            name = name,
-            notes = state.notes,
-            bpm = state.bpm,
-            createdAt = if (state.loadedMelodyId != null) {
-                repo.get(state.loadedMelodyId)?.createdAt ?: System.currentTimeMillis()
-            } else {
-                System.currentTimeMillis()
-            },
-        )
+        val melody =
+            Melody(
+                id =
+                    state.loadedMelodyId ?: java.util.UUID
+                        .randomUUID()
+                        .toString(),
+                name = name,
+                notes = state.notes,
+                bpm = state.bpm,
+                createdAt =
+                    if (state.loadedMelodyId != null) {
+                        repo.get(state.loadedMelodyId)?.createdAt ?: System.currentTimeMillis()
+                    } else {
+                        System.currentTimeMillis()
+                    },
+            )
         repo.save(melody)
         _uiState.update {
             it.copy(
@@ -399,7 +417,10 @@ class MelodyViewModel : ViewModel() {
         refreshSavedMelodies()
     }
 
-    fun renameMelody(id: String, newName: String) {
+    fun renameMelody(
+        id: String,
+        newName: String,
+    ) {
         val repo = repository ?: return
         val melody = repo.get(id) ?: return
         val updated = melody.copy(name = newName)
@@ -439,26 +460,32 @@ class MelodyViewModel : ViewModel() {
         val ctx = appContext ?: return
         if (_uiState.value.isPlaying) stopPlayback()
 
-        frameGate.awaitEnter()
-        try {
-            resetRecordingState()
-            _uiState.update {
-                it.copy(
-                    isRecording = true,
-                    detectedNote = null,
-                    stabilizationProgress = 0f,
-                )
-            }
-        } finally {
-            frameGate.exit()
+        _uiState.update {
+            it.copy(
+                isRecording = true,
+                detectedNote = null,
+                stabilizationProgress = 0f,
+            )
         }
 
-        AudioCaptureEngine.start(
-            viewModelScope,
-            ctx,
-            onInterrupted = { stopRecording() },
-        ) { buffer ->
-            processRecordingBuffer(buffer)
+        viewModelScope.launch {
+            if (!frameGate.awaitEnterSuspending()) {
+                _uiState.update { it.copy(isRecording = false) }
+                return@launch
+            }
+            try {
+                resetRecordingState()
+            } finally {
+                frameGate.exit()
+            }
+
+            AudioCaptureEngine.start(
+                viewModelScope,
+                ctx,
+                onInterrupted = { stopRecording() },
+            ) { buffer ->
+                processRecordingBuffer(buffer)
+            }
         }
     }
 
@@ -541,11 +568,12 @@ class MelodyViewModel : ViewModel() {
             return
         }
 
-        val result = PitchDetector.detect(
-            samples,
-            AudioCaptureEngine.SAMPLE_RATE,
-            previousFrequency = previousFrequency,
-        )
+        val result =
+            PitchDetector.detect(
+                samples,
+                AudioCaptureEngine.SAMPLE_RATE,
+                previousFrequency = previousFrequency,
+            )
 
         if (result == null) {
             previousFrequency = null
@@ -565,19 +593,21 @@ class MelodyViewModel : ViewModel() {
         if (recentFrequencies.size > SMOOTHING_WINDOW) {
             recentFrequencies.removeFirst()
         }
-        val smoothedHz = recentFrequencies.sorted().let { sorted ->
-            val mid = sorted.size / 2
-            if (sorted.size % 2 == 0 && sorted.size >= 2) {
-                (sorted[mid - 1] + sorted[mid]) / 2.0
-            } else {
-                sorted[mid]
+        val smoothedHz =
+            recentFrequencies.sorted().let { sorted ->
+                val mid = sorted.size / 2
+                if (sorted.size % 2 == 0 && sorted.size >= 2) {
+                    (sorted[mid - 1] + sorted[mid]) / 2.0
+                } else {
+                    sorted[mid]
+                }
             }
-        }
 
-        val noteInfo = TunerNoteMapper.mapFrequency(
-            smoothedHz,
-            TunerNoteMapper.DEFAULT_A4_HZ,
-        ) ?: return
+        val noteInfo =
+            TunerNoteMapper.mapFrequency(
+                smoothedHz,
+                TunerNoteMapper.DEFAULT_A4_HZ,
+            ) ?: return
 
         val previousStable = stableNoteInfo
         if (previousStable != null &&
@@ -608,11 +638,12 @@ class MelodyViewModel : ViewModel() {
 
     private fun acceptRecordedNote(noteInfo: NoteInfo) {
         val state = _uiState.value
-        val note = MelodyNote(
-            pitchClass = noteInfo.pitchClass,
-            octave = noteInfo.octave,
-            duration = state.selectedDuration,
-        )
+        val note =
+            MelodyNote(
+                pitchClass = noteInfo.pitchClass,
+                octave = noteInfo.octave,
+                duration = state.selectedDuration,
+            )
         val noteName = Notes.pitchClassToName(noteInfo.pitchClass)
         val durationLabel = state.selectedDuration.label.lowercase()
         val feedback = "$noteName${noteInfo.octave} $durationLabel"

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -8,15 +8,15 @@ import com.baijum.ukufretboard.audio.AudioCaptureEngine
 import com.baijum.ukufretboard.domain.AudioChordDetector
 import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordFrameInput
+import com.baijum.ukufretboard.domain.FrameGate
 import com.baijum.ukufretboard.domain.FrameGateResult
-import com.baijum.ukufretboard.domain.PitchMonitorStateMachine
 import com.baijum.ukufretboard.domain.NeuralPitchResult
 import com.baijum.ukufretboard.domain.NeuralPitchSupervisor
 import com.baijum.ukufretboard.domain.PitchDetector
+import com.baijum.ukufretboard.domain.PitchMonitorStateMachine
 import com.baijum.ukufretboard.domain.PitchResult
 import com.baijum.ukufretboard.domain.TunerNoteMapper
-import com.baijum.ukufretboard.domain.FrameGate
-import kotlin.math.abs
+import com.baijum.ukufretboard.domain.awaitEnterSuspending
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 import kotlin.math.log2
 import kotlin.math.roundToInt
 
@@ -47,28 +48,20 @@ data class PitchPoint(
 data class PitchMonitorUiState(
     /** Whether the microphone is actively capturing audio. */
     val isListening: Boolean = false,
-
     /** Rolling history of pitch data points for the scrolling canvas. */
     val pitchHistory: List<PitchPoint> = emptyList(),
-
     /** Display name of the current note (e.g. "A4"), or null if silent. */
     val currentNote: String? = null,
-
     /** Name of the detected chord (e.g. "C", "Am7"), or null if none. */
     val detectedChord: String? = null,
-
     /** Notes of the detected chord (e.g. ["C", "E", "G"]). */
     val detectedChordNotes: List<String> = emptyList(),
-
     /** Confidence of the chord detection (0.0 .. 1.0). */
     val chordConfidence: Float = 0f,
-
     /** Rolling history of recently detected note names, deduped on consecutive repeats. */
     val recentNotes: List<String> = emptyList(),
-
     /** True when the displayed chord was detected via arpeggio (sequential notes). */
     val isArpeggioChord: Boolean = false,
-
     /** 12-bin chromagram energy (C=0 .. B=11), normalized 0..1. Used for canvas glow. */
     val chromaEnergy: FloatArray = FloatArray(12),
 )
@@ -91,7 +84,6 @@ data class PitchMonitorUiState(
  * `DisposableEffect` in the UI layer.
  */
 class PitchMonitorViewModel : ViewModel() {
-
     companion object {
         /** Maximum pitch history duration in milliseconds (~10 seconds). */
         private const val HISTORY_DURATION_MS = 10_000L
@@ -182,29 +174,35 @@ class PitchMonitorViewModel : ViewModel() {
 
         initializeNeuralSupervisor()
 
-        frameGate.awaitEnter()
-        try {
-            _uiState.update { it.copy(isListening = true) }
-            stateMachine.reset()
-            chordFrameCounter = 0
-            lastChromaEnergy = FloatArray(12)
-            previousFrequency = null
-            neuralFrameCounter = 0
-            lastNeuralResult = null
-            neuralResultAgeFrames = Int.MAX_VALUE
-            lastNeuralFrequencyForConsistency = null
-            neuralConsistencyFrames = 0
-            telemetryFrameCounter = 0
-        } finally {
-            frameGate.exit()
-        }
+        _uiState.update { it.copy(isListening = true) }
 
-        AudioCaptureEngine.start(
-            viewModelScope,
-            ctx,
-            onInterrupted = { stopListening() },
-        ) { buffer ->
-            processBuffer(buffer)
+        viewModelScope.launch {
+            if (!frameGate.awaitEnterSuspending()) {
+                _uiState.update { it.copy(isListening = false) }
+                return@launch
+            }
+            try {
+                stateMachine.reset()
+                chordFrameCounter = 0
+                lastChromaEnergy = FloatArray(12)
+                previousFrequency = null
+                neuralFrameCounter = 0
+                lastNeuralResult = null
+                neuralResultAgeFrames = Int.MAX_VALUE
+                lastNeuralFrequencyForConsistency = null
+                neuralConsistencyFrames = 0
+                telemetryFrameCounter = 0
+            } finally {
+                frameGate.exit()
+            }
+
+            AudioCaptureEngine.start(
+                viewModelScope,
+                ctx,
+                onInterrupted = { stopListening() },
+            ) { buffer ->
+                processBuffer(buffer)
+            }
         }
     }
 
@@ -246,18 +244,22 @@ class PitchMonitorViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        val supervisor = synchronized(supervisorLock) {
-            isCleared = true
-            val s = neuralSupervisor
-            neuralSupervisor = null
-            s
-        }
+        val supervisor =
+            synchronized(supervisorLock) {
+                isCleared = true
+                val s = neuralSupervisor
+                neuralSupervisor = null
+                s
+            }
         AudioCaptureEngine.stop()
-        frameGate.awaitEnter()
-        try {
+        if (frameGate.tryEnter()) {
+            try {
+                supervisor?.close()
+            } finally {
+                frameGate.exit()
+            }
+        } else {
             supervisor?.close()
-        } finally {
-            frameGate.exit()
         }
     }
 
@@ -298,6 +300,7 @@ class PitchMonitorViewModel : ViewModel() {
                 }
                 return
             }
+
             FrameGateResult.Silent -> {
                 previousFrequency = null
                 lastChromaEnergy = FloatArray(12)
@@ -313,62 +316,71 @@ class PitchMonitorViewModel : ViewModel() {
                 }
                 return
             }
+
             FrameGateResult.Process -> { /* proceed with detection */ }
         }
 
         // --- Pitch detection (YIN + neural arbitration) -------------------------
-        val yinResult = PitchDetector.detect(
-            samples,
-            AudioCaptureEngine.SAMPLE_RATE,
-            previousFrequency = previousFrequency,
-        )
+        val yinResult =
+            PitchDetector.detect(
+                samples,
+                AudioCaptureEngine.SAMPLE_RATE,
+                previousFrequency = previousFrequency,
+            )
         val neuralResult = runNeuralSupervisor(samples)
         val pitchResult = arbitrate(yinResult, neuralResult)
 
         previousFrequency = pitchResult?.frequencyHz
 
         // --- Chord detection (throttled) ----------------------------------------
-        val chordInput: ChordFrameInput? = if (chordFrameCounter++ % CHORD_DETECTION_INTERVAL == 0) {
-            val preferredRootPitchClass = preferredRootPitchClass(neuralResult, pitchResult)
-            val chordResult = AudioChordDetector.detect(
-                samples = samples,
-                preferredRootPitchClass = preferredRootPitchClass,
-            )
-            lastChromaEnergy = chordResult.chromagram
+        val chordInput: ChordFrameInput? =
+            if (chordFrameCounter++ % CHORD_DETECTION_INTERVAL == 0) {
+                val preferredRootPitchClass = preferredRootPitchClass(neuralResult, pitchResult)
+                val chordResult =
+                    AudioChordDetector.detect(
+                        samples = samples,
+                        preferredRootPitchClass = preferredRootPitchClass,
+                    )
+                lastChromaEnergy = chordResult.chromagram
 
-            val rawChordName = when (val det = chordResult.detection) {
-                is ChordDetector.DetectionResult.ChordFound -> det.result.name
-                else -> null
-            }
-            val rawChordNotes = when (val det = chordResult.detection) {
-                is ChordDetector.DetectionResult.ChordFound -> det.result.notes.map { it.name }
-                else -> emptyList()
-            }
+                val rawChordName =
+                    when (val det = chordResult.detection) {
+                        is ChordDetector.DetectionResult.ChordFound -> det.result.name
+                        else -> null
+                    }
+                val rawChordNotes =
+                    when (val det = chordResult.detection) {
+                        is ChordDetector.DetectionResult.ChordFound -> det.result.notes.map { it.name }
+                        else -> emptyList()
+                    }
 
-            ChordFrameInput(
-                name = rawChordName,
-                notes = rawChordNotes,
-                confidence = chordResult.confidence,
-            )
-        } else {
-            null
-        }
+                ChordFrameInput(
+                    name = rawChordName,
+                    notes = rawChordNotes,
+                    confidence = chordResult.confidence,
+                )
+            } else {
+                null
+            }
 
         // --- Delegate to shared state machine -----------------------------------
-        val frame = stateMachine.processDetections(
-            pitchHz = pitchResult?.frequencyHz,
-            chordInput = chordInput,
-            timestampMs = now,
-        )
+        val frame =
+            stateMachine.processDetections(
+                pitchHz = pitchResult?.frequencyHz,
+                chordInput = chordInput,
+                timestampMs = now,
+            )
 
         // --- Build UI state from frame output -----------------------------------
-        val midiNote: Float? = frame.smoothedFrequency?.let {
-            (69.0 + 12.0 * log2(it / 440.0)).toFloat()
-        }
+        val midiNote: Float? =
+            frame.smoothedFrequency?.let {
+                (69.0 + 12.0 * log2(it / 440.0)).toFloat()
+            }
 
-        val currentNote: String? = frame.smoothedFrequency?.let { hz ->
-            TunerNoteMapper.mapFrequency(hz)?.let { "${it.noteName}${it.octave}" }
-        }
+        val currentNote: String? =
+            frame.smoothedFrequency?.let { hz ->
+                TunerNoteMapper.mapFrequency(hz)?.let { "${it.noteName}${it.octave}" }
+            }
 
         val newPoint = PitchPoint(timestampMs = now, midiNote = midiNote)
 
@@ -376,11 +388,12 @@ class PitchMonitorViewModel : ViewModel() {
             val cutoff = now - HISTORY_DURATION_MS
             val trimmed = current.pitchHistory.dropWhile { it.timestampMs < cutoff }
 
-            val updatedNotes = if (currentNote != null && currentNote != current.recentNotes.lastOrNull()) {
-                (current.recentNotes + currentNote).takeLast(20)
-            } else {
-                current.recentNotes
-            }
+            val updatedNotes =
+                if (currentNote != null && currentNote != current.recentNotes.lastOrNull()) {
+                    (current.recentNotes + currentNote).takeLast(20)
+                } else {
+                    current.recentNotes
+                }
 
             current.copy(
                 pitchHistory = trimmed + newPoint,
@@ -412,14 +425,15 @@ class PitchMonitorViewModel : ViewModel() {
             var supervisor: NeuralPitchSupervisor? = null
             var registered = false
             try {
-                supervisor = withContext(Dispatchers.IO) {
-                    try {
-                        NeuralPitchSupervisor(ctx)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
-                        null
+                supervisor =
+                    withContext(Dispatchers.IO) {
+                        try {
+                            NeuralPitchSupervisor(ctx)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
+                            null
+                        }
                     }
-                }
                 synchronized(supervisorLock) {
                     if (!isCleared) {
                         neuralSupervisor = supervisor
@@ -488,13 +502,14 @@ class PitchMonitorViewModel : ViewModel() {
             return
         }
         val previous = lastNeuralFrequencyForConsistency
-        neuralConsistencyFrames = if (previous != null &&
-            semitoneDistance(previous, neuralFrequencyHz) <= 0.5
-        ) {
-            neuralConsistencyFrames + 1
-        } else {
-            1
-        }
+        neuralConsistencyFrames =
+            if (previous != null &&
+                semitoneDistance(previous, neuralFrequencyHz) <= 0.5
+            ) {
+                neuralConsistencyFrames + 1
+            } else {
+                1
+            }
         lastNeuralFrequencyForConsistency = neuralFrequencyHz
     }
 
@@ -502,23 +517,30 @@ class PitchMonitorViewModel : ViewModel() {
         neuralResult: NeuralPitchResult?,
         finalResult: PitchResult?,
     ): Int? {
-        val sourceHz = when {
-            neuralResult != null && neuralResult.confidence >= 0.70 -> neuralResult.frequencyHz
-            finalResult != null -> finalResult.frequencyHz
-            else -> return null
-        }
+        val sourceHz =
+            when {
+                neuralResult != null && neuralResult.confidence >= 0.70 -> neuralResult.frequencyHz
+                finalResult != null -> finalResult.frequencyHz
+                else -> return null
+            }
         if (sourceHz <= 0.0) return null
         val midi = 69.0 + 12.0 * log2(sourceHz / 440.0)
         val pitchClass = ((midi.roundToInt() % 12) + 12) % 12
         return pitchClass
     }
 
-    private fun semitoneDistance(aHz: Double, bHz: Double): Double {
+    private fun semitoneDistance(
+        aHz: Double,
+        bHz: Double,
+    ): Double {
         if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
         return abs(12.0 * log2(aHz / bHz))
     }
 
-    private fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
+    private fun isOctaveRelation(
+        aHz: Double,
+        bHz: Double,
+    ): Boolean {
         if (aHz <= 0.0 || bHz <= 0.0) return false
         val semitones = semitoneDistance(aHz, bHz)
         return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
@@ -541,8 +563,10 @@ class PitchMonitorViewModel : ViewModel() {
         val neuralConf = neuralResult?.confidence?.let { "%.2f".format(it) } ?: "null"
         val finalHz = finalResult?.frequencyHz?.let { "%.2f".format(it) } ?: "null"
         val finalConf = finalResult?.confidence?.let { "%.2f".format(it) } ?: "null"
-        val neuralMs = synchronized(supervisorLock) { neuralSupervisor }
-            ?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
+        val neuralMs =
+            synchronized(supervisorLock) { neuralSupervisor }
+                ?.lastInferenceMs()
+                ?.let { "%.2f".format(it) } ?: "null"
 
         Log.d(
             TAG,

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/TunerViewModel.kt
@@ -17,6 +17,7 @@ import com.baijum.ukufretboard.domain.PitchDetector
 import com.baijum.ukufretboard.domain.PitchResult
 import com.baijum.ukufretboard.domain.StringMatch
 import com.baijum.ukufretboard.domain.TunerNoteMapper
+import com.baijum.ukufretboard.domain.awaitEnterSuspending
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +39,6 @@ import kotlin.math.abs
  * string as completed.
  */
 class TunerViewModel : ViewModel() {
-
     companion object {
         /** Default cents threshold for "in tune" (standard mode). */
         const val IN_TUNE_CENTS = 6.0
@@ -192,9 +192,10 @@ class TunerViewModel : ViewModel() {
     private var displayCentsFiltered = 0.0
 
     /** Frames to hold the last non-silent reading before switching to SILENT. */
-    private val lostSignalHoldFrames = (
-        LOST_SIGNAL_HOLD_MS / FRAME_INTERVAL_MS
-    ).toInt().coerceAtLeast(1)
+    private val lostSignalHoldFrames =
+        (
+            LOST_SIGNAL_HOLD_MS / FRAME_INTERVAL_MS
+        ).toInt().coerceAtLeast(1)
 
     // --- Frame-dropping (backpressure) ----------------------------------------
     private val frameGate = FrameGate()
@@ -264,42 +265,48 @@ class TunerViewModel : ViewModel() {
         if (_uiState.value.isListening) return
         val ctx = appContext ?: return
 
-        frameGate.awaitEnter()
-        try {
-            _uiState.update {
-                it.copy(
-                    isListening = true,
-                    tuningStatus = TuningStatus.SILENT,
-                    lastSettledNote = null,
-                    lastSettledCents = 0.0,
-                )
-            }
-            recentFrequencies.clear()
-            inTuneFrames = 0
-            inTuneStringIndex = -1
-            previousRms = 0f
-            rmsEma = 0f
-            blankingFramesRemaining = 0
-            lostSignalFrames = 0
-            previousFrequency = null
-            displayCentsFiltered = 0.0
-            settledNoteName = null
-            settledNoteFrames = 0
-            settledNoteCents = 0.0
-            neuralArbitrator.reset()
-            telemetryFrameCounter = 0
-            telemetryOverrideCount = 0
-            lastLoggedStatus = TuningStatus.SILENT
-        } finally {
-            frameGate.exit()
+        _uiState.update {
+            it.copy(
+                isListening = true,
+                tuningStatus = TuningStatus.SILENT,
+                lastSettledNote = null,
+                lastSettledCents = 0.0,
+            )
         }
 
-        AudioCaptureEngine.start(
-            viewModelScope,
-            ctx,
-            onInterrupted = { stopTuning() },
-        ) { buffer ->
-            processBuffer(buffer)
+        viewModelScope.launch {
+            if (!frameGate.awaitEnterSuspending()) {
+                _uiState.update { it.copy(isListening = false) }
+                return@launch
+            }
+            try {
+                recentFrequencies.clear()
+                inTuneFrames = 0
+                inTuneStringIndex = -1
+                previousRms = 0f
+                rmsEma = 0f
+                blankingFramesRemaining = 0
+                lostSignalFrames = 0
+                previousFrequency = null
+                displayCentsFiltered = 0.0
+                settledNoteName = null
+                settledNoteFrames = 0
+                settledNoteCents = 0.0
+                neuralArbitrator.reset()
+                telemetryFrameCounter = 0
+                telemetryOverrideCount = 0
+                lastLoggedStatus = TuningStatus.SILENT
+            } finally {
+                frameGate.exit()
+            }
+
+            AudioCaptureEngine.start(
+                viewModelScope,
+                ctx,
+                onInterrupted = { stopTuning() },
+            ) { buffer ->
+                processBuffer(buffer)
+            }
         }
     }
 
@@ -347,18 +354,22 @@ class TunerViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        val supervisor = synchronized(supervisorLock) {
-            isCleared = true
-            val s = neuralSupervisor
-            neuralSupervisor = null
-            s
-        }
+        val supervisor =
+            synchronized(supervisorLock) {
+                isCleared = true
+                val s = neuralSupervisor
+                neuralSupervisor = null
+                s
+            }
         AudioCaptureEngine.stop()
-        frameGate.awaitEnter()
-        try {
+        if (frameGate.tryEnter()) {
+            try {
+                supervisor?.close()
+            } finally {
+                frameGate.exit()
+            }
+        } else {
             supervisor?.close()
-        } finally {
-            frameGate.exit()
         }
         shutdownTts()
     }
@@ -394,15 +405,20 @@ class TunerViewModel : ViewModel() {
             // Adaptive ratio: inversely proportional to the EMA level.
             // Quiet passages → higher ratio (more selective), loud passages
             // → lower ratio (still catches onsets above the sustained level).
-            val adaptiveRatio = (ONSET_MIN_RATIO + (0.01f / rmsEma))
-                .coerceIn(ONSET_MIN_RATIO, ONSET_MAX_RATIO)
+            val adaptiveRatio =
+                (ONSET_MIN_RATIO + (0.01f / rmsEma))
+                    .coerceIn(ONSET_MIN_RATIO, ONSET_MAX_RATIO)
             if (currentRms / rmsEma > adaptiveRatio) {
                 blankingFramesRemaining = BLANKING_FRAMES
             }
         }
         // Update EMA (use direct assignment for the first frame).
-        rmsEma = if (rmsEma == 0f) currentRms
-        else rmsEma + ONSET_EMA_ALPHA * (currentRms - rmsEma)
+        rmsEma =
+            if (rmsEma == 0f) {
+                currentRms
+            } else {
+                rmsEma + ONSET_EMA_ALPHA * (currentRms - rmsEma)
+            }
         previousRms = currentRms
 
         if (blankingFramesRemaining > 0) {
@@ -433,11 +449,12 @@ class TunerViewModel : ViewModel() {
             return
         }
 
-        val result = PitchDetector.detect(
-            samples,
-            AudioCaptureEngine.SAMPLE_RATE,
-            previousFrequency = previousFrequency,
-        )
+        val result =
+            PitchDetector.detect(
+                samples,
+                AudioCaptureEngine.SAMPLE_RATE,
+                previousFrequency = previousFrequency,
+            )
 
         if (result == null) {
             // Brief gaps are common while strings decay. Keep the last reading
@@ -495,13 +512,14 @@ class TunerViewModel : ViewModel() {
         val a4Ref = tunerSettings.a4Reference.toDouble()
         val noteInfo = TunerNoteMapper.mapFrequency(smoothedHz, a4Ref) ?: return
         val previousTargetStringIndex = _uiState.value.targetString?.stringIndex
-        val stringMatch = TunerNoteMapper.findNearestStringWithHysteresis(
-            noteInfo = noteInfo,
-            tuning = currentTuning,
-            previousStringIndex = previousTargetStringIndex,
-            switchHysteresisCents = STRING_SWITCH_HYSTERESIS_CENTS,
-            a4Reference = a4Ref,
-        )
+        val stringMatch =
+            TunerNoteMapper.findNearestStringWithHysteresis(
+                noteInfo = noteInfo,
+                tuning = currentTuning,
+                previousStringIndex = previousTargetStringIndex,
+                switchHysteresisCents = STRING_SWITCH_HYSTERESIS_CENTS,
+                a4Reference = a4Ref,
+            )
 
         // Use cents-from-target-string for the meter (more useful than
         // cents-from-nearest-chromatic-note when tuning a specific string).
@@ -510,18 +528,20 @@ class TunerViewModel : ViewModel() {
         val clampedCents = cents.coerceIn(-50.0, 50.0)
         val displayCents = smoothDisplayCents(clampedCents)
 
-        val effectiveInTuneCents = if (tunerSettings.precisionMode) {
-            PRECISION_IN_TUNE_CENTS
-        } else {
-            IN_TUNE_CENTS
-        }
+        val effectiveInTuneCents =
+            if (tunerSettings.precisionMode) {
+                PRECISION_IN_TUNE_CENTS
+            } else {
+                IN_TUNE_CENTS
+            }
 
-        val status = when {
-            absCents <= effectiveInTuneCents -> TuningStatus.IN_TUNE
-            absCents <= CLOSE_CENTS -> TuningStatus.CLOSE
-            cents < 0 -> TuningStatus.FLAT
-            else -> TuningStatus.SHARP
-        }
+        val status =
+            when {
+                absCents <= effectiveInTuneCents -> TuningStatus.IN_TUNE
+                absCents <= CLOSE_CENTS -> TuningStatus.CLOSE
+                cents < 0 -> TuningStatus.FLAT
+                else -> TuningStatus.SHARP
+            }
 
         // --- String completion tracking --------------------------------------
         val progress = _uiState.value.stringProgress.toMutableList()
@@ -543,13 +563,14 @@ class TunerViewModel : ViewModel() {
         }
 
         // --- Auto-advance target ---------------------------------------------
-        val autoAdvanceIdx = if (tunerSettings.autoAdvance && justTuned) {
-            findNextUntunedString(progress)
-        } else if (tunerSettings.autoAdvance) {
-            _uiState.value.autoAdvanceTarget
-        } else {
-            -1
-        }
+        val autoAdvanceIdx =
+            if (tunerSettings.autoAdvance && justTuned) {
+                findNextUntunedString(progress)
+            } else if (tunerSettings.autoAdvance) {
+                _uiState.value.autoAdvanceTarget
+            } else {
+                -1
+            }
 
         // --- Settled note tracking -------------------------------------------
         val displayNote = "${noteInfo.noteName}${noteInfo.octave}"
@@ -563,11 +584,12 @@ class TunerViewModel : ViewModel() {
             settledNoteCents = clampedCents
         }
 
-        val settledUpdate = if (settledNoteFrames >= SETTLED_NOTE_MIN_FRAMES) {
-            settledNoteName to settledNoteCents
-        } else {
-            null
-        }
+        val settledUpdate =
+            if (settledNoteFrames >= SETTLED_NOTE_MIN_FRAMES) {
+                settledNoteName to settledNoteCents
+            } else {
+                null
+            }
 
         // --- Emit state ------------------------------------------------------
         _uiState.update {
@@ -637,14 +659,15 @@ class TunerViewModel : ViewModel() {
             var supervisor: NeuralPitchSupervisor? = null
             var registered = false
             try {
-                supervisor = withContext(Dispatchers.IO) {
-                    try {
-                        NeuralPitchSupervisor(ctx)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
-                        null
+                supervisor =
+                    withContext(Dispatchers.IO) {
+                        try {
+                            NeuralPitchSupervisor(ctx)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Neural supervisor unavailable: ${e.message}")
+                            null
+                        }
                     }
-                }
                 synchronized(supervisorLock) {
                     if (!isCleared) {
                         neuralSupervisor = supervisor
@@ -697,7 +720,6 @@ class TunerViewModel : ViewModel() {
         return neuralArbitrator.currentResult()
     }
 
-
     private fun smoothDisplayCents(rawCents: Double): Double {
         val target = if (abs(rawCents) < DISPLAY_DEADBAND_CENTS) 0.0 else rawCents
         displayCentsFiltered += DISPLAY_CENTS_ALPHA * (target - displayCentsFiltered)
@@ -726,10 +748,11 @@ class TunerViewModel : ViewModel() {
     private fun initializeTts() {
         if (tts != null) return
         val ctx = appContext ?: return
-        tts = TextToSpeech(ctx) { status ->
-            ttsReady = status == TextToSpeech.SUCCESS
-            tts?.language = Locale.US
-        }
+        tts =
+            TextToSpeech(ctx) { status ->
+                ttsReady = status == TextToSpeech.SUCCESS
+                tts?.language = Locale.US
+            }
     }
 
     private fun shutdownTts() {
@@ -767,23 +790,32 @@ class TunerViewModel : ViewModel() {
             return
         }
 
-        val message = when (status) {
-            TuningStatus.SILENT -> return
-            TuningStatus.IN_TUNE -> "$noteName, in tune"
-            TuningStatus.CLOSE -> {
-                val absCents = abs(cents).toInt()
-                val direction = if (cents < 0) "flat" else "sharp"
-                "$noteName, $absCents cents $direction"
+        val message =
+            when (status) {
+                TuningStatus.SILENT -> {
+                    return
+                }
+
+                TuningStatus.IN_TUNE -> {
+                    "$noteName, in tune"
+                }
+
+                TuningStatus.CLOSE -> {
+                    val absCents = abs(cents).toInt()
+                    val direction = if (cents < 0) "flat" else "sharp"
+                    "$noteName, $absCents cents $direction"
+                }
+
+                TuningStatus.FLAT -> {
+                    val absCents = abs(cents).toInt()
+                    "$noteName, $absCents cents flat"
+                }
+
+                TuningStatus.SHARP -> {
+                    val absCents = abs(cents).toInt()
+                    "$noteName, $absCents cents sharp"
+                }
             }
-            TuningStatus.FLAT -> {
-                val absCents = abs(cents).toInt()
-                "$noteName, $absCents cents flat"
-            }
-            TuningStatus.SHARP -> {
-                val absCents = abs(cents).toInt()
-                "$noteName, $absCents cents sharp"
-            }
-        }
 
         tts?.speak(message, TextToSpeech.QUEUE_FLUSH, null, "feedback_$noteName")
     }
@@ -827,15 +859,19 @@ class TunerViewModel : ViewModel() {
 
         val neuralFreq = neuralResult?.frequencyHz?.let { "%.2f".format(it) } ?: "null"
         val neuralConf = neuralResult?.confidence?.let { "%.2f".format(it) } ?: "null"
-        val inferenceMs = synchronized(supervisorLock) { neuralSupervisor }
-            ?.lastInferenceMs()?.let { "%.2f".format(it) } ?: "null"
+        val inferenceMs =
+            synchronized(supervisorLock) { neuralSupervisor }
+                ?.lastInferenceMs()
+                ?.let { "%.2f".format(it) } ?: "null"
 
         Log.d(
             TAG,
             "Telemetry frame=$telemetryFrameCounter " +
                 "yinHz=${"%.2f".format(yinResult.frequencyHz)} yinConf=${"%.2f".format(yinResult.confidence)} " +
                 "neuralHz=$neuralFreq neuralConf=$neuralConf neuralMs=$inferenceMs " +
-                "finalHz=${"%.2f".format(arbitration.frequencyHz)} finalConf=${"%.2f".format(arbitration.confidence)} " +
+                "finalHz=${"%.2f".format(
+                    arbitration.frequencyHz,
+                )} finalConf=${"%.2f".format(arbitration.confidence)} " +
                 "string=${stringMatch.stringName} cents=${"%.2f".format(cents)} status=$status " +
                 "reason=${arbitration.reason} overrides=$telemetryOverrideCount",
         )

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FrameGate.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FrameGate.kt
@@ -6,9 +6,9 @@ import com.baijum.ukufretboard.platform.PlatformLock
  * Gate for audio frame processing. Only one frame can be in-flight at
  * a time; additional frames are dropped ([tryEnter] returns false).
  *
- * Two usage patterns:
+ * Usage patterns:
  * - **Drop-if-busy** (audio callback): `if (!gate.tryEnter()) return`
- * - **Spin-until-free** (start/stop drain): `gate.awaitEnter()`
+ * - **Non-blocking drain** (start/stop in coroutines): use [awaitEnterSuspending] extension
  *
  * Thread-safe: all access is serialized through [PlatformLock].
  */
@@ -25,24 +25,6 @@ class FrameGate {
             return true
         } finally {
             lock.unlock()
-        }
-    }
-
-    /**
-     * Spin until the gate is free, then enter. Use only in start/stop
-     * drain paths — never on the audio callback thread.
-     */
-    fun awaitEnter() {
-        while (true) {
-            lock.lock()
-            try {
-                if (!processing) {
-                    processing = true
-                    return
-                }
-            } finally {
-                lock.unlock()
-            }
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FrameGateTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/FrameGateTest.kt
@@ -46,22 +46,4 @@ class FrameGateTest {
         gate.exit()
         assertFalse(gate.isActive, "exited gate should be inactive")
     }
-
-    @Test
-    fun awaitEnterOnFreeGateSucceedsImmediately() {
-        val gate = FrameGate()
-        gate.awaitEnter()
-        assertTrue(gate.isActive)
-        gate.exit()
-    }
-
-    @Test
-    fun awaitEnterAfterExitSucceeds() {
-        val gate = FrameGate()
-        gate.tryEnter()
-        gate.exit()
-        gate.awaitEnter()
-        assertTrue(gate.isActive)
-        gate.exit()
-    }
 }


### PR DESCRIPTION
## Summary

- Replaces the unbounded busy-spin in `FrameGate.awaitEnter()` with non-blocking alternatives that prevent ANR/jank on the main thread
- Start paths now use `viewModelScope.launch` + a new `awaitEnterSuspending()` extension that yields via `delay(1)` between attempts with a 500ms timeout
- `onCleared` paths use `tryEnter()` to check gate availability and close the neural supervisor directly if a frame is in-flight (the supervisor is tolerant of concurrent access)

## Test plan

- [x] Shared module FrameGate tests pass
- [x] All unit tests pass
- [x] Lint and detekt pass
- [x] ktlint passes
- [ ] CI checks pass
- [ ] Manual verification: tuner start/stop/clear with rapid tapping shows no jank

Fixes #460

Made with [Cursor](https://cursor.com)