### PR TITLE
Fix: localize hardcoded setlist accessibility strings

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/SetlistTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/SetlistTab.kt
@@ -20,15 +20,15 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,10 +37,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.ChordSheet
 import com.baijum.ukufretboard.data.Setlist
 import com.baijum.ukufretboard.viewmodel.SetlistViewModel
@@ -89,9 +91,10 @@ private fun SetlistListView(
     Box(modifier = modifier.fillMaxSize()) {
         if (setlists.isEmpty()) {
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(32.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
@@ -110,19 +113,23 @@ private fun SetlistListView(
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                contentPadding =
+                    androidx.compose.foundation.layout
+                        .PaddingValues(16.dp),
             ) {
                 items(setlists) { setlist ->
                     var showDeleteDialog by remember { mutableStateOf(false) }
                     Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { onSelect(setlist) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(setlist) },
                     ) {
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
@@ -138,7 +145,10 @@ private fun SetlistListView(
                                 )
                             }
                             IconButton(onClick = { showDeleteDialog = true }) {
-                                Icon(Icons.Filled.Delete, contentDescription = "Delete setlist")
+                                Icon(
+                                    Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.cd_setlist_delete),
+                                )
                             }
                         }
                     }
@@ -164,11 +174,12 @@ private fun SetlistListView(
 
         FloatingActionButton(
             onClick = { showCreateDialog = true },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
         ) {
-            Icon(Icons.Filled.Add, contentDescription = "Create setlist")
+            Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.cd_setlist_create))
         }
 
         if (showCreateDialog) {
@@ -217,31 +228,34 @@ private fun SetlistDetailView(
 
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 4.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = onBack) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
             }
             Text(
                 text = setlist.name,
                 style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier
-                    .weight(1f)
-                    .semantics { heading() },
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .semantics { heading() },
             )
             IconButton(onClick = { showAddDialog = true }) {
-                Icon(Icons.Filled.Add, contentDescription = "Add song to setlist")
+                Icon(Icons.Filled.Add, contentDescription = stringResource(R.string.cd_setlist_add_song))
             }
         }
 
         if (setlistSongs.isEmpty()) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(32.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -254,14 +268,17 @@ private fun SetlistDetailView(
             LazyColumn(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                contentPadding =
+                    androidx.compose.foundation.layout
+                        .PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 itemsIndexed(setlistSongs) { index, song ->
                     Card(modifier = Modifier.fillMaxWidth()) {
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
@@ -284,16 +301,25 @@ private fun SetlistDetailView(
                             }
                             if (index > 0) {
                                 IconButton(onClick = { onMoveSong(index, index - 1) }) {
-                                    Icon(Icons.Filled.ArrowUpward, contentDescription = "Move up")
+                                    Icon(
+                                        Icons.Filled.ArrowUpward,
+                                        contentDescription = stringResource(R.string.cd_setlist_move_up),
+                                    )
                                 }
                             }
                             if (index < setlistSongs.size - 1) {
                                 IconButton(onClick = { onMoveSong(index, index + 1) }) {
-                                    Icon(Icons.Filled.ArrowDownward, contentDescription = "Move down")
+                                    Icon(
+                                        Icons.Filled.ArrowDownward,
+                                        contentDescription = stringResource(R.string.cd_setlist_move_down),
+                                    )
                                 }
                             }
                             IconButton(onClick = { onRemoveSong(song.id) }) {
-                                Icon(Icons.Filled.Delete, contentDescription = "Remove from setlist")
+                                Icon(
+                                    Icons.Filled.Delete,
+                                    contentDescription = stringResource(R.string.cd_setlist_remove_song),
+                                )
                             }
                         }
                     }
@@ -323,10 +349,11 @@ private fun AddSongSheet(
     onAdd: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val availableSongs = remember(allSongs, currentSongIds) {
-        val idSet = currentSongIds.toSet()
-        allSongs.filter { it.id !in idSet }
-    }
+    val availableSongs =
+        remember(allSongs, currentSongIds) {
+            val idSet = currentSongIds.toSet()
+            allSongs.filter { it.id !in idSet }
+        }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(
@@ -334,18 +361,20 @@ private fun AddSongSheet(
         sheetState = sheetState,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(bottom = 32.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 32.dp),
         ) {
             Text(
                 text = "Add Song",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                modifier = Modifier
-                    .padding(bottom = 16.dp, start = 8.dp)
-                    .semantics { heading() },
+                modifier =
+                    Modifier
+                        .padding(bottom = 16.dp, start = 8.dp)
+                        .semantics { heading() },
             )
             if (availableSongs.isEmpty()) {
                 Text(
@@ -358,10 +387,11 @@ private fun AddSongSheet(
                 LazyColumn(modifier = Modifier.fillMaxWidth()) {
                     items(availableSongs, key = { it.id }) { song ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { onAdd(song.id) }
-                                .padding(vertical = 12.dp, horizontal = 8.dp),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onAdd(song.id) }
+                                    .padding(vertical = 12.dp, horizontal = 8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Column(modifier = Modifier.weight(1f)) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1202,4 +1202,10 @@
     <string name="cd_section_collapsed">مطوي</string>
     <string name="cd_decrease_capo">تقليل الكابو</string>
     <string name="cd_increase_capo">زيادة الكابو</string>
+    <string name="cd_setlist_create">إنشاء قائمة تشغيل</string>
+    <string name="cd_setlist_delete">حذف قائمة التشغيل</string>
+    <string name="cd_setlist_add_song">إضافة أغنية إلى القائمة</string>
+    <string name="cd_setlist_move_up">تحريك لأعلى</string>
+    <string name="cd_setlist_move_down">تحريك لأسفل</string>
+    <string name="cd_setlist_remove_song">إزالة من القائمة</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -1192,4 +1192,10 @@
     <string name="batch_select_all">全选</string>
     <string name="batch_cancel">取消</string>
     <string name="batch_delete">删除</string>
+    <string name="cd_setlist_create">创建歌单</string>
+    <string name="cd_setlist_delete">删除歌单</string>
+    <string name="cd_setlist_add_song">添加歌曲到歌单</string>
+    <string name="cd_setlist_move_up">上移</string>
+    <string name="cd_setlist_move_down">下移</string>
+    <string name="cd_setlist_remove_song">从歌单中移除</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1196,4 +1196,10 @@
     <string name="cd_section_collapsed">Eingeklappt</string>
     <string name="cd_decrease_capo">Capo verringern</string>
     <string name="cd_increase_capo">Capo erhöhen</string>
+    <string name="cd_setlist_create">Setlist erstellen</string>
+    <string name="cd_setlist_delete">Setlist löschen</string>
+    <string name="cd_setlist_add_song">Lied zur Setlist hinzufügen</string>
+    <string name="cd_setlist_move_up">Nach oben verschieben</string>
+    <string name="cd_setlist_move_down">Nach unten verschieben</string>
+    <string name="cd_setlist_remove_song">Aus Setlist entfernen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1209,4 +1209,10 @@
     <string name="cd_section_collapsed">Contraído</string>
     <string name="cd_decrease_capo">Disminuir cejilla</string>
     <string name="cd_increase_capo">Aumentar cejilla</string>
+    <string name="cd_setlist_create">Crear lista de canciones</string>
+    <string name="cd_setlist_delete">Eliminar lista de canciones</string>
+    <string name="cd_setlist_add_song">Añadir canción a la lista</string>
+    <string name="cd_setlist_move_up">Mover arriba</string>
+    <string name="cd_setlist_move_down">Mover abajo</string>
+    <string name="cd_setlist_remove_song">Eliminar de la lista</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1193,4 +1193,10 @@
     <string name="cd_section_collapsed">Réduit</string>
     <string name="cd_decrease_capo">Diminuer le capo</string>
     <string name="cd_increase_capo">Augmenter le capo</string>
+    <string name="cd_setlist_create">Créer une setlist</string>
+    <string name="cd_setlist_delete">Supprimer la setlist</string>
+    <string name="cd_setlist_add_song">Ajouter une chanson à la setlist</string>
+    <string name="cd_setlist_move_up">Déplacer vers le haut</string>
+    <string name="cd_setlist_move_down">Déplacer vers le bas</string>
+    <string name="cd_setlist_remove_song">Retirer de la setlist</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1198,4 +1198,10 @@
     <string name="cd_section_collapsed">संकुचित</string>
     <string name="cd_decrease_capo">कैपो घटाएं</string>
     <string name="cd_increase_capo">कैपो बढ़ाएं</string>
+    <string name="cd_setlist_create">सेटलिस्ट बनाएं</string>
+    <string name="cd_setlist_delete">सेटलिस्ट हटाएं</string>
+    <string name="cd_setlist_add_song">सेटलिस्ट में गाना जोड़ें</string>
+    <string name="cd_setlist_move_up">ऊपर ले जाएं</string>
+    <string name="cd_setlist_move_down">नीचे ले जाएं</string>
+    <string name="cd_setlist_remove_song">सेटलिस्ट से हटाएं</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1195,4 +1195,10 @@
     <string name="cd_section_collapsed">Diciutkan</string>
     <string name="cd_decrease_capo">Kurangi capo</string>
     <string name="cd_increase_capo">Tambah capo</string>
+    <string name="cd_setlist_create">Buat daftar lagu</string>
+    <string name="cd_setlist_delete">Hapus daftar lagu</string>
+    <string name="cd_setlist_add_song">Tambah lagu ke daftar</string>
+    <string name="cd_setlist_move_up">Pindah ke atas</string>
+    <string name="cd_setlist_move_down">Pindah ke bawah</string>
+    <string name="cd_setlist_remove_song">Hapus dari daftar</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1197,4 +1197,10 @@
     <string name="cd_section_collapsed">Compresso</string>
     <string name="cd_decrease_capo">Diminuisci capo</string>
     <string name="cd_increase_capo">Aumenta capo</string>
+    <string name="cd_setlist_create">Crea scaletta</string>
+    <string name="cd_setlist_delete">Elimina scaletta</string>
+    <string name="cd_setlist_add_song">Aggiungi brano alla scaletta</string>
+    <string name="cd_setlist_move_up">Sposta su</string>
+    <string name="cd_setlist_move_down">Sposta giù</string>
+    <string name="cd_setlist_remove_song">Rimuovi dalla scaletta</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1197,4 +1197,10 @@
     <string name="cd_section_collapsed">折りたたみ</string>
     <string name="cd_decrease_capo">カポを下げる</string>
     <string name="cd_increase_capo">カポを上げる</string>
+    <string name="cd_setlist_create">セットリストを作成</string>
+    <string name="cd_setlist_delete">セットリストを削除</string>
+    <string name="cd_setlist_add_song">セットリストに曲を追加</string>
+    <string name="cd_setlist_move_up">上に移動</string>
+    <string name="cd_setlist_move_down">下に移動</string>
+    <string name="cd_setlist_remove_song">セットリストから削除</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1197,4 +1197,10 @@
     <string name="cd_section_collapsed">접힘</string>
     <string name="cd_decrease_capo">카포 감소</string>
     <string name="cd_increase_capo">카포 증가</string>
+    <string name="cd_setlist_create">세트리스트 만들기</string>
+    <string name="cd_setlist_delete">세트리스트 삭제</string>
+    <string name="cd_setlist_add_song">세트리스트에 곡 추가</string>
+    <string name="cd_setlist_move_up">위로 이동</string>
+    <string name="cd_setlist_move_down">아래로 이동</string>
+    <string name="cd_setlist_remove_song">세트리스트에서 제거</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1196,4 +1196,10 @@
     <string name="cd_section_collapsed">Ingeklapt</string>
     <string name="cd_decrease_capo">Capo verlagen</string>
     <string name="cd_increase_capo">Capo verhogen</string>
+    <string name="cd_setlist_create">Setlist aanmaken</string>
+    <string name="cd_setlist_delete">Setlist verwijderen</string>
+    <string name="cd_setlist_add_song">Nummer toevoegen aan setlist</string>
+    <string name="cd_setlist_move_up">Omhoog verplaatsen</string>
+    <string name="cd_setlist_move_down">Omlaag verplaatsen</string>
+    <string name="cd_setlist_remove_song">Verwijderen uit setlist</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1198,4 +1198,10 @@
     <string name="cd_section_collapsed">Zwinięte</string>
     <string name="cd_decrease_capo">Zmniejsz capo</string>
     <string name="cd_increase_capo">Zwiększ capo</string>
+    <string name="cd_setlist_create">Utwórz listę utworów</string>
+    <string name="cd_setlist_delete">Usuń listę utworów</string>
+    <string name="cd_setlist_add_song">Dodaj utwór do listy</string>
+    <string name="cd_setlist_move_up">Przenieś w górę</string>
+    <string name="cd_setlist_move_down">Przenieś w dół</string>
+    <string name="cd_setlist_remove_song">Usuń z listy</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1195,4 +1195,10 @@
     <string name="cd_section_collapsed">Recolhido</string>
     <string name="cd_decrease_capo">Diminuir capo</string>
     <string name="cd_increase_capo">Aumentar capo</string>
+    <string name="cd_setlist_create">Criar lista de músicas</string>
+    <string name="cd_setlist_delete">Excluir lista de músicas</string>
+    <string name="cd_setlist_add_song">Adicionar música à lista</string>
+    <string name="cd_setlist_move_up">Mover para cima</string>
+    <string name="cd_setlist_move_down">Mover para baixo</string>
+    <string name="cd_setlist_remove_song">Remover da lista</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1200,4 +1200,10 @@
     <string name="cd_section_collapsed">Свёрнуто</string>
     <string name="cd_decrease_capo">Уменьшить капо</string>
     <string name="cd_increase_capo">Увеличить капо</string>
+    <string name="cd_setlist_create">Создать сет-лист</string>
+    <string name="cd_setlist_delete">Удалить сет-лист</string>
+    <string name="cd_setlist_add_song">Добавить песню в сет-лист</string>
+    <string name="cd_setlist_move_up">Переместить вверх</string>
+    <string name="cd_setlist_move_down">Переместить вниз</string>
+    <string name="cd_setlist_remove_song">Убрать из сет-листа</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1196,4 +1196,10 @@
     <string name="cd_section_collapsed">Daraltıldı</string>
     <string name="cd_decrease_capo">Kapoyu azalt</string>
     <string name="cd_increase_capo">Kapoyu artır</string>
+    <string name="cd_setlist_create">Set listesi oluştur</string>
+    <string name="cd_setlist_delete">Set listesini sil</string>
+    <string name="cd_setlist_add_song">Set listesine şarkı ekle</string>
+    <string name="cd_setlist_move_up">Yukarı taşı</string>
+    <string name="cd_setlist_move_down">Aşağı taşı</string>
+    <string name="cd_setlist_remove_song">Set listesinden kaldır</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -20,4 +20,10 @@
     <string name="cd_step_sequencer_grid">旋律步进音序器，%d 步</string>
     <string name="cd_step_note">第 %1$d 步：%2$s %3$s</string>
     <string name="cd_step_empty">第 %d 步：空</string>
+    <string name="cd_setlist_create">建立歌單</string>
+    <string name="cd_setlist_delete">刪除歌單</string>
+    <string name="cd_setlist_add_song">新增歌曲至歌單</string>
+    <string name="cd_setlist_move_up">上移</string>
+    <string name="cd_setlist_move_down">下移</string>
+    <string name="cd_setlist_remove_song">從歌單中移除</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,6 +293,12 @@
     <string name="cd_filter_label">Filter by label %s</string>
     <string name="cd_add_label">Add label</string>
     <string name="nav_setlists">Setlists</string>
+    <string name="cd_setlist_create">Create setlist</string>
+    <string name="cd_setlist_delete">Delete setlist</string>
+    <string name="cd_setlist_add_song">Add song to setlist</string>
+    <string name="cd_setlist_move_up">Move up</string>
+    <string name="cd_setlist_move_down">Move down</string>
+    <string name="cd_setlist_remove_song">Remove from setlist</string>
     <string name="songbook_duplicate">Duplicate</string>
     <string name="songbook_font_decrease">Decrease font size</string>
     <string name="songbook_font_increase">Increase font size</string>

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -18172,6 +18172,606 @@
         }
       }
     },
+    "cd_setlist_add_song": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add song to setlist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une chanson à la setlist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lied zur Setlist hinzufügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir canción a la lista"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi brano alla scaletta"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar música à lista"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nummer toevoegen aan setlist"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить песню в сет-лист"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set listesine şarkı ekle"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj utwór do listy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットリストに曲を追加"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세트리스트에 곡 추가"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटलिस्ट में गाना जोड़ें"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tambah lagu ke daftar"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إضافة أغنية إلى القائمة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加歌曲到歌单"
+          }
+        }
+      }
+    },
+    "cd_setlist_create": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create setlist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer une setlist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setlist erstellen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crear lista de canciones"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Crea scaletta"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar lista de músicas"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setlist aanmaken"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создать сет-лист"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set listesi oluştur"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwórz listę utworów"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットリストを作成"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세트리스트 만들기"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटलिस्ट बनाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buat daftar lagu"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إنشاء قائمة تشغيل"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建歌单"
+          }
+        }
+      }
+    },
+    "cd_setlist_delete": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete setlist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer la setlist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setlist löschen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar lista de canciones"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elimina scaletta"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Excluir lista de músicas"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setlist verwijderen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить сет-лист"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set listesini sil"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń listę utworów"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットリストを削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세트리스트 삭제"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटलिस्ट हटाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hapus daftar lagu"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حذف قائمة التشغيل"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除歌单"
+          }
+        }
+      }
+    },
+    "cd_setlist_move_down": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move down"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer vers le bas"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach unten verschieben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover abajo"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta giù"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para baixo"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omlaag verplaatsen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить вниз"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aşağı taşı"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś w dół"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下に移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아래로 이동"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "नीचे ले जाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pindah ke bawah"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحريك لأسفل"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下移"
+          }
+        }
+      }
+    },
+    "cd_setlist_move_up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move up"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer vers le haut"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach oben verschieben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover arriba"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sposta su"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover para cima"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omhoog verplaatsen"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить вверх"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yukarı taşı"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenieś w górę"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上に移動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위로 이동"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ऊपर ले जाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pindah ke atas"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحريك لأعلى"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上移"
+          }
+        }
+      }
+    },
+    "cd_setlist_remove_song": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove from setlist"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retirer de la setlist"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aus Setlist entfernen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar de la lista"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimuovi dalla scaletta"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remover da lista"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwijderen uit setlist"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Убрать из сет-листа"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set listesinden kaldır"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń z listy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セットリストから削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "세트리스트에서 제거"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "सेटलिस्ट से हटाएं"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hapus dari daftar"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إزالة من القائمة"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从歌单中移除"
+          }
+        }
+      }
+    },
     "cd_settings": {
       "localizations": {
         "en": {

--- a/iosApp/UkuleleCompanion/Views/SetlistView.swift
+++ b/iosApp/UkuleleCompanion/Views/SetlistView.swift
@@ -57,7 +57,7 @@ struct SetlistView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
-                    .accessibilityLabel("Create setlist")
+                    .accessibilityLabel(String(localized: "cd_setlist_create"))
                 }
             }
             .alert("New Setlist", isPresented: $showingCreateSheet) {
@@ -135,7 +135,7 @@ struct SetlistDetailView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
-                .accessibilityLabel("Add song to setlist")
+                .accessibilityLabel(String(localized: "cd_setlist_add_song"))
             }
             ToolbarItem(placement: .primaryAction) {
                 EditButton()


### PR DESCRIPTION
## Summary

- Replaces 7 hardcoded English `contentDescription` strings in `SetlistTab.kt` with `stringResource()` calls
- Replaces 2 hardcoded English `.accessibilityLabel()` strings in iOS `SetlistView.swift` with `String(localized:)` calls
- Adds 6 new `cd_setlist_*` string resources with translations for all 16 supported locales
- Regenerates iOS `Localizable.xcstrings` from Android sources

## Test plan

- [x] `./gradlew assembleDebug` — builds without errors
- [x] `./gradlew lintDebug` — no new lint issues (no MissingTranslation)
- [x] ktlint passes with baseline
- [ ] Enable TalkBack (Android) in a non-English locale, navigate to Setlists, verify actions announced in correct language
- [ ] Enable VoiceOver (iOS) in a non-English locale, verify "Create setlist" and "Add song" announced correctly

Fixes #464

Made with [Cursor](https://cursor.com)