### PR TITLE
Fix: eliminate per-frame allocations in audio hot path

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioChordDetector.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioChordDetector.kt
@@ -1,5 +1,7 @@
 package com.baijum.ukufretboard.domain
 
+import com.baijum.ukufretboard.platform.PlatformLock
+import com.baijum.ukufretboard.platform.withLock
 import kotlin.math.max
 
 /**
@@ -19,7 +21,6 @@ import kotlin.math.max
  * system, which was originally designed for fret-selection input.
  */
 object AudioChordDetector {
-
     /**
      * Result of audio-based chord detection.
      *
@@ -53,6 +54,25 @@ object AudioChordDetector {
 
     private const val MIN_PITCH_CLASSES = 3
 
+    private val lock = PlatformLock()
+    private var cachedFftSize = 0
+    private var cachedReal = FloatArray(0)
+    private var cachedImag = FloatArray(0)
+    private var cachedMagnitudes = FloatArray(0)
+    private var cachedChroma = FloatArray(12)
+    private var cachedWeightedChroma = FloatArray(12)
+
+    private fun ensureBuffers(fftSize: Int) {
+        if (fftSize != cachedFftSize) {
+            cachedFftSize = fftSize
+            cachedReal = FloatArray(fftSize)
+            cachedImag = FloatArray(fftSize)
+            cachedMagnitudes = FloatArray(fftSize / 2)
+        } else {
+            cachedImag.fill(0f)
+        }
+    }
+
     /**
      * Detects a chord from raw audio samples.
      *
@@ -70,68 +90,69 @@ object AudioChordDetector {
         threshold: Float = DEFAULT_THRESHOLD,
         preferredRootPitchClass: Int? = null,
         preferredRootWeight: Float = 1.15f,
-    ): AudioChordResult {
-        // Step 1: Windowed FFT
-        val windowed = FFTProcessor.hanningWindow(samples)
-        val real = windowed.copyOf()
-        val imag = FloatArray(windowed.size)
-        FFTProcessor.fft(real, imag)
+    ): AudioChordResult =
+        lock.withLock {
+            ensureBuffers(samples.size)
 
-        // Step 2: Magnitude spectrum
-        val magnitudes = FFTProcessor.magnitudeSpectrum(real, imag)
+            // Step 1: Windowed FFT — write Hanning window directly into cachedReal
+            FFTProcessor.hanningWindowInto(samples, cachedReal)
+            FFTProcessor.fft(cachedReal, cachedImag)
 
-        // Step 3: Chromagram
-        val chroma = Chromagram.compute(
-            magnitudes = magnitudes,
-            sampleRate = sampleRate,
-            fftSize = samples.size,
-        )
+            // Step 2: Magnitude spectrum into pre-allocated buffer
+            FFTProcessor.magnitudeSpectrumInto(cachedReal, cachedImag, cachedMagnitudes)
 
-        // Optional guidance: bias the chroma toward a stable root hint from
-        // external pitch estimation (e.g., neural supervisor in Pitch Monitor).
-        val weightedChroma = chroma.copyOf()
-        if (preferredRootPitchClass != null && preferredRootPitchClass in 0..11) {
-            weightedChroma[preferredRootPitchClass] =
-                weightedChroma[preferredRootPitchClass] * max(1.0f, preferredRootWeight)
-        }
+            // Step 3: Chromagram
+            Chromagram.computeInto(
+                magnitudes = cachedMagnitudes,
+                sampleRate = sampleRate,
+                fftSize = samples.size,
+                out = cachedChroma,
+            )
 
-        // Step 4: Threshold — find active pitch classes
-        val maxEnergy = weightedChroma.max()
-        if (maxEnergy <= 0f) {
-            return AudioChordResult(
-                detection = ChordDetector.DetectionResult.NoSelection,
-                confidence = 0f,
-                activePitchClasses = emptySet(),
-                chromagram = FloatArray(12),
+            // Optional guidance: bias the chroma toward a stable root hint
+            cachedChroma.copyInto(cachedWeightedChroma)
+            if (preferredRootPitchClass != null && preferredRootPitchClass in 0..11) {
+                cachedWeightedChroma[preferredRootPitchClass] =
+                    cachedWeightedChroma[preferredRootPitchClass] * max(1.0f, preferredRootWeight)
+            }
+
+            // Step 4: Threshold — find active pitch classes
+            val maxEnergy = cachedWeightedChroma.max()
+            if (maxEnergy <= 0f) {
+                return@withLock AudioChordResult(
+                    detection = ChordDetector.DetectionResult.NoSelection,
+                    confidence = 0f,
+                    activePitchClasses = emptySet(),
+                    chromagram = cachedChroma.copyOf(),
+                )
+            }
+
+            val cutoff = threshold * maxEnergy
+            val activePitchClasses = mutableSetOf<Int>()
+            var activeEnergy = 0f
+
+            for (i in cachedWeightedChroma.indices) {
+                if (cachedWeightedChroma[i] >= cutoff) {
+                    activePitchClasses.add(i)
+                    activeEnergy += cachedWeightedChroma[i]
+                }
+            }
+
+            // Step 5: Match against chord formulas (reuses existing ChordDetector)
+            val detection =
+                if (activePitchClasses.size >= MIN_PITCH_CLASSES) {
+                    ChordDetector.detect(activePitchClasses.toList())
+                } else {
+                    ChordDetector.DetectionResult.NoSelection
+                }
+
+            val confidence = activeEnergy / cachedWeightedChroma.sum().coerceAtLeast(1e-6f)
+
+            AudioChordResult(
+                detection = detection,
+                confidence = confidence,
+                activePitchClasses = activePitchClasses,
+                chromagram = cachedChroma.copyOf(),
             )
         }
-
-        val cutoff = threshold * maxEnergy
-        val activePitchClasses = mutableSetOf<Int>()
-        var activeEnergy = 0f
-
-        for (i in weightedChroma.indices) {
-            if (weightedChroma[i] >= cutoff) {
-                activePitchClasses.add(i)
-                activeEnergy += weightedChroma[i]
-            }
-        }
-
-        // Step 5: Match against chord formulas (reuses existing ChordDetector)
-        val detection = if (activePitchClasses.size >= MIN_PITCH_CLASSES) {
-            ChordDetector.detect(activePitchClasses.toList())
-        } else {
-            ChordDetector.DetectionResult.NoSelection
-        }
-
-        // Confidence: fraction of total energy captured by the active bins
-        val confidence = activeEnergy / weightedChroma.sum().coerceAtLeast(1e-6f)
-
-        return AudioChordResult(
-            detection = detection,
-            confidence = confidence,
-            activePitchClasses = activePitchClasses,
-            chromagram = chroma,
-        )
-    }
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioResampler.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/AudioResampler.kt
@@ -22,7 +22,7 @@ object AudioResampler {
      * providing ~14 dB attenuation at 8 kHz — sufficient for the neural
      * model's frequency range (46–2094 Hz fundamentals).
      */
-    private const val MA_HALF = 2  // 5-tap: indices -2..+2
+    private const val MA_HALF = 2 // 5-tap: indices -2..+2
 
     private val lock = PlatformLock()
 
@@ -32,6 +32,13 @@ object AudioResampler {
     private var cachedFiltered = FloatArray(0)
     private var cachedOutput = FloatArray(0)
 
+    /**
+     * Downsamples from 44.1 kHz to 16 kHz, returning the internal cached buffer.
+     *
+     * **Important:** The returned array is reused across calls. Callers must
+     * consume the data before the next call to this function (which is the
+     * normal pattern in the audio pipeline — process immediately, don't store).
+     */
     fun downsample44kTo16k(input: FloatArray): FloatArray {
         if (input.isEmpty()) return FloatArray(0)
 
@@ -56,7 +63,7 @@ object AudioResampler {
                 output[i] = filtered[baseIdx] * (1f - frac) + filtered[nextIdx] * frac
             }
 
-            output.copyOf()
+            output
         }
     }
 
@@ -64,7 +71,10 @@ object AudioResampler {
      * Applies a simple 5-tap moving average low-pass filter, writing results
      * into the pre-allocated [out] buffer.
      */
-    private fun applyMovingAverageInto(input: FloatArray, out: FloatArray) {
+    private fun applyMovingAverageInto(
+        input: FloatArray,
+        out: FloatArray,
+    ) {
         val n = input.size
         if (n <= MA_HALF * 2) {
             input.copyInto(out, 0, 0, n)

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/Chromagram.kt
@@ -73,4 +73,40 @@ object Chromagram {
 
         return chroma
     }
+
+    /**
+     * Computes a 12-bin chromagram into a pre-allocated [out] buffer.
+     * Avoids per-call allocation when callers own the output buffer.
+     */
+    fun computeInto(
+        magnitudes: FloatArray,
+        sampleRate: Int,
+        fftSize: Int,
+        out: FloatArray,
+        minFreq: Float = 130.0f,
+        maxFreq: Float = 1050.0f,
+    ) {
+        out.fill(0f)
+        val freqPerBin = sampleRate.toFloat() / fftSize
+
+        val minBin = (minFreq / freqPerBin).toInt().coerceAtLeast(1)
+        val maxBin = (maxFreq / freqPerBin).toInt().coerceAtMost(magnitudes.size - 1)
+
+        for (bin in minBin..maxBin) {
+            val freq = bin * freqPerBin
+            if (freq < minFreq) continue
+
+            val semitones = (12.0 * log2(freq.toDouble() / C0_HZ)).toFloat()
+            val pitchClass = Notes.normalizePitchClass(semitones.roundToInt())
+
+            out[pitchClass] += magnitudes[bin] * magnitudes[bin]
+        }
+
+        val total = out.sum()
+        if (total > 0f) {
+            for (i in out.indices) {
+                out[i] /= total
+            }
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FFTProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/FFTProcessor.kt
@@ -20,7 +20,6 @@ import kotlin.math.sqrt
  * processing on the UI thread budget (~93 ms per frame at 44.1 kHz / 4096).
  */
 object FFTProcessor {
-
     /**
      * Cached twiddle factors (cos, sin) for each FFT stage length.
      *
@@ -34,9 +33,12 @@ object FFTProcessor {
      * Pre-computed cos/sin twiddle factors for all butterfly stages of a
      * given FFT size.
      */
-    private class TwiddleFactors(n: Int) {
+    private class TwiddleFactors(
+        n: Int,
+    ) {
         /** Twiddle real parts, indexed [stage][k]. */
         val real: Array<FloatArray>
+
         /** Twiddle imaginary parts, indexed [stage][k]. */
         val imag: Array<FloatArray>
 
@@ -63,11 +65,10 @@ object FFTProcessor {
         }
     }
 
-    private fun getTwiddle(n: Int): TwiddleFactors {
-        return cacheLock.withLock {
+    private fun getTwiddle(n: Int): TwiddleFactors =
+        cacheLock.withLock {
             twiddleCache.getOrPut(n) { TwiddleFactors(n) }
         }
-    }
 
     /**
      * Applies a Hanning window to [samples] to reduce spectral leakage.
@@ -99,7 +100,10 @@ object FFTProcessor {
      * @param imag Imaginary part (should be all-zero for a real signal;
      *   overwritten with FFT result).
      */
-    fun fft(real: FloatArray, imag: FloatArray) {
+    fun fft(
+        real: FloatArray,
+        imag: FloatArray,
+    ) {
         val n = real.size
         require(n > 0 && n and (n - 1) == 0) { "FFT size must be a power of 2" }
 
@@ -115,9 +119,13 @@ object FFTProcessor {
 
             if (i < j) {
                 // Swap real
-                val tmpR = real[i]; real[i] = real[j]; real[j] = tmpR
+                val tmpR = real[i]
+                real[i] = real[j]
+                real[j] = tmpR
                 // Swap imag
-                val tmpI = imag[i]; imag[i] = imag[j]; imag[j] = tmpI
+                val tmpI = imag[i]
+                imag[i] = imag[j]
+                imag[j] = tmpI
             }
         }
 
@@ -168,7 +176,10 @@ object FFTProcessor {
      * @param real Real part of the frequency-domain signal (overwritten).
      * @param imag Imaginary part (overwritten).
      */
-    fun ifft(real: FloatArray, imag: FloatArray) {
+    fun ifft(
+        real: FloatArray,
+        imag: FloatArray,
+    ) {
         val n = real.size
         require(n > 0 && n and (n - 1) == 0) { "IFFT size must be a power of 2" }
 
@@ -196,12 +207,45 @@ object FFTProcessor {
      * @param imag Imaginary part of the FFT result.
      * @return A [FloatArray] of length N/2 containing magnitude values.
      */
-    fun magnitudeSpectrum(real: FloatArray, imag: FloatArray): FloatArray {
+    fun magnitudeSpectrum(
+        real: FloatArray,
+        imag: FloatArray,
+    ): FloatArray {
         val halfN = real.size / 2
         val magnitudes = FloatArray(halfN)
         for (i in 0 until halfN) {
             magnitudes[i] = sqrt(real[i] * real[i] + imag[i] * imag[i])
         }
         return magnitudes
+    }
+
+    /**
+     * Applies a Hanning window to [samples], writing results into [out].
+     * Avoids per-call allocation when callers own the output buffer.
+     */
+    fun hanningWindowInto(
+        samples: FloatArray,
+        out: FloatArray,
+    ) {
+        val n = samples.size
+        for (i in 0 until n) {
+            val w = 0.5f * (1.0f - cos(2.0 * PI * i / (n - 1)).toFloat())
+            out[i] = samples[i] * w
+        }
+    }
+
+    /**
+     * Computes magnitude spectrum into a pre-allocated [out] buffer.
+     * Avoids per-call allocation when callers own the output buffer.
+     */
+    fun magnitudeSpectrumInto(
+        real: FloatArray,
+        imag: FloatArray,
+        out: FloatArray,
+    ) {
+        val halfN = real.size / 2
+        for (i in 0 until halfN) {
+            out[i] = sqrt(real[i] * real[i] + imag[i] * imag[i])
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Removes `output.copyOf()` from `AudioResampler.downsample44kTo16k` — returns cached buffer directly
- Adds buffer caching with `PlatformLock` to `AudioChordDetector` following the `PitchDetector.ensureBuffers` pattern
- Adds `hanningWindowInto()` and `magnitudeSpectrumInto()` variants to `FFTProcessor` for zero-allocation hot-path usage
- Adds `computeInto()` to `Chromagram` for pre-allocated output

These changes eliminate 5+ `FloatArray` allocations per audio frame (~43/sec) in the Pitch Monitor and Play Along detection pipeline, reducing GC pressure during extended practice sessions.

## Test plan

- [x] `./gradlew :shared:jvmTest` — shared module tests pass (including AudioChordDetector, AudioResampler, FFTProcessor tests)
- [x] `./gradlew testDebugUnitTest` — all Android unit tests pass
- [x] ktlint passes
- [ ] Extended Pitch Monitor session (30+ min) — no audio glitches or dropped frames
- [ ] Play Along session with chord detection — correct chords still detected

Fixes #466

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved chord detection performance by optimizing buffer management and adding thread-safety improvements.
  * Enhanced audio signal processing efficiency by minimizing memory allocations during computation.
  * Streamlined fast Fourier transform utilities with additional in-place processing options.

* **Documentation**
  * Updated documentation for audio resampling and processing methods with clearer usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->