### PR TITLE
Fix: iOS MelodyCoder passes createdAt through without double-scaling

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -505,7 +505,7 @@ private enum MelodyCoder {
                 name: m["name"] as? String ?? "",
                 notes: notes,
                 bpm: Int32(m["bpm"] as? Int ?? 120),
-                createdAt: BackupTimestamp.toMillis(m["createdAt"] as? Double ?? 0)
+                createdAt: BackupTimestamp.fromAny(m["createdAt"])
             )
         }
     }
@@ -529,7 +529,7 @@ private enum MelodyCoder {
             return [
                 "id": m.id, "name": m.name, "notes": notes,
                 "bpm": Int(m.bpm),
-                "createdAt": BackupTimestamp.toSeconds(m.createdAt),
+                "createdAt": Double(m.createdAt),
             ] as [String: Any]
         }
     }


### PR DESCRIPTION
## Summary

- Changes `MelodyCoder.build` to use `BackupTimestamp.fromAny(m["createdAt"])` instead of `BackupTimestamp.toMillis(...)` — avoids double-scaling ms values
- Changes `MelodyCoder.extract` to use `Double(m.createdAt)` instead of `BackupTimestamp.toSeconds(...)` — avoids incorrectly dividing ms by 1000

This matches the pattern used by `ChordSheetCoder` and `SetlistCoder` which correctly pass ms-based timestamps through unchanged.

**Before:** A melody created at epoch ms `1,700,000,000,000` was written to backup as `1,700,000,000,000,000` (~year 55,800), corrupting dates on cross-platform restore.

**After:** The backup JSON contains the correct 13-digit ms timestamp.

## Test plan

- [x] `./gradlew assembleDebug` — Android builds (no shared module changes)
- [ ] iOS build passes (CI will verify)
- [ ] Export backup on iOS, verify melody `createdAt` is a 13-digit epoch ms value
- [ ] Import Android backup on iOS — melodies retain correct creation dates
- [ ] iOS→iOS round-trip preserves melody dates

Fixes #468

Made with [Cursor](https://cursor.com)