### PR TITLE
Chore(deps): Bump github/codeql-action init and analyze to v4.37.5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
         with:
           languages: actions
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5


### PR DESCRIPTION
## Summary
- Supersedes #489, which only bumped the `analyze` step and left `init` on v4.36.2, causing CodeQL to fail with "Loaded a configuration file for version '4.36.2', but running version '4.37.5'".
- Bumps both `init` and `analyze` steps to v4.37.5 together so they stay in sync.

## Test plan
- [x] CI CodeQL Analyze check passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL analysis actions to a newer version for improved security scanning reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->