### PR TITLE
Chore: Group github/codeql-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
     labels:
       - "ci-cd"
       - "dependencies"
+    groups:
+      # init and analyze must stay on the same version -- CodeQL fails with a
+      # configuration error when they disagree.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## Summary

Groups the `github/codeql-action/*` sub-actions into a single dependabot update, so `init` and `analyze` are always bumped together.

## Why

The CodeQL action requires every step using `github/codeql-action` to be on the same version. Dependabot was treating `init` and `analyze` as independent dependencies and opening a PR for each, so whichever landed first left the workflow mismatched and CodeQL failed with:

> Not all workflow steps that use `github/codeql-action` actions use the same version.

This has now happened twice, each time needing a hand-written commit to bump the other half — #498 (v4.37.5) and #504 (v4.37.7).

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML
- Verified on the next dependabot run: a bump should arrive as one PR titled for the `codeql-action` group, touching both lines in `.github/workflows/codeql.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped related CodeQL security analysis updates so they can be managed together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->