### PR TITLE
Fix: Share one accessible capo stepper between Explorer and the song editor

### DIFF
--- a/app/src/androidTest/java/com/baijum/ukufretboard/ExplorerCapoStepperTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/ExplorerCapoStepperTest.kt
@@ -1,0 +1,165 @@
+package com.baijum.ukufretboard
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertWidthIsAtLeast
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
+import com.baijum.ukufretboard.ui.navigation.CapoSelector
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * UI tests for the Explorer's capo stepper (issue #523).
+ *
+ * The Explorer had its own copy of the stepper that predated the song editor's:
+ * it announced nothing after a press, read the value as a bare number, and boxed
+ * it in a fixed 32.dp width that clips longer translations of "Off". Both screens
+ * now share one [com.baijum.ukufretboard.ui.CapoStepper].
+ *
+ * Run with: ./gradlew connectedAndroidTest
+ *   -Pandroid.testInstrumentationRunnerArguments.class=com.baijum.ukufretboard.ExplorerCapoStepperTest
+ */
+class ExplorerCapoStepperTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private var capo = 0
+
+    private fun str(
+        id: Int,
+        vararg args: Any,
+    ): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.getString(id, *args)
+    }
+
+    private fun renderSelector(
+        initialCapo: Int = 0,
+        lastFret: Int = 12,
+    ) {
+        capo = initialCapo
+        composeTestRule.setContent {
+            MaterialTheme {
+                var value by remember { mutableIntStateOf(initialCapo) }
+                CapoSelector(
+                    capoFret = value,
+                    lastFret = lastFret,
+                    onCapoChange = {
+                        value = it
+                        capo = it
+                    },
+                )
+            }
+        }
+    }
+
+    private fun increase() = composeTestRule.onNodeWithContentDescription(str(R.string.cd_increase_capo))
+
+    private fun decrease() = composeTestRule.onNodeWithContentDescription(str(R.string.cd_decrease_capo))
+
+    private fun valueNode(capoFret: Int) =
+        composeTestRule.onNodeWithContentDescription(
+            if (capoFret == 0) {
+                str(R.string.capo_calc_no_capo)
+            } else {
+                str(R.string.songbook_capo_value, capoFret)
+            },
+        )
+
+    @Test
+    fun theValueIsALiveRegionSoChangesAreSpoken() {
+        // The blocking defect: focus stays on the +/- button after a press, so with
+        // no live region TalkBack says nothing and the user has to swipe away and
+        // back to learn the new value.
+        renderSelector(initialCapo = 3)
+
+        val node = valueNode(3).fetchSemanticsNode()
+
+        assertEquals(
+            LiveRegionMode.Polite,
+            node.config.getOrNull(SemanticsProperties.LiveRegion),
+        )
+    }
+
+    @Test
+    fun theValueAnnouncesItsMeaningNotABareNumber() {
+        renderSelector(initialCapo = 3)
+
+        valueNode(3).assertIsDisplayed()
+    }
+
+    @Test
+    fun zeroAnnouncesNoCapo() {
+        renderSelector(initialCapo = 0)
+
+        valueNode(0).assertIsDisplayed()
+    }
+
+    @Test
+    fun theValueIsNotBoxedIntoAFixedWidth() {
+        // 32.dp fitted "Off" and no more; "Désactivé", "Выкл." and any two-digit
+        // fret at a large font scale overflowed it.
+        renderSelector(initialCapo = 0)
+
+        valueNode(0).assertWidthIsAtLeast(40.dp)
+    }
+
+    @Test
+    fun steppingUpdatesTheValueAndReportsIt() {
+        renderSelector(initialCapo = 3)
+
+        increase().performClick()
+        composeTestRule.waitForIdle()
+        valueNode(4).assertIsDisplayed()
+        assertEquals(4, capo)
+
+        decrease().performClick()
+        decrease().performClick()
+        composeTestRule.waitForIdle()
+        valueNode(2).assertIsDisplayed()
+        assertEquals(2, capo)
+    }
+
+    @Test
+    fun decreaseIsDisabledAtZero() {
+        renderSelector(initialCapo = 0)
+
+        decrease().assertIsNotEnabled()
+        increase().assertIsEnabled()
+    }
+
+    @Test
+    fun increaseIsDisabledAtTheLastFret() {
+        renderSelector(initialCapo = 5, lastFret = 5)
+
+        increase().assertIsNotEnabled()
+        decrease().assertIsEnabled()
+    }
+
+    @Test
+    fun theStepperRespectsTheCallersFretBound() {
+        // The Explorer passes the user's own last-fret setting; the song editor caps
+        // at 12. A shared component has to honour whichever it is given.
+        renderSelector(initialCapo = 6, lastFret = 7)
+
+        increase().performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(7, capo)
+        increase().assertIsNotEnabled()
+    }
+}

--- a/app/src/main/java/com/baijum/ukufretboard/ui/CapoStepper.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/CapoStepper.kt
@@ -1,0 +1,116 @@
+package com.baijum.ukufretboard.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.baijum.ukufretboard.R
+import com.baijum.ukufretboard.viewmodel.FretboardViewModel
+
+/** Widest the value label needs before "Off" or a two-digit fret starts to clip. */
+private val VALUE_MIN_WIDTH = 40.dp
+
+/** Alpha applied to a stepper glyph once its button is disabled. */
+private const val DISABLED_GLYPH_ALPHA = 0.3f
+
+/**
+ * Minus / value / plus stepper for a capo position, `0..maxFret`.
+ *
+ * Shared by the Explorer and the song editor. The Explorer had its own copy that
+ * announced nothing after a press, read the value as a bare number, and clipped
+ * longer translations of "Off" in a fixed 32.dp box (issue #523).
+ *
+ * Callers supply their own "Capo" label — the two screens place it differently.
+ */
+@Composable
+internal fun CapoStepper(
+    capo: Int,
+    onCapoChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    maxFret: Int = FretboardViewModel.LAST_FRET,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val decreaseCapoDescription = stringResource(R.string.cd_decrease_capo)
+        IconButton(
+            onClick = { onCapoChange((capo - 1).coerceAtLeast(0)) },
+            enabled = capo > 0,
+            modifier = Modifier.semantics { contentDescription = decreaseCapoDescription },
+        ) {
+            StepperGlyph(glyph = "−", enabled = capo > 0)
+        }
+
+        // TalkBack reads the value as "Capo 3" rather than a bare "3", which carries
+        // no meaning once focus has moved off the stepper's buttons.
+        val capoValueDescription =
+            if (capo == 0) {
+                stringResource(R.string.capo_calc_no_capo)
+            } else {
+                stringResource(R.string.songbook_capo_value, capo)
+            }
+        Text(
+            text = if (capo == 0) stringResource(R.string.explorer_capo_off) else "$capo",
+            style = MaterialTheme.typography.titleMedium,
+            color =
+                if (capo > 0) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            textAlign = TextAlign.Center,
+            modifier =
+                Modifier
+                    // A fixed width clips "Désactivé" / "Выкл.", and clips even "Off"
+                    // at the large font scales low-vision users run.
+                    .widthIn(min = VALUE_MIN_WIDTH)
+                    .semantics {
+                        contentDescription = capoValueDescription
+                        // Focus stays on the +/- button after a press, so without this
+                        // the new value is never spoken and the stepper is silent to
+                        // TalkBack — including when a button silently disables itself
+                        // at 0 or at maxFret.
+                        liveRegion = LiveRegionMode.Polite
+                    },
+        )
+
+        val increaseCapoDescription = stringResource(R.string.cd_increase_capo)
+        IconButton(
+            onClick = { onCapoChange((capo + 1).coerceAtMost(maxFret)) },
+            enabled = capo < maxFret,
+            modifier = Modifier.semantics { contentDescription = increaseCapoDescription },
+        ) {
+            StepperGlyph(glyph = "+", enabled = capo < maxFret)
+        }
+    }
+}
+
+/** The +/- label of a stepper button, dimmed when the button is disabled. */
+@Composable
+private fun StepperGlyph(
+    glyph: String,
+    enabled: Boolean,
+) {
+    Text(
+        text = glyph,
+        style = MaterialTheme.typography.titleLarge,
+        color =
+            if (enabled) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_GLYPH_ALPHA)
+            },
+    )
+}

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt
@@ -40,6 +40,7 @@ import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.domain.ChordInfo
 import com.baijum.ukufretboard.domain.ChordVoicing
 import com.baijum.ukufretboard.ui.localizedLabel
+import com.baijum.ukufretboard.ui.CapoStepper
 import com.baijum.ukufretboard.ui.ChordResultView
 import com.baijum.ukufretboard.ui.FretboardView
 import com.baijum.ukufretboard.ui.ScaleSelector
@@ -310,42 +311,10 @@ internal fun CapoSelector(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.width(12.dp))
-        val decreaseCapoDescription = stringResource(R.string.cd_decrease_capo)
-        IconButton(
-            onClick = { onCapoChange((capoFret - 1).coerceAtLeast(0)) },
-            enabled = capoFret > 0,
-            modifier = Modifier.semantics { contentDescription = decreaseCapoDescription },
-        ) {
-            Text(
-                text = "−",
-                style = MaterialTheme.typography.titleLarge,
-                color = if (capoFret > 0)
-                    MaterialTheme.colorScheme.primary
-                else
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-            )
-        }
-        Text(
-            text = if (capoFret == 0) stringResource(R.string.explorer_capo_off) else "$capoFret",
-            style = MaterialTheme.typography.titleMedium,
-            color = if (capoFret > 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.width(32.dp),
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+        CapoStepper(
+            capo = capoFret,
+            onCapoChange = onCapoChange,
+            maxFret = lastFret,
         )
-        val increaseCapoDescription = stringResource(R.string.cd_increase_capo)
-        IconButton(
-            onClick = { onCapoChange((capoFret + 1).coerceAtMost(lastFret)) },
-            enabled = capoFret < lastFret,
-            modifier = Modifier.semantics { contentDescription = increaseCapoDescription },
-        ) {
-            Text(
-                text = "+",
-                style = MaterialTheme.typography.titleLarge,
-                color = if (capoFret < lastFret)
-                    MaterialTheme.colorScheme.primary
-                else
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
-            )
-        }
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -42,21 +41,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.ChordParser
 import com.baijum.ukufretboard.data.ChordSheet
+import com.baijum.ukufretboard.ui.CapoStepper
 
 /** Highest capo position offered by the editor stepper; matches the iOS 0...12 range. */
 private const val MAX_CAPO_FRET = 12
@@ -374,80 +370,12 @@ private fun KeyAndCapoRow(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        CapoStepper(capo = capo, onCapoChange = onCapoChange)
+        CapoStepper(
+            capo = capo,
+            onCapoChange = onCapoChange,
+            maxFret = MAX_CAPO_FRET,
+        )
     }
-}
-
-/** Minus/value/plus stepper for the capo position, 0..[MAX_CAPO_FRET]. */
-@Composable
-private fun CapoStepper(
-    capo: Int,
-    onCapoChange: (Int) -> Unit,
-) {
-    val decreaseCapoDescription = stringResource(R.string.cd_decrease_capo)
-    IconButton(
-        onClick = { onCapoChange((capo - 1).coerceAtLeast(0)) },
-        enabled = capo > 0,
-        modifier = Modifier.semantics { contentDescription = decreaseCapoDescription },
-    ) {
-        StepperGlyph(glyph = "−", enabled = capo > 0)
-    }
-
-    // TalkBack reads the value as "Capo 3" rather than a bare "3", which carries
-    // no meaning once focus has moved off the stepper's buttons.
-    val capoValueDescription =
-        if (capo == 0) {
-            stringResource(R.string.capo_calc_no_capo)
-        } else {
-            stringResource(R.string.songbook_capo_value, capo)
-        }
-    Text(
-        text = if (capo == 0) stringResource(R.string.explorer_capo_off) else "$capo",
-        style = MaterialTheme.typography.titleMedium,
-        color =
-            if (capo > 0) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            },
-        textAlign = TextAlign.Center,
-        modifier =
-            Modifier
-                .widthIn(min = 40.dp)
-                .semantics {
-                    contentDescription = capoValueDescription
-                    // Focus stays on the +/- button after a press, so without this the
-                    // new value is never spoken and the stepper is silent to TalkBack.
-                    liveRegion = LiveRegionMode.Polite
-                },
-    )
-
-    val increaseCapoDescription = stringResource(R.string.cd_increase_capo)
-    IconButton(
-        onClick = { onCapoChange((capo + 1).coerceAtMost(MAX_CAPO_FRET)) },
-        enabled = capo < MAX_CAPO_FRET,
-        modifier = Modifier.semantics { contentDescription = increaseCapoDescription },
-    ) {
-        StepperGlyph(glyph = "+", enabled = capo < MAX_CAPO_FRET)
-    }
-}
-
-/** The +/- label of a stepper button, dimmed when the button is disabled. */
-@Composable
-private fun StepperGlyph(
-    glyph: String,
-    enabled: Boolean,
-) {
-    Text(
-        text = glyph,
-        style = MaterialTheme.typography.titleLarge,
-        color =
-            if (enabled) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-            },
-    )
 }
 
 /**

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -2278,59 +2278,53 @@
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/navigation/ExplorerTab.kt">
         <error line="3" column="1" source="standard:import-ordering" />
-        <error line="70" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="88" column="31" source="standard:multiline-expression-wrapping" />
-        <error line="91" column="36" source="standard:multiline-expression-wrapping" />
-        <error line="116" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="131" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="134" column="37" source="standard:multiline-expression-wrapping" />
-        <error line="143" column="22" source="standard:argument-list-wrapping" />
-        <error line="143" column="71" source="standard:argument-list-wrapping" />
-        <error line="143" column="99" source="standard:argument-list-wrapping" />
-        <error line="143" column="121" source="standard:argument-list-wrapping" />
-        <error line="143" column="121" source="standard:max-line-length" />
-        <error line="143" column="145" source="standard:argument-list-wrapping" />
-        <error line="143" column="146" source="standard:argument-list-wrapping" />
-        <error line="155" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="159" column="44" source="standard:multiline-expression-wrapping" />
-        <error line="163" column="121" source="standard:max-line-length" />
-        <error line="167" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="169" column="15" source="standard:if-else-wrapping" />
-        <error line="169" column="20" source="standard:if-else-bracing" />
-        <error line="169" column="20" source="standard:if-else-wrapping" />
-        <error line="169" column="20" source="standard:multiline-if-else" />
-        <error line="170" column="52" source="standard:binary-expression-wrapping" />
-        <error line="170" column="121" source="standard:max-line-length" />
-        <error line="171" column="31" source="standard:multiline-expression-wrapping" />
-        <error line="177" column="32" source="standard:multiline-expression-wrapping" />
-        <error line="188" column="52" source="standard:multiline-expression-wrapping" />
-        <error line="192" column="121" source="standard:max-line-length" />
-        <error line="196" column="15" source="standard:if-else-wrapping" />
-        <error line="196" column="20" source="standard:if-else-bracing" />
-        <error line="196" column="20" source="standard:if-else-wrapping" />
-        <error line="196" column="20" source="standard:multiline-if-else" />
-        <error line="197" column="11" source="standard:if-else-wrapping" />
-        <error line="197" column="16" source="standard:if-else-bracing" />
-        <error line="197" column="16" source="standard:if-else-wrapping" />
-        <error line="197" column="16" source="standard:multiline-if-else" />
-        <error line="209" column="38" source="standard:multiline-expression-wrapping" />
-        <error line="211" column="15" source="standard:if-else-wrapping" />
-        <error line="211" column="20" source="standard:if-else-bracing" />
-        <error line="211" column="20" source="standard:if-else-wrapping" />
-        <error line="211" column="20" source="standard:multiline-if-else" />
-        <error line="213" column="31" source="standard:multiline-expression-wrapping" />
-        <error line="216" column="36" source="standard:multiline-expression-wrapping" />
-        <error line="233" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="271" column="20" source="standard:function-signature" />
-        <error line="271" column="39" source="standard:function-signature" />
-        <error line="271" column="51" source="standard:function-signature" />
-        <error line="273" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="322" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="323" column="21" source="standard:multiline-if-else" />
-        <error line="325" column="21" source="standard:multiline-if-else" />
-        <error line="344" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="345" column="21" source="standard:multiline-if-else" />
-        <error line="347" column="21" source="standard:multiline-if-else" />
+        <error line="71" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="89" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="92" column="36" source="standard:multiline-expression-wrapping" />
+        <error line="117" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="132" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="135" column="37" source="standard:multiline-expression-wrapping" />
+        <error line="144" column="22" source="standard:argument-list-wrapping" />
+        <error line="144" column="71" source="standard:argument-list-wrapping" />
+        <error line="144" column="99" source="standard:argument-list-wrapping" />
+        <error line="144" column="121" source="standard:argument-list-wrapping" />
+        <error line="144" column="121" source="standard:max-line-length" />
+        <error line="144" column="145" source="standard:argument-list-wrapping" />
+        <error line="144" column="146" source="standard:argument-list-wrapping" />
+        <error line="156" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="160" column="44" source="standard:multiline-expression-wrapping" />
+        <error line="164" column="121" source="standard:max-line-length" />
+        <error line="168" column="29" source="standard:multiline-expression-wrapping" />
+        <error line="170" column="15" source="standard:if-else-wrapping" />
+        <error line="170" column="20" source="standard:if-else-bracing" />
+        <error line="170" column="20" source="standard:if-else-wrapping" />
+        <error line="170" column="20" source="standard:multiline-if-else" />
+        <error line="171" column="52" source="standard:binary-expression-wrapping" />
+        <error line="171" column="121" source="standard:max-line-length" />
+        <error line="172" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="178" column="32" source="standard:multiline-expression-wrapping" />
+        <error line="189" column="52" source="standard:multiline-expression-wrapping" />
+        <error line="193" column="121" source="standard:max-line-length" />
+        <error line="197" column="15" source="standard:if-else-wrapping" />
+        <error line="197" column="20" source="standard:if-else-bracing" />
+        <error line="197" column="20" source="standard:if-else-wrapping" />
+        <error line="197" column="20" source="standard:multiline-if-else" />
+        <error line="198" column="11" source="standard:if-else-wrapping" />
+        <error line="198" column="16" source="standard:if-else-bracing" />
+        <error line="198" column="16" source="standard:if-else-wrapping" />
+        <error line="198" column="16" source="standard:multiline-if-else" />
+        <error line="210" column="38" source="standard:multiline-expression-wrapping" />
+        <error line="212" column="15" source="standard:if-else-wrapping" />
+        <error line="212" column="20" source="standard:if-else-bracing" />
+        <error line="212" column="20" source="standard:if-else-wrapping" />
+        <error line="212" column="20" source="standard:multiline-if-else" />
+        <error line="214" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="217" column="36" source="standard:multiline-expression-wrapping" />
+        <error line="234" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="272" column="20" source="standard:function-signature" />
+        <error line="272" column="39" source="standard:function-signature" />
+        <error line="272" column="51" source="standard:function-signature" />
+        <error line="274" column="20" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt">
         <error line="3" column="1" source="standard:import-ordering" />
@@ -2732,21 +2726,20 @@
         <error line="146" column="122" source="standard:argument-list-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt">
-        <error line="3" column="1" source="standard:import-ordering" />
-        <error line="92" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="119" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="195" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="208" column="32" source="standard:multiline-expression-wrapping" />
-        <error line="240" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="264" column="1" source="standard:blank-line-between-when-conditions" />
-        <error line="272" column="50" source="standard:multiline-expression-wrapping" />
-        <error line="283" column="42" source="standard:trailing-comma-on-call-site" />
-        <error line="293" column="41" source="standard:multiline-expression-wrapping" />
-        <error line="301" column="37" source="standard:multiline-expression-wrapping" />
-        <error line="314" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="466" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="478" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="511" column="34" source="standard:multiline-expression-wrapping" />
+        <error line="88" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="115" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="191" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="204" column="32" source="standard:multiline-expression-wrapping" />
+        <error line="236" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="260" column="1" source="standard:blank-line-between-when-conditions" />
+        <error line="268" column="50" source="standard:multiline-expression-wrapping" />
+        <error line="279" column="42" source="standard:trailing-comma-on-call-site" />
+        <error line="289" column="41" source="standard:multiline-expression-wrapping" />
+        <error line="297" column="37" source="standard:multiline-expression-wrapping" />
+        <error line="310" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="394" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="406" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="439" column="34" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt">
         <error line="3" column="1" source="standard:import-ordering" />


### PR DESCRIPTION
Fixes #523.

## The bug

`CapoSelector` in the Explorer predates the stepper added to the song editor in #522, and still had all three accessibility defects that PR fixed in the editor copy.

| | Before | After |
|---|---|---|
| Value change announced | no `liveRegion` — silence after every press | `LiveRegionMode.Polite` |
| Value announced as | a bare `"3"` | `"Capo 3"` / `"No capo"` |
| Value box | fixed `32.dp` | `widthIn(min = 40.dp)` |

The live region is the one that actually blocks use. TalkBack focus stays on the +/− button after activation, so nothing was spoken and the user had to swipe forward to the value and back for every single increment. It is worse at the boundaries: going to 0 or up to `lastFret` silently disables the focused button, so the control just stops responding with no explanation.

## The change

Rather than fix the same bug twice, the editor's working `CapoStepper` (and its `StepperGlyph` helper) moves to [`ui/CapoStepper.kt`](app/src/main/java/com/baijum/ukufretboard/ui/CapoStepper.kt) and both screens call it. `CapoSelector` had one caller, so the change is contained.

The fret ceiling is now a parameter, which is the one thing the two callers genuinely disagreed on: the Explorer passes the user's own `lastFret` setting, the editor keeps `MAX_CAPO_FRET = 12`. Each screen still supplies its own "Capo" label, since the two place it differently.

Net effect on the editor is nil — it keeps the same component it already had, now shared.

## Verification

- **8 instrumented tests** in `ExplorerCapoStepperTest`. I reintroduced all three defects (`Modifier.width(32.dp)`, no semantics) and confirmed **5 fail**: the live-region assertion, both content-description assertions, the width assertion, and the stepping test. The other 3 cover the enable/disable bounds, which the old code already got right — they are regression guards, not defect tests, and passing both ways is correct for them.
- Full instrumented suite: 47 tests, 0 failures — including the 7 `SheetEditorKeyCapoTest` cases that cover the editor's side of the shared component.
- `scripts/preflight.sh` (ktlint ratchet, shared KMP tests, Android unit tests, lint) and detekt pass.
- Verified on a Pixel_Tablet emulator. The value node now dumps as `text='3' content-desc='Capo 3'` and measures 80px = 40.dp at 2× density, against 64px before. Screenshotted both screens: the Explorer row still reads `Capo − 3 +` centred under the fretboard, and the editor's `Capo − 2 +` sits beside the Key field exactly as before, so wrapping the stepper in its own `Row` is layout-neutral.

## Two deliberate omissions

**No reformatting.** My first pass ran `ktlint -F` over both files, which reformatted them wholesale and turned a 40-line fix into a 460-line diff. I reverted that and redid the edits surgically. Worth knowing: `ktlint -F` on `ExplorerTab.kt` auto-corrects ~50 of its baselined violations, so that is easy cleanup available whenever you want it — but it belongs in its own commit, not buried in an accessibility fix where it would hide the real change.

**iOS untouched.** I checked `CapoControl` in `FretboardView.swift:296-327` before deciding. It already avoids two of the three defects — `frame(minWidth: 70)` and `"No capo"` / `"Fret 3"` via `.accessibilityValue`, so no clipping and no bare number. It plausibly shares the announcement gap, since VoiceOver focus also stays on the button after activation, but the SwiftUI remedy is different in kind (`.accessibilityAdjustableAction`, not a live region) and I have not tested it with VoiceOver actually running. Rather than guess at a fix for a platform I could not verify, I left it. Happy to file it if you want it tracked.

## Baseline

`ktlint-baseline.xml` is spliced per file, never regenerated wholesale: `ExplorerTab.kt` 54 → 48 entries and `SheetEditor.kt` 15 → 14, purely from the removed lines, with all 259 file blocks asserted intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
