### PR TITLE
Test: Cover the song details panel's wiring after the #501 extraction

### DIFF
--- a/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
@@ -1,0 +1,252 @@
+package com.baijum.ukufretboard
+
+import android.content.Context
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.baijum.ukufretboard.data.ChordSheet
+import com.baijum.ukufretboard.domain.UkuleleString
+import com.baijum.ukufretboard.ui.songbook.SheetViewer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression tests for the details panel's wiring (issue #501).
+ *
+ * #501 moved subtitle, key, capo, transpose, section shortcuts, tempo, statistics and
+ * the chord rail out of `SheetViewer` and into `SongDetailsPanel`, turning direct state
+ * mutation into callbacks — `transposeSemitones--` became `onTransposeChange(n - 1)`,
+ * and the section-scroll and metronome lambdas crossed a file boundary. Silently
+ * dropping one of those wires would leave a control that renders but does nothing, so
+ * each is exercised here through the real [SheetViewer].
+ *
+ * Run with: ./gradlew connectedAndroidTest
+ *   -Pandroid.testInstrumentationRunnerArguments.class=com.baijum.ukufretboard.SongDetailsPanelWiringTest
+ */
+class SongDetailsPanelWiringTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val highG =
+        listOf(
+            UkuleleString(name = "G", openPitchClass = 7),
+            UkuleleString(name = "C", openPitchClass = 0),
+            UkuleleString(name = "E", openPitchClass = 4),
+            UkuleleString(name = "A", openPitchClass = 9),
+        )
+
+    private var appliedTranspose: Int? = null
+    private var startedTempo: Int? = null
+
+    private fun context(): Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun str(
+        id: Int,
+        vararg args: Any,
+    ): String = context().getString(id, *args)
+
+    /** The panel starts collapsed if an earlier test left the flag set. */
+    private fun clearPersistedState() {
+        context()
+            .getSharedPreferences("songbook_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .remove("song_details_collapsed")
+            .commit()
+    }
+
+    @Before
+    fun resetState() {
+        clearPersistedState()
+        appliedTranspose = null
+        startedTempo = null
+    }
+
+    @After
+    fun restorePrefs() = clearPersistedState()
+
+    /** Carries a tempo directive, several sections, and a viewing history. */
+    private fun sheet(): ChordSheet =
+        ChordSheet(
+            title = "Heart of Gold",
+            artist = "Neil Young",
+            content =
+                "Tempo: 96 BPM\n" +
+                    "[Verse 1]\n" +
+                    "[Em]I wanna live [C]I wanna give\n" +
+                    // Padding so the chorus heading starts below the fold and the
+                    // section shortcut has somewhere to scroll to.
+                    "[G]filler line\n".repeat(40) +
+                    "[Chorus]\n" +
+                    "[Am]Keep me searching for a heart of gold",
+            key = "G",
+            viewCount = 4,
+            lastViewedAt = 1_755_000_000_000L,
+            totalViewTimeMs = 180_000L,
+        )
+
+    private fun renderViewer() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                SheetViewer(
+                    sheet = sheet(),
+                    allLabels = emptySet(),
+                    onBack = {},
+                    onEdit = {},
+                    onDelete = {},
+                    onDuplicate = {},
+                    onChordTapped = {},
+                    onPlayChord = {},
+                    onStartMetronome = { startedTempo = it },
+                    tuning = highG,
+                    leftHanded = false,
+                    onStrumPatternChange = {},
+                    onLabelsChange = {},
+                    onApplyTranspose = { appliedTranspose = it },
+                )
+            }
+        }
+    }
+
+    private fun tapAction(id: Int) = composeTestRule.onNodeWithContentDescription(str(id)).performClick()
+
+    private fun transposeUp() = tapAction(R.string.cd_transpose_up)
+
+    private fun transposeDown() = tapAction(R.string.cd_transpose_down)
+
+    @Test
+    fun transposingUpRewritesTheChords() {
+        renderViewer()
+
+        transposeUp()
+        transposeUp()
+
+        // Em + 2 = F#m. The name lands twice, once in the chord rail and once in the
+        // song, so this only asserts it is there; the key label is the precise half.
+        composeTestRule.onAllNodesWithText("F#m", substring = true).onFirst().assertExists()
+        composeTestRule.onNodeWithText(str(R.string.songbook_key_prefix) + "A").assertExists()
+    }
+
+    @Test
+    fun transposingDownRewritesTheChords() {
+        renderViewer()
+
+        transposeDown()
+
+        // Em - 1 spells flat, Ebm, while the key label spells sharp, F#. That split is
+        // the app's existing behaviour, not something this panel decides.
+        composeTestRule.onAllNodesWithText("Ebm", substring = true).onFirst().assertExists()
+        composeTestRule.onNodeWithText(str(R.string.songbook_key_prefix) + "F#").assertExists()
+    }
+
+    @Test
+    fun resetReturnsToTheOriginalKey() {
+        renderViewer()
+
+        transposeUp()
+        transposeUp()
+        composeTestRule.onNodeWithText(str(R.string.dialog_reset)).performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.songbook_key_prefix) + "G").assertExists()
+        // The reset control only exists while a transpose is previewed.
+        composeTestRule.onNodeWithText(str(R.string.dialog_reset)).assertDoesNotExist()
+    }
+
+    @Test
+    fun theCapoHintAppearsOnlyWhileTransposed() {
+        renderViewer()
+
+        composeTestRule.onNodeWithText("Capo", substring = true).assertDoesNotExist()
+
+        transposeUp()
+        transposeUp()
+
+        composeTestRule.onNodeWithText(str(R.string.songbook_capo_hint, 2)).assertExists()
+    }
+
+    /** The save button has to report the previewed amount, not zero or a stale value. */
+    @Test
+    fun savingInTheNewKeyReportsTheTransposedAmount() {
+        renderViewer()
+
+        transposeUp()
+        transposeUp()
+        transposeDown()
+        composeTestRule.onNodeWithText(str(R.string.songbook_save_in_key)).performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals("the previewed transpose should reach onApplyTranspose", 1, appliedTranspose)
+        }
+    }
+
+    @Test
+    fun theTempoDirectiveStartsTheMetronomeAtThatBpm() {
+        renderViewer()
+
+        // Matches twice: the tempo row, and the raw "Tempo: 96 BPM" line the song body
+        // still shows. The button below is unique.
+        composeTestRule.onAllNodesWithText(str(R.string.songbook_tempo_label, 96)).onFirst().assertExists()
+        composeTestRule.onNodeWithText(str(R.string.songbook_start_metronome)).performClick()
+
+        composeTestRule.runOnIdle {
+            assertEquals("the song's tempo should reach onStartMetronome", 96, startedTempo)
+        }
+    }
+
+    /**
+     * Tapping a section shortcut has to scroll the song to that section. The chip and
+     * the heading carry the same label, so they are told apart by the click action —
+     * only the chip has one.
+     */
+    @Test
+    fun aSectionShortcutScrollsTheSongToThatSection() {
+        renderViewer()
+
+        val chip = { composeTestRule.onNode(hasText("Chorus") and hasClickAction()) }
+        val heading = { composeTestRule.onNode(hasText("Chorus") and hasClickAction().not()) }
+
+        heading().assertIsNotDisplayed()
+
+        chip().performClick()
+        composeTestRule.waitForIdle()
+
+        heading().assertIsDisplayed()
+    }
+
+    @Test
+    fun theStatisticsRowShowsAViewingHistory() {
+        renderViewer()
+
+        val views =
+            context().resources.getQuantityString(R.plurals.stats_views, 4, 4)
+        composeTestRule.onNodeWithText(views).assertExists()
+        composeTestRule.onNodeWithText(str(R.string.stats_time_minutes, 3)).assertExists()
+    }
+
+    @Test
+    fun theChordRailRendersTheSongsChords() {
+        renderViewer()
+
+        // Matched on the diagram's own description, which the song text does not carry.
+        composeTestRule.onNodeWithContentDescription("Chord A C E A", substring = true).assertExists()
+    }
+
+    @Test
+    fun theKeyAndArtistSurviveTheExtraction() {
+        renderViewer()
+
+        composeTestRule.onNodeWithText("Neil Young").assertIsDisplayed()
+        composeTestRule.onNodeWithText(str(R.string.songbook_key_prefix) + "G").assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
@@ -20,7 +20,6 @@ import com.baijum.ukufretboard.ui.songbook.SheetViewer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -108,7 +107,12 @@ class SongDetailsPanelWiringTest {
      */
     private fun leanSheet(withTempo: Boolean): ChordSheet =
         ChordSheet(
-            title = "Heart of Gold",
+            // Deliberately short. At CI's 320dp width the toolbar's six icon buttons
+            // leave the title no room and it wraps one character per line: "Heart of
+            // Gold" measures 312dp tall, over half the 640dp viewport, which pushes the
+            // bottom of the panel off screen where a tap lands on nothing. That is #529,
+            // and a four-letter title steps around it without weakening anything here.
+            title = "Gold",
             content =
                 (if (withTempo) "Tempo: 96 BPM\n" else "") +
                     "[Em]I wanna live [C]I wanna give",
@@ -211,18 +215,7 @@ class SongDetailsPanelWiringTest {
         transposeUp()
         transposeUp()
         transposeDown()
-        // The save button is the last thing in the panel. On a viewport too short to
-        // hold the panel it is measured against maxHeight = 0 and a tap lands on
-        // nothing -- the layout problem in #529, not a fault in the wiring. CI's
-        // emulator is the 320x640dp default skin and hits exactly that, so state the
-        // requirement rather than assert something the screen cannot present.
-        val save = composeTestRule.onNodeWithText(str(R.string.songbook_save_in_key))
-        assumeTrue(
-            "needs a viewport tall enough to lay the save button out; see #529",
-            save.fetchSemanticsNode().size.height > 0,
-        )
-
-        save.performClick()
+        composeTestRule.onNodeWithText(str(R.string.songbook_save_in_key)).performClick()
 
         composeTestRule.runOnIdle {
             assertEquals("the previewed transpose should reach onApplyTranspose", 1, appliedTranspose)

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -18,6 +19,8 @@ import com.baijum.ukufretboard.domain.UkuleleString
 import com.baijum.ukufretboard.ui.songbook.SheetViewer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -96,11 +99,36 @@ class SongDetailsPanelWiringTest {
             totalViewTimeMs = 180_000L,
         )
 
-    private fun renderViewer() {
+    /**
+     * A song with nothing optional in it. CI's emulator is the default 320x640dp skin,
+     * and the details sit in a non-scrolling `Column`: with artist, key, statistics and
+     * section shortcuts all present, the controls at the bottom of the panel fall past
+     * the screen edge, where a tap lands on nothing. Tests that press one of those use
+     * this instead.
+     */
+    private fun leanSheet(withTempo: Boolean): ChordSheet =
+        ChordSheet(
+            title = "Heart of Gold",
+            content =
+                (if (withTempo) "Tempo: 96 BPM\n" else "") +
+                    "[Em]I wanna live [C]I wanna give",
+        )
+
+    /**
+     * The chord rail is off unless a test needs it. It is the tallest thing in the
+     * panel at roughly 150dp, and the viewer's details sit in a non-scrolling `Column`:
+     * on a 360x640dp screen the rail pushes the tempo row and the save button past the
+     * bottom edge, where a tap lands on nothing and the wiring under test never runs.
+     */
+    private fun renderViewer(
+        sheet: ChordSheet = sheet(),
+        showRail: Boolean = false,
+    ) {
         composeTestRule.setContent {
             MaterialTheme {
                 SheetViewer(
-                    sheet = sheet(),
+                    showChordDiagramRail = showRail,
+                    sheet = sheet,
                     allLabels = emptySet(),
                     onBack = {},
                     onEdit = {},
@@ -178,12 +206,23 @@ class SongDetailsPanelWiringTest {
     /** The save button has to report the previewed amount, not zero or a stale value. */
     @Test
     fun savingInTheNewKeyReportsTheTransposedAmount() {
-        renderViewer()
+        renderViewer(leanSheet(withTempo = false))
 
         transposeUp()
         transposeUp()
         transposeDown()
-        composeTestRule.onNodeWithText(str(R.string.songbook_save_in_key)).performClick()
+        // The save button is the last thing in the panel. On a viewport too short to
+        // hold the panel it is measured against maxHeight = 0 and a tap lands on
+        // nothing -- the layout problem in #529, not a fault in the wiring. CI's
+        // emulator is the 320x640dp default skin and hits exactly that, so state the
+        // requirement rather than assert something the screen cannot present.
+        val save = composeTestRule.onNodeWithText(str(R.string.songbook_save_in_key))
+        assumeTrue(
+            "needs a viewport tall enough to lay the save button out; see #529",
+            save.fetchSemanticsNode().size.height > 0,
+        )
+
+        save.performClick()
 
         composeTestRule.runOnIdle {
             assertEquals("the previewed transpose should reach onApplyTranspose", 1, appliedTranspose)
@@ -192,7 +231,7 @@ class SongDetailsPanelWiringTest {
 
     @Test
     fun theTempoDirectiveStartsTheMetronomeAtThatBpm() {
-        renderViewer()
+        renderViewer(leanSheet(withTempo = true))
 
         // Matches twice: the tempo row, and the raw "Tempo: 96 BPM" line the song body
         // still shows. The button below is unique.
@@ -216,12 +255,21 @@ class SongDetailsPanelWiringTest {
         val chip = { composeTestRule.onNode(hasText("Chorus") and hasClickAction()) }
         val heading = { composeTestRule.onNode(hasText("Chorus") and hasClickAction().not()) }
 
-        heading().assertIsNotDisplayed()
+        // "It scrolled up" rather than "it is now displayed": whether the heading ends
+        // up fully on screen depends on how much height the song area was left with,
+        // and that varies by device.
+        //
+        // positionInRoot, not boundsInRoot — the heading starts well below the fold and
+        // boundsInRoot is clipped, so it reads a flat 0 for anything off screen and both
+        // measurements would compare equal no matter what the shortcut did.
+        val before = heading().fetchSemanticsNode().positionInRoot.y
+        assertTrue("the heading should start below the fold, was at $before", before > 0f)
 
         chip().performClick()
         composeTestRule.waitForIdle()
 
-        heading().assertIsDisplayed()
+        val after = heading().fetchSemanticsNode().positionInRoot.y
+        assertTrue("the shortcut should scroll the song, but the heading stayed at $after", after < before)
     }
 
     @Test
@@ -236,10 +284,15 @@ class SongDetailsPanelWiringTest {
 
     @Test
     fun theChordRailRendersTheSongsChords() {
-        renderViewer()
+        renderViewer(showRail = true)
 
-        // Matched on the diagram's own description, which the song text does not carry.
-        composeTestRule.onNodeWithContentDescription("Chord A C E A", substring = true).assertExists()
+        // Matched on the diagram's own description, which the song text does not carry,
+        // and on whichever diagram comes first: the rail is a LazyRow, so on a narrow
+        // screen the later chords are never composed.
+        composeTestRule
+            .onAllNodesWithContentDescription("Chord ", substring = true)
+            .onFirst()
+            .assertExists()
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #528. Test-only — no production code changes.

## Why

#528 moved subtitle, key, capo, transpose, section shortcuts, tempo, statistics and the chord rail out of `SheetViewer` into `SongDetailsPanel`. That turned direct state mutation into callbacks:

```kotlin
// before, inside SheetViewer
onClick = { transposeSemitones-- }

// after, inside SongDetailsPanel
onClick = { onTransposeChange(transposeSemitones - 1) }
```

and it pushed the section-scroll and metronome lambdas across a file boundary. Each of those is a wire that could be dropped silently, leaving a control that still renders and still responds to taps but does nothing.

None of them were covered. The tests in #528 exercised collapsing and expanding, which is the feature, not the refactor underneath it. `codecov/patch` said as much — 70.8% against a 75% floor — and the panel's transpose, tempo, statistics and section paths were the bulk of the uncovered lines.

## What

Ten tests driving the real `SheetViewer`:

| Test | Wire |
|---|---|
| `transposingUpRewritesTheChords` | `onTransposeChange` up |
| `transposingDownRewritesTheChords` | `onTransposeChange` down |
| `resetReturnsToTheOriginalKey` | reset path |
| `theCapoHintAppearsOnlyWhileTransposed` | conditional row |
| `savingInTheNewKeyReportsTheTransposedAmount` | `onApplyTranspose` payload |
| `theTempoDirectiveStartsTheMetronomeAtThatBpm` | `onStartMetronome` payload |
| `aSectionShortcutScrollsTheSongToThatSection` | section-scroll lambda |
| `theStatisticsRowShowsAViewingHistory` | render |
| `theChordRailRendersTheSongsChords` | render |
| `theKeyAndArtistSurviveTheExtraction` | render |

The payload tests matter most: `savingInTheNewKeyReportsTheTransposedAmount` transposes +1, +1, −1 and asserts `onApplyTranspose` receives **1**, so a callback wired to a stale or zeroed value fails rather than passing on a lucky match.

## Verified to discriminate

Cutting three wires — `onTransposeChange`, `onStartMetronome`, and the section-scroll lambda — makes **7 of the 10 fail**:

```
aSectionShortcutScrollsTheSongToThatSection   FAILED
resetReturnsToTheOriginalKey                  FAILED
theTempoDirectiveStartsTheMetronomeAtThatBpm  FAILED
theCapoHintAppearsOnlyWhileTransposed         FAILED
transposingDownRewritesTheChords              FAILED
transposingUpRewritesTheChords                FAILED
savingInTheNewKeyReportsTheTransposedAmount   FAILED
```

The three survivors are the static render checks, which are not wiring tests and are labelled as such.

## Two assumptions the app corrected

Worth recording, because both would have made a plausible-looking test that asserted the wrong thing:

- **Transposing down spells flats.** `Em − 1` renders as `Ebm`, not `D#m` — while the key label spells sharps, `G − 1` → `F#`. I had written `D#m` and the test failed; a semantics dump showed the real output. That sharp/flat split predates #501 and the test comments say so rather than pinning it as intended behaviour.
- **The tempo directive is rendered twice.** `Tempo: 96 BPM` is parsed into the tempo row *and* left in the song body, so `onNodeWithText` matches two nodes. Same for chord names, which appear in both the rail and the song. Those selectors now say explicitly which match they mean instead of assuming uniqueness.

## Checks

- 10/10 pass against merged `main` (`760e07b`); full instrumented suite 66/66.
- ktlint and detekt clean; no baseline entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive regression coverage for song details controls.
  - Verified transpose, reset, capo hints, and saving changes in key.
  - Confirmed tempo controls start the metronome at the correct BPM.
  - Verified section shortcuts scroll correctly, while statistics, chord diagrams, key, and artist details remain visible and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->