### PR TITLE
Fix: Point Codecov at the real instrumented coverage report

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -105,6 +105,11 @@ jobs:
           name: shared-coverage-report
           path: shared/build/reports/kover/report.xml
 
+      # Fails loudly if the report moves. Without this the Codecov CLI just
+      # warns and scans the workspace, so a stale path uploads by accident (#524).
+      - name: Check the coverage report is where Codecov is told to look
+        run: ls -l shared/build/reports/kover/report.xml
+
       - name: Upload shared coverage to Codecov
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -141,6 +146,11 @@ jobs:
         with:
           name: test-report
           path: app/build/reports/tests/testDebugUnitTest/
+
+      # Fails loudly if the report moves. Without this the Codecov CLI just
+      # warns and scans the workspace, so a stale path uploads by accident (#524).
+      - name: Check the coverage report is where Codecov is told to look
+        run: ls -l app/build/reports/coverage/test/debug/report.xml
 
       - name: Upload coverage to Codecov
         if: always()
@@ -293,11 +303,16 @@ jobs:
           name: instrumented-test-report-api${{ matrix.api-level }}
           path: app/build/reports/androidTests/connected/
 
+      # Fails loudly if the report moves. Without this the Codecov CLI just
+      # warns and scans the workspace, so a stale path uploads by accident (#524).
+      - name: Check the coverage report is where Codecov is told to look
+        run: ls -l app/build/reports/coverage/androidTest/debug/connected/report.xml
+
       - name: Upload instrumented test coverage to Codecov
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: app/build/reports/coverage/androidTest/debug/report.xml
+          files: app/build/reports/coverage/androidTest/debug/connected/report.xml
           flags: android-instrumented-tests
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Closes #524.

## The bug

`android.yml` told Codecov to upload `app/build/reports/coverage/androidTest/debug/report.xml`. AGP writes `.../androidTest/debug/**connected**/report.xml`.

The upload succeeded regardless — the CLI warned, then scanned the workspace and found the real report — so the `android-instrumented-tests` flag has been populated by accident. Confirmed on the most recent `main` run ([32280827648](https://github.com/baijum/ukulele-companion/actions/runs/32280827648)), in both matrix jobs:

```
warning -- Some files were not found --- {"not_found_files": ["app/build/reports/coverage/androidTest/debug/report.xml"]}
info    -- Found 1 coverage files to report
info    -- > .../app/build/reports/coverage/androidTest/debug/connected/report.xml
```

The shared and unit uploads in the same run named their paths correctly (no warning, file found directly), so this was the only wrong one.

## The fix

One line for the path. Plus a guard before each of the three Android coverage uploads:

```yaml
- name: Check the coverage report is where Codecov is told to look
  run: ls -l app/build/reports/coverage/androidTest/debug/connected/report.xml
```

`ls -l` prints a self-explaining error and a non-zero exit when the file is gone, and the file's size when it is there — so a zero-byte report is visible too. Verified it discriminates against a stale local build tree: exit 0 on the corrected path, exit 1 with `No such file or directory` on the old one. Had this existed, #524 would have been a red build rather than a silent accident.

The guards carry the default `success()` condition, so a run whose tests already failed skips them rather than collecting a second, misleading failure. The uploads keep `if: always()`.

## On `fail_ci_if_error`

The issue floated it as a judgement call. Not adding it: the guard already fails on the case worth failing on — a missing or misplaced report — without coupling every build to Codecov's availability.

## Deliberately untouched

`ios.yml` writes `coverage.xml` to the repo root and uploads `coverage.xml`; that path is right and out of scope here. Worth a separate look, though: `xcresultparser ... > coverage.xml` creates the file even when the parser fails, so an empty report could upload cleanly. Same silent-failure shape, different mechanism.

## Verification

The instrumented job cannot be exercised locally without an emulator, so the evidence is the CI log above plus the local build tree, which contains only the `connected/` report. The real check is this PR's own `android-instrumented-tests` upload — it should now report the file found with no `not_found_files` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)