### PR TITLE
Fix: Upload only the iOS report we generate, not 12 the CLI invents

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -139,10 +139,21 @@ jobs:
         if: always()
         run: xcresultparser --output-format cobertura TestResults.xcresult > coverage.xml
 
+      # Fails loudly if the report moves. Without this the Codecov CLI just
+      # warns and scans the workspace, so a stale path uploads by accident (#524).
+      - name: Check the coverage report is where Codecov is told to look
+        run: ls -l coverage.xml
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
+          # `files` only *adds* to what the CLI finds by itself. Without these two,
+          # the Xcode plugin runs llvm-cov and the workspace scan sweeps up a
+          # .coverage.txt per binary -- XCTest, onnxruntime and a second reading of
+          # our own sources all landed under ios-tests, 13 files for one named (#532).
+          disable_search: true
+          plugins: noop
           flags: ios-tests
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ iosApp/Frameworks/
 *.xcuserdata
 xcuserdata/
 /screenshots/
+
+# iOS coverage artifacts, written to the repo root by the Codecov CLI
+/coverage.xml
+/*.coverage.txt
+/TestResults.xcresult/


### PR DESCRIPTION
Closes #532.

## The bug

`ios.yml` named one file and uploaded thirteen. This is not a quirk — it is documented behaviour of the `files` input, quoted from the action's own `action.yml` at the pinned SHA:

> Comma-separated list of explicit files to upload. **These will be added to the coverage files found for upload.** If you wish to only upload the specified files, please consider using `disable_search` to disable uploading other files.

So the CLI ran its Xcode plugin, shelled out to `llvm-cov`, wrote a `.coverage.txt` per binary into the repo root, then scanned the workspace and sent the lot under `ios-tests`. From run [32275855964](https://github.com/baijum/ukulele-companion/actions/runs/32275855964):

```
info -- Found 13 coverage files to report
info -- > .../XCTest.framework.coverage.txt
info -- > .../onnxruntime.framework.coverage.txt
info -- > .../UkuleleCompanion.app.coverage.txt
info -- > .../coverage.xml
... (9 more)
```

Most strays are third-party or test-bundle code that the flag's `paths: [iosApp/UkuleleCompanion/]` filter should discard. `UkuleleCompanion.app.coverage.txt` is the one that matters: llvm-cov measuring exactly the app sources xcresultparser had already measured, both inside the same upload, under the same flag.

## The fix

```yaml
files: coverage.xml
disable_search: true
plugins: noop
```

`disable_search` makes the named file authoritative. `plugins: noop` stops the `llvm-cov` pass running at all, so the strays are never generated rather than generated and then ignored.

Both input names were the open question in the issue. Verified present on the exact pinned SHA `fb8b358` rather than on `main` of the action:

```
gh api "repos/codecov/codecov-action/contents/action.yml?ref=fb8b3582c8e4def4969c97caa2f19720cb33a72f"
```

→ `disable_search` (default `'false'`), `plugins` (`Specify 'noop' to turn off all plugins`). Both present.

## Also here

**The `ls -l` guard**, matching `android.yml` since #531. Neither switch above makes a *missing* report loud — with search disabled the CLI simply finds nothing and still exits 0 — and until now the twelve strays were enough to keep the upload looking healthy even if `coverage.xml` disappeared. The guard carries the default `success()` condition, so a run whose tests already failed skips it rather than collecting a second, misleading failure.

**`.gitignore` entries.** `coverage.xml` and `*.coverage.txt` were untracked but not ignored, so anyone running the conversion step or the CLI locally left a dozen files sitting in `git status`. Root-anchored, so only the paths CI actually writes.

## What to watch on this run

The iOS path filter includes `.github/workflows/ios.yml`, so `Build & Test` runs on this PR and the change is verifiable here rather than after merge. The upload should log `Found 1 coverage files to report` with no plugin output above it.

One thing genuinely worth checking rather than assuming: **if the `ios-tests` number moves**, that means Codecov was crediting llvm-cov's reading of the app sources, not just xcresultparser's, and the two disagree. I'll report the flag delta from the Codecov comment either way — a drop here would be a real finding about which report has been carrying that flag, not a regression introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)