### PR TITLE
Add: A stably-named Android CI gate for required status checks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -327,3 +327,36 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+
+  android-gate:
+    name: Android CI Complete
+    # A single, stably-named check for the ruleset to require.
+    #
+    # The instrumented job is a matrix, so GitHub reports it as "Instrumented
+    # Tests (33)" and "Instrumented Tests (35)" when it runs -- but as a bare,
+    # unexpanded "Instrumented Tests" when the path filter skips it. Requiring
+    # the expanded names therefore left every PR that touches no Android path
+    # (iOS-only, docs-only) waiting forever on two checks that were never going
+    # to be reported. This job has no `if:`, so its name is reported either way.
+    needs: [changes, lint, shared-tests, unit-tests, build, instrumented-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check every Android job succeeded or was skipped
+        env:
+          # success | skipped | failure | cancelled, one per job in `needs`.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "upstream results: $RESULTS"
+          # A gate that can pass on an empty list is worse than no gate.
+          if [ -z "$RESULTS" ]; then
+            echo "::error::no upstream results -- refusing to pass vacuously"
+            exit 1
+          fi
+          for result in $RESULTS; do
+            case "$result" in
+              success | skipped) ;;
+              *) echo "::error::an upstream Android job reported '$result'" ; exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
Workflow half of the fix for PRs that hang on checks which will never report. **The ruleset change is a separate, manual step — see below.**

## The problem

The `main` ruleset requires seven contexts, two of which are matrix-expanded:

```
Lint · Unit Tests · Build · Build & Test · Shared Module Tests
Instrumented Tests (33) · Instrumented Tests (35)
```

GitHub appends matrix values to a job's name only when the job actually runs. When `if: needs.changes.outputs.android == 'true'` skips it, the matrix is not expanded and one check is reported, named plainly `Instrumented Tests`. So on any PR that touches no Android path, the two required names are never reported at all and sit at "Expected — waiting for status to be reported" indefinitely.

Both shapes, on two open PRs:

| PR | Touches `android.yml`? | Instrumented contexts reported |
|---|---|---|
| #531 | yes | `Instrumented Tests (33)`, `Instrumented Tests (35)` |
| #533 | no | `Instrumented Tests` (skipped) |

#533 is `mergeStateStatus: BLOCKED` right now with every check that ran passing. The other four Android contexts are fine — they report as `skipped`, which rulesets count as satisfied. It is only the matrix pair that vanishes.

This bites iOS-only, docs-only and tooling-only PRs. It has been invisible so far because the repo role bypass lets an admin merge through it.

## This PR

One job, no `if:`, so its context exists whether the Android suite runs, skips, or expands a matrix:

```yaml
android-gate:
  name: Android CI Complete
  needs: [changes, lint, shared-tests, unit-tests, build, instrumented-tests]
  if: always()
```

It passes when every upstream job reported `success` or `skipped`, and fails on anything else — so a skipped suite is green, a failed one is not. It also refuses to pass on an empty result list, because a gate that can pass vacuously is worse than no gate.

Logic checked against every combination before pushing:

| upstream results | gate |
|---|---|
| all `success` | pass |
| all `skipped` (path filter) | pass |
| any `failure` | **fail** |
| any `cancelled` | **fail** |
| empty | **fail** |

`needs` covers exactly the five Android jobs the ruleset requires today, so the swap preserves what blocks a merge. `release-build` is deliberately excluded: it does not gate today, and changing what blocks merges at the same time as changing how results are reported would make any regression hard to attribute. Adding it later is a one-word change.

## What this PR does *not* do

The ruleset still requires the old seven contexts. Until someone with repo admin swaps them, `Android CI Complete` is an extra, non-blocking check and #533 stays blocked. The follow-up is to replace these five required contexts:

```
Lint · Unit Tests · Build · Shared Module Tests
Instrumented Tests (33) · Instrumented Tests (35)
```

with one:

```
Android CI Complete
```

leaving `Build & Test` (iOS) as-is — it has no matrix, so it always reports a stable name.

## Verification

This PR edits `android.yml`, which is inside the Android path filter, so its own run exercises the **all-success** path only. The skipped path — the one that actually matters — cannot be exercised from a PR that touches Android files. The clean way to prove it is to rebase #533 onto `main` once this lands: that re-runs its CI with the gate present and the Android suite skipped, and `Android CI Complete` should report green rather than not at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a stable Android CI completion check.
  - The check reports success only when all required Android validation jobs complete successfully or are appropriately skipped.
  - Detects and reports failed, cancelled, or missing job results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->