### PR TITLE
Fix: Stop rebuilding AVAudioEngine on every SwiftUI re-render

### DIFF
--- a/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
+++ b/iosApp/UkuleleCompanion/Audio/TonePlayer.swift
@@ -4,7 +4,7 @@ import AVFoundation
 ///
 /// Supports polyphonic playback via a pool of `AVAudioPlayerNode` instances,
 /// allowing strummed chords where multiple notes overlap with configurable delay.
-final class TonePlayer {
+final class TonePlayer: ObservableObject {
     private var audioEngine: AVAudioEngine?
     private var playerNodes: [AVAudioPlayerNode] = []
     private var varispeedNodes: [AVAudioUnitVarispeed] = []

--- a/iosApp/UkuleleCompanion/Views/ChordEarTrainingView.swift
+++ b/iosApp/UkuleleCompanion/Views/ChordEarTrainingView.swift
@@ -10,7 +10,7 @@ struct ChordEarTrainingView: View {
     @State private var score = 0
     @State private var total = 0
 
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
     private static let sampleNames = [
         "uke_a", "uke_asharp", "uke_b", "uke_c", "uke_csharp",
         "uke_d", "uke_dsharp", "uke_e", "uke_f", "uke_fsharp",

--- a/iosApp/UkuleleCompanion/Views/FavoritesView.swift
+++ b/iosApp/UkuleleCompanion/Views/FavoritesView.swift
@@ -10,7 +10,7 @@ struct FavoritesView: View {
     @State private var managingVoicing: FavoriteVoicingData?
     @State private var isReordering = false
     @State private var shareInfo: ShareChordInfo?
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
 
     var body: some View {
         Group {

--- a/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
@@ -9,7 +9,7 @@ struct FretboardNoteMapView: View {
 
     private let fretCount = 12
     private var cellSize: CGFloat { sizeClass == .regular ? 52 : 36 }
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
 
     private var effectiveTuning: UkuleleTuning {
         if isLowG { return .lowG }

--- a/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
+++ b/iosApp/UkuleleCompanion/Views/IntervalTrainerView.swift
@@ -14,7 +14,7 @@ struct IntervalTrainerView: View {
     @State private var bestStreak = 0
     @State private var isAudioMode = true
 
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
 
     var body: some View {
         ScrollView {

--- a/iosApp/UkuleleCompanion/Views/ProgressionPracticeView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionPracticeView.swift
@@ -14,7 +14,7 @@ struct ProgressionPracticeView: View {
     @State private var isPlaying = false
     @State private var timer: AnyCancellable?
 
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
     private let leftHanded: Bool
     private let tuning: [shared.UkuleleString]
     private let cachedVoicings: [[ChordVoicing]]

--- a/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionsView.swift
@@ -3,7 +3,7 @@ import shared
 
 struct ProgressionsView: View {
     @StateObject private var viewModel = ProgressionsViewModel()
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
     @State private var playbackState = ProgressionPlaybackState()
     @State private var deletingCustomId: String?
     @State private var deletingCustomName: String?

--- a/iosApp/UkuleleCompanion/Views/SongViewerView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongViewerView.swift
@@ -37,7 +37,7 @@ struct SongViewerView: View {
     @State private var viewOpenedAt: Date?
     @State private var showPerformanceMode = false
 
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
 
     let song: StoredSong
 

--- a/iosApp/UkuleleCompanion/Views/VoiceLeadingView.swift
+++ b/iosApp/UkuleleCompanion/Views/VoiceLeadingView.swift
@@ -8,7 +8,7 @@ struct VoiceLeadingView: View {
     @State private var currentStep = 0
     @State private var path: VoiceLeading.Path?
 
-    private let tonePlayer = TonePlayer()
+    @StateObject private var tonePlayer = TonePlayer()
     private let leftHanded: Bool
     private let tuning: [shared.UkuleleString]
 


### PR DESCRIPTION
## Summary

- Made `TonePlayer` conform to `ObservableObject` so it can be used with `@StateObject`
- Changed all 8 View structs from `private let tonePlayer = TonePlayer()` to `@StateObject private var tonePlayer = TonePlayer()`, ensuring SwiftUI creates the instance once per view lifetime instead of on every parent re-render
- Prevents repeated `AVAudioEngine` construction/teardown (16 node attachments + `engine.start()` per init), playback cutoffs from `deinit { audioEngine?.stop() }`, and thrown-away WAV decode caches

Closes #526

## Test plan

- [ ] iOS build succeeds (verified locally)
- [ ] Play a chord in SongViewerView — confirm sound plays without cutoff
- [ ] Navigate between views that use TonePlayer — confirm no audio glitches
- [ ] Trigger parent re-renders (e.g. toggle settings) while a note is playing — confirm it continues ringing

🤖 Generated with [Claude Code](https://claude.com/claude-code)