### PR TITLE
Fix: Replace deprecated SKStoreReviewController with the SwiftUI action

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/ReviewPromptManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/ReviewPromptManager.swift
@@ -1,6 +1,4 @@
 import Foundation
-import StoreKit
-import UIKit
 
 /// Manages in-app review prompt state and eligibility.
 ///
@@ -11,6 +9,10 @@ import UIKit
 /// There is deliberately no "user said no" state: Apple forbids preceding the
 /// sheet with a custom opinion prompt, so the app never learns whether the user
 /// reviewed or declined. Attempts are capped instead.
+///
+/// This type owns eligibility and state only. Requesting the sheet itself is the
+/// view's job, via SwiftUI's `\.requestReview` environment action, which targets
+/// the scene the view actually lives in.
 @MainActor
 final class ReviewPromptManager {
 
@@ -97,18 +99,6 @@ final class ReviewPromptManager {
         }
 
         return true
-    }
-
-    // MARK: - Native review API
-
-    /// Requests the App Store review dialog via SKStoreReviewController.
-    func requestReview() {
-        if let windowScene = UIApplication.shared
-            .connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first {
-            SKStoreReviewController.requestReview(in: windowScene)
-        }
     }
 
     // MARK: - Private

--- a/iosApp/UkuleleCompanion/Views/AchievementsView.swift
+++ b/iosApp/UkuleleCompanion/Views/AchievementsView.swift
@@ -1,3 +1,4 @@
+import StoreKit
 import SwiftUI
 import shared
 
@@ -72,6 +73,7 @@ private nonisolated(unsafe) let allAchievements: [AchievementDisplayInfo] = [
 
 struct AchievementsView: View {
     @EnvironmentObject var learnVM: LearnViewModel
+    @Environment(\.requestReview) private var requestReview
 
     var body: some View {
         let _ = learnVM.stateVersion
@@ -202,7 +204,7 @@ struct AchievementsView: View {
         // whether the sheet is actually shown.
         if unlockedAny, ReviewPromptManager.shared.isEligible() {
             ReviewPromptManager.shared.recordPromptShown()
-            ReviewPromptManager.shared.requestReview()
+            requestReview()
         }
     }
 }


### PR DESCRIPTION
Fixes #539.

`SKStoreReviewController.requestReview(in:)` is deprecated as of iOS 18. The deployment target is **iOS 16.0**, and both replacements are available from 16.0, so no availability check is needed:

```
StoreKit.swiftinterface:1830   @available(iOS 16.0, macCatalyst 16.0, visionOS 1.0, *)
                        1834   public static func requestReview(in scene: UIWindowScene)

_StoreKit_SwiftUI.swiftinterface:510  @available(iOS 16.0, macCatalyst 16.0, visionOS 1.0, macOS 13.0, *)
                                 513  public struct RequestReviewAction
```

## Why the environment action rather than `AppStore.requestReview(in:)`

Both clear the deprecation. The SwiftUI action additionally removes the manual scene lookup the old code needed:

```swift
UIApplication.shared.connectedScenes
    .compactMap { $0 as? UIWindowScene }
    .first
```

Taking `.first` of `connectedScenes` picks an arbitrary scene. On iPad — where this app supports a sidebar/split layout — that can be a background or wrong-window scene rather than the one the user is looking at. `@Environment(\.requestReview)` targets the scene the view actually lives in, so it is correct by construction.

## Change

- `AchievementsView` declares `@Environment(\.requestReview) private var requestReview` and calls it once the eligibility gates pass
- `ReviewPromptManager` drops its `requestReview()` wrapper and no longer imports `StoreKit` or `UIKit` — it now owns eligibility and state only

The trigger point is unchanged from #545: requested directly after an achievement unlock, with no app UI in front of it and no button tap driving it.

## Verification

| Check | Result |
|---|---|
| `xcodebuild ... clean build` (iPhone 17 Pro sim) | BUILD SUCCEEDED |
| Deprecation warnings in clean build output | none |
| `grep -rn SKStoreReviewController iosApp/` | no matches |

Availability was confirmed against the iOS 26.4 SDK `.swiftinterface` files rather than from memory.

**Android is untouched** — this is Swift-only, 2 files, +7/−15.

**No tests added.** There is still no coverage for the review prompt on either platform; that remains #540, which also covers extracting the duplicated eligibility logic into `:shared`. Expect `codecov/patch` to flag this diff for the same reason it flagged #545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the in-app review request flow to use the system-supported SwiftUI review prompt.
  - Review prompts now appear from the achievements experience after newly earned achievements meet eligibility requirements.
  - Simplified review eligibility and state management for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->