### PR TITLE
Refactor: Move instrumented tests to the v2 compose test rule

### DIFF
--- a/app/src/androidTest/java/com/baijum/ukufretboard/AccessibilityTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/AccessibilityTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.printToLog

--- a/app/src/androidTest/java/com/baijum/ukufretboard/AchievementWatcherTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/AchievementWatcherTest.kt
@@ -2,7 +2,7 @@ package com.baijum.ukufretboard
 
 import android.app.Application
 import android.content.Context
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.baijum.ukufretboard.domain.AchievementDef
 import com.baijum.ukufretboard.ui.navigation.AchievementWatcher

--- a/app/src/androidTest/java/com/baijum/ukufretboard/AutoScrollTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/AutoScrollTest.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp

--- a/app/src/androidTest/java/com/baijum/ukufretboard/ExplorerCapoStepperTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/ExplorerCapoStepperTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertWidthIsAtLeast
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp

--- a/app/src/androidTest/java/com/baijum/ukufretboard/PerformanceModeRenderingTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/PerformanceModeRenderingTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorKeyCapoTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorKeyCapoTest.kt
@@ -1,7 +1,7 @@
 package com.baijum.ukufretboard
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerCollapsibleDetailsTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerCollapsibleDetailsTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerKeyDisplayTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerKeyDisplayTest.kt
@@ -1,7 +1,7 @@
 package com.baijum.ukufretboard
 
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerPerformanceModeTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetViewerPerformanceModeTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.click
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SongDetailsPanelWiringTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SongbookTabSaveWiringTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SongbookTabSaveWiringTest.kt
@@ -2,7 +2,7 @@ package com.baijum.ukufretboard
 
 import android.app.Application
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance

--- a/app/src/androidTest/java/com/baijum/ukufretboard/TunerSpokenFeedbackTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/TunerSpokenFeedbackTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import com.baijum.ukufretboard.data.TunerSettings
 import org.junit.Rule


### PR DESCRIPTION
## Why

`androidx.compose.ui.test.junit4.createComposeRule` is deprecated and warns on every CI build — once per test class, so 12 warnings per run.

## What

The import, in all 12 instrumented test classes:

```diff
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
```

Nothing else. v2 returns the same `ComposeContentTestRule`, so call sites and `mainClock` usage are unchanged.

This isn't a safe find-and-replace in general: v2 swaps `UnconfinedTestDispatcher` for `StandardTestDispatcher`, which queues tasks rather than running them immediately, and tests relying on immediate execution can need extra synchronization. Here the existing `waitForIdle()` / `runOnIdle()` calls already covered it, so no test bodies needed changing.

## Verification

| Run | Tablet (1280x800dp) | CI AVD size (320x640dp) |
|---|---|---|
| Before | 71/71 | 71/71 |
| After | 71/71 | 71/71 |

Both sizes were checked because [CI's AVD is 320x640dp](https://github.com/baijum/ukulele-companion/blob/main/docs/known-failures.md) and tests that pass on a tablet can fail there. All 12 deprecation warnings reproduced on the baseline; a forced recompile after the change emits **0**.

### Do the tests still discriminate?

A green suite alone proves little here — the specific hazard of `StandardTestDispatcher` is effect-driven assertions passing *vacuously* when queued work never runs. So the four most async-sensitive assertions were inverted, and each still fails:

| Test | Negated assertion | Result |
|---|---|---|
| `AchievementWatcherTest` | the `LaunchedEffect` watcher reports nothing | failed |
| `AutoScrollTest` | the `mainClock`-advanced scroll didn't move | failed |
| `SongDetailsPanelWiringTest` | the section shortcut didn't scroll | failed |
| `SongbookTabSaveWiringTest` | the old key survived | failed, `expected:<G> but was:<D>` |

That last one is the clearest signal that the StateFlow save genuinely propagates under the new dispatcher. Probes were reverted before committing.

## Note for the reviewer

`scripts/ktlint.sh` already exits 1 on `main` — confirmed by stashing these changes and re-running against a clean tree. The violation set is byte-identical before and after this change, so nothing here adds to it, but the local ratchet looks out of sync with `ktlint-baseline.xml` independently of this work and is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Android UI tests to use the latest Compose testing rule implementation.
  * Test coverage and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->