### PR TITLE
Fix: Drop the redundant per-section active-day recording

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/ReviewPromptRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/ReviewPromptRepository.kt
@@ -32,6 +32,9 @@ class ReviewPromptRepository(
 
     /**
      * Records today as an active usage day.
+     *
+     * Called once per launch from the root screen, unconditionally: "active"
+     * means the app was opened, not that any particular section was used.
      * Idempotent per calendar day, and stops writing once the gate is satisfied
      * so the stored set cannot grow without bound.
      */

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
@@ -181,6 +181,9 @@ fun FretboardScreen(
     val reviewPromptRepository = remember { ReviewPromptRepository(context) }
     LaunchedEffect(Unit) {
         reviewPromptRepository.initFirstLaunch()
+        // Unconditional: an active day means "the app was opened today", not
+        // "a particular section was visited". Do not re-add a per-section call
+        // here — it would be dead code, since this already banked the day.
         reviewPromptRepository.recordActiveDay()
     }
 
@@ -641,9 +644,6 @@ fun FretboardScreen(
     val drawerItemOnClick: (NavSection) -> Unit = { section ->
         previousSection = null
         selectedSection = section
-        if (section in PLAY_CREATE_SECTIONS) {
-            reviewPromptRepository.recordActiveDay()
-        }
         if (!isTabletWidth) scope.launch { drawerState.close() }
     }
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/NavigationConstants.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/NavigationConstants.kt
@@ -22,12 +22,6 @@ import com.baijum.ukufretboard.data.NavSection
 import com.baijum.ukufretboard.domain.ChordNameParser
 import com.baijum.ukufretboard.viewmodel.ChordLibraryViewModel
 
-internal val PLAY_CREATE_SECTIONS = setOf(
-    NavSection.EXPLORER, NavSection.TUNER, NavSection.PITCH_MONITOR, NavSection.METRONOME,
-    NavSection.LIBRARY, NavSection.FAVORITES, NavSection.SONGWRITER_MODE, NavSection.SONGBOOK,
-    NavSection.MELODY_NOTEPAD, NavSection.PATTERNS, NavSection.PROGRESSIONS,
-)
-
 internal data class DrawerItem(
     val section: NavSection,
     val label: String,

--- a/iosApp/UkuleleCompanion/ContentView.swift
+++ b/iosApp/UkuleleCompanion/ContentView.swift
@@ -9,16 +9,6 @@ enum SidebarDestination: String, Hashable {
     case theoryLessons, theoryQuiz
     case learningProgress, achievements
     case glossary, capoGuide, fretboardNoteMap, chordSubstitutions, scaleChords, circleOfFifths
-
-    var isPlayOrCreate: Bool {
-        switch self {
-        case .explorer, .tuner, .pitchMonitor, .metronome, .chordLibrary, .favorites,
-             .songwriterMode, .progressions, .strumPatterns, .songbook, .setlists, .melodyNotepad:
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 struct ContentView: View {
@@ -134,12 +124,10 @@ struct ContentView: View {
         .onChange(of: showSettings) { isShowing in
             if !isShowing { settingsVM.load() }
         }
+        // Unconditional: an active day means "the app was opened today", not
+        // "a particular tab was visited". Do not re-add a per-tab call here —
+        // it would be dead code, since this already banked the day.
         .onAppear { ReviewPromptManager.shared.recordActiveDay() }
-        .onChange(of: selectedTab) { tab in
-            if tab == 0 || tab == 1 {
-                ReviewPromptManager.shared.recordActiveDay()
-            }
-        }
     }
 
     // MARK: - Sidebar layout (iPad landscape)
@@ -163,11 +151,6 @@ struct ContentView: View {
             if !isShowing { settingsVM.load() }
         }
         .onAppear { ReviewPromptManager.shared.recordActiveDay() }
-        .onChange(of: selectedDestination) { dest in
-            if dest?.isPlayOrCreate == true {
-                ReviewPromptManager.shared.recordActiveDay()
-            }
-        }
     }
 
     private var sidebarList: some View {

--- a/iosApp/UkuleleCompanion/Helpers/ReviewPromptManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/ReviewPromptManager.swift
@@ -39,9 +39,12 @@ final class ReviewPromptManager {
 
     // MARK: - Active day tracking
 
-    /// Records today as an active usage day. Idempotent per calendar day, and
-    /// stops writing once the gate is satisfied so the stored set cannot grow
-    /// without bound.
+    /// Records today as an active usage day.
+    ///
+    /// Called once per launch from the root view, unconditionally: "active"
+    /// means the app was opened, not that any particular tab was used.
+    /// Idempotent per calendar day, and stops writing once the gate is
+    /// satisfied so the stored set cannot grow without bound.
     func recordActiveDay() {
         var days = activeDays()
         guard ReviewPromptEligibility.shared.shouldRecordActiveDay(activeDayCount: Int32(clamping: days.count)) else { return }

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -2480,40 +2480,31 @@
         <error line="713" column="52" source="standard:argument-list-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/navigation/NavigationConstants.kt">
-        <error line="25" column="37" source="standard:multiline-expression-wrapping" />
-        <error line="26" column="26" source="standard:argument-list-wrapping" />
-        <error line="26" column="44" source="standard:argument-list-wrapping" />
-        <error line="26" column="70" source="standard:argument-list-wrapping" />
-        <error line="27" column="25" source="standard:argument-list-wrapping" />
-        <error line="27" column="47" source="standard:argument-list-wrapping" />
-        <error line="27" column="75" source="standard:argument-list-wrapping" />
-        <error line="28" column="32" source="standard:argument-list-wrapping" />
-        <error line="28" column="53" source="standard:argument-list-wrapping" />
-        <error line="49" column="54" source="standard:multiline-expression-wrapping" />
-        <error line="49" column="54" source="standard:function-signature" />
-        <error line="50" column="19" source="standard:wrapping" />
-        <error line="50" column="61" source="standard:wrapping" />
-        <error line="50" column="62" source="standard:multiline-expression-wrapping" />
-        <error line="57" column="5" source="standard:wrapping" />
-        <error line="58" column="19" source="standard:wrapping" />
-        <error line="58" column="63" source="standard:wrapping" />
-        <error line="58" column="64" source="standard:multiline-expression-wrapping" />
-        <error line="65" column="5" source="standard:wrapping" />
-        <error line="66" column="19" source="standard:wrapping" />
-        <error line="66" column="62" source="standard:wrapping" />
-        <error line="66" column="63" source="standard:multiline-expression-wrapping" />
-        <error line="79" column="5" source="standard:wrapping" />
-        <error line="80" column="19" source="standard:wrapping" />
-        <error line="80" column="66" source="standard:wrapping" />
-        <error line="80" column="67" source="standard:multiline-expression-wrapping" />
-        <error line="83" column="20" source="standard:argument-list-wrapping" />
-        <error line="83" column="43" source="standard:argument-list-wrapping" />
-        <error line="83" column="58" source="standard:argument-list-wrapping" />
-        <error line="83" column="90" source="standard:argument-list-wrapping" />
-        <error line="83" column="93" source="standard:argument-list-wrapping" />
-        <error line="83" column="121" source="standard:max-line-length" />
-        <error line="83" column="123" source="standard:argument-list-wrapping" />
-        <error line="87" column="5" source="standard:wrapping" />
+        <error line="43" column="54" source="standard:multiline-expression-wrapping" />
+        <error line="43" column="54" source="standard:function-signature" />
+        <error line="44" column="19" source="standard:wrapping" />
+        <error line="44" column="61" source="standard:wrapping" />
+        <error line="44" column="62" source="standard:multiline-expression-wrapping" />
+        <error line="51" column="5" source="standard:wrapping" />
+        <error line="52" column="19" source="standard:wrapping" />
+        <error line="52" column="63" source="standard:wrapping" />
+        <error line="52" column="64" source="standard:multiline-expression-wrapping" />
+        <error line="59" column="5" source="standard:wrapping" />
+        <error line="60" column="19" source="standard:wrapping" />
+        <error line="60" column="62" source="standard:wrapping" />
+        <error line="60" column="63" source="standard:multiline-expression-wrapping" />
+        <error line="73" column="5" source="standard:wrapping" />
+        <error line="74" column="19" source="standard:wrapping" />
+        <error line="74" column="66" source="standard:wrapping" />
+        <error line="74" column="67" source="standard:multiline-expression-wrapping" />
+        <error line="77" column="20" source="standard:argument-list-wrapping" />
+        <error line="77" column="43" source="standard:argument-list-wrapping" />
+        <error line="77" column="58" source="standard:argument-list-wrapping" />
+        <error line="77" column="90" source="standard:argument-list-wrapping" />
+        <error line="77" column="93" source="standard:argument-list-wrapping" />
+        <error line="77" column="121" source="standard:max-line-length" />
+        <error line="77" column="123" source="standard:argument-list-wrapping" />
+        <error line="81" column="5" source="standard:wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/patterns/CreateFingerpickingPatternSheet.kt">
         <error line="49" column="25" source="standard:function-signature" />


### PR DESCRIPTION
Fixes #541.

## What the issue found

`ReviewPromptRepository` (Android) and `ReviewPromptManager` (iOS) gate the store review request on 5 distinct "active days". Both platforms record an active day **unconditionally at launch**, before any section or tab has been chosen:

- `FretboardScreen.kt` — `recordActiveDay()` in a `LaunchedEffect(Unit)` at screen start
- `ContentView.swift` — `.onAppear { ReviewPromptManager.shared.recordActiveDay() }` on both the tab and sidebar layouts

So the later `PLAY_CREATE_SECTIONS` / `isPlayOrCreate` checks could never bank a day that was not already banked — they were dead for gating purposes, while reading as if Play/Create usage were the signal.

## What this does

Takes the first option the issue suggested: keep "app opened" as the signal (which is what the doc comments and `ReviewPromptEligibility` already say) and delete the redundant checks.

- **Android:** removed the `if (section in PLAY_CREATE_SECTIONS)` branch from `drawerItemOnClick`, and the now-unused `PLAY_CREATE_SECTIONS` constant from `NavigationConstants.kt`.
- **iOS:** removed the `.onChange(of: selectedTab)` and `.onChange(of: selectedDestination)` recording handlers, and the now-unused `SidebarDestination.isPlayOrCreate`.
- Commented the remaining launch-time call sites on both platforms, and extended the `recordActiveDay` doc comments, so the redundant checks do not get re-added.

No behavior change: the same day was already recorded a moment earlier on every path.

The doc comments the issue quoted had already been corrected to "distinct calendar days the app was opened" in the eligibility refactor, so only the code half was outstanding.

## Baseline note

`ktlint-baseline.xml` entries for `NavigationConstants.kt` all shift up by the removed constant. Only that file's `<file>` block was spliced — the baseline was not regenerated wholesale.

## Verification

- `scripts/preflight.sh` — ktlint ratchet, shared KMP tests, Android unit tests, Android lint all pass
- `xcodebuild -scheme UkuleleCompanion -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — no errors (warnings are pre-existing)

Accessibility unaffected: the removed code was analytics-free state bookkeeping with no UI or semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)