### PR TITLE
Docs: Reconcile the offline claims with the store review flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,27 @@ Detailed coding rules live in `.cursor/rules/*.mdc` — **the canonical source**
 Ukulele Companion is a **free, fully offline** multiplatform app (Android + iOS) for learning and playing ukulele. A core user base includes **blind and visually impaired musicians** who rely on TalkBack (Android) and VoiceOver (iOS). Every code change must preserve accessibility. Breaking accessibility is treated as seriously as breaking functionality.
 
 **Hard constraints -- never violate these:**
-- No network dependencies -- the app must remain fully offline
+- No network dependencies -- every app feature must work with the radio off
 - No analytics, tracking, or telemetry
 - No ads or monetization code without prior discussion
 - No third-party SDKs without prior discussion
 - Never commit `keystore.properties`, API keys, or secrets
+
+**Approved exceptions** (already discussed and shipped — do not treat these as
+precedent for new ones, and do not "fix" them by deleting them):
+
+| Exception | Where | Why it is allowed |
+|-----------|-------|-------------------|
+| `com.google.android.play:review` / `:review-ktx` | `app/build.gradle.kts`, `ui/ReviewPromptLauncher.kt` | The Play In-App Review flow is the only Play-policy-compliant way to ask for a rating (see #65, #537). It brokers the request through the Play Store app already on the device; the app sends no data of its own and receives nothing back. iOS uses Apple's StoreKit `requestReview` for the same purpose. Both are covered by a carve-out in [docs/privacy-policy.md](docs/privacy-policy.md). |
+| Outbound links under Settings (website, free book, video guide, licences) | `ui/AboutSection.kt`, `Views/SettingsView.swift`, `Views/OpenSourceLicensesView.swift` | Hands a URL to the system browser; the app makes no request itself. |
+
+Anything a *user's own tap* hands to the OS (a link, a share sheet, a store
+review request) is not a network dependency. Anything the app fetches, uploads,
+or phones home with is — and stays banned.
+
+Because of these, prefer "works fully offline" over "sends nothing anywhere" in
+user-facing copy: the store review flow and outbound links are real, and this
+project's users read privacy claims literally.
 
 ## Tech Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 - **ObservableObject + @Published (iOS)**: SwiftUI state managed via ObservableObject ViewModels
 - **Repository Pattern**: Data access is abstracted through repository classes
 - **Pure Domain Logic**: The shared `domain/` package has no platform dependencies, making it easy to test
-- **No Network**: The app is fully offline — do not add network dependencies
+- **No Network**: The app is fully offline — do not add network dependencies. The Play In-App Review dependency is a documented exception; see [Approved exceptions](AGENTS.md#project-overview) in `AGENTS.md`
 
 ### Linting & Pre-Submission Checks
 
@@ -259,7 +259,7 @@ This app is actively used by blind and visually impaired musicians with screen r
 
 ### Things to Avoid
 
-- **Do not add network dependencies** — the app must remain fully offline
+- **Do not add network dependencies** — every app feature must work with the radio off. The Play In-App Review SDK is the one approved exception (it brokers a rating request through the Play Store app); see **Approved exceptions** in `AGENTS.md` before adding anything similar
 - **Do not add analytics or tracking** — this is a core principle of the project
 - **Do not add ads or monetization without prior discussion** — changes to the business model require maintainer approval
 - **Do not add third-party SDKs** without prior discussion — keep the dependency footprint minimal

--- a/README.md
+++ b/README.md
@@ -344,7 +344,10 @@ We actively encourage contributors to use **AI coding tools** to accelerate thei
 ## 📖 Documentation
 
 - **Website**: https://baijum.github.io/ukulele-companion/
-- **Privacy policy**: https://baijum.github.io/ukulele-companion/privacy-policy/
+- **Privacy policy**: https://baijum.github.io/ukulele-companion/privacy-policy/ — no accounts,
+  no analytics, and no data leaves your device. Every feature works offline; the only things that
+  reach outside the app are links you tap and the app store's own review prompt (Google Play
+  In-App Review / StoreKit).
 
 Detailed feature documentation and a user manual are available in the [`docs/`](docs/) directory:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,13 @@
 
 ## About This App
 
-Ukulele Companion is a **fully offline** Android and iOS app with no backend servers, no user accounts, no analytics, and no network-dependent features. All data is stored locally on the device (SharedPreferences on Android, UserDefaults on iOS).
+Ukulele Companion is a **fully offline** Android and iOS app with no backend servers, no user accounts, and no analytics. Every music feature works with the radio off, and all data is stored locally on the device (SharedPreferences on Android, UserDefaults on iOS).
+
+The app itself opens no sockets. Two paths do hand work to the operating system:
+the store review prompt (Google Play In-App Review on Android, StoreKit
+`requestReview` on iOS) and the outbound links under Settings, which are
+handed to the system browser. Neither carries app data. See the
+[privacy policy](docs/privacy-policy.md) for the user-facing wording.
 
 ### Android Permissions
 
@@ -10,7 +16,7 @@ Ukulele Companion is a **fully offline** Android and iOS app with no backend ser
 |------------|---------|----------|
 | `RECORD_AUDIO` | Chromatic tuner and audio chord detection | Optional |
 | `POST_NOTIFICATIONS` | Chord of the Day daily notification | Optional |
-| `INTERNET` | Declared in the app manifest (no dependency requires it); not actively used for data transmission | — |
+| `INTERNET` | Declared in the app manifest; the app opens no connections of its own. The Play In-App Review flow runs inside the Play Store app, not this process | — |
 
 ### iOS Permissions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ hide:
     </div>
     <div class="hero-stats">
       <div><strong>30+</strong><span>learning screens</span></div>
-      <div><strong>100%</strong><span>offline capable</span></div>
+      <div><strong>100%</strong><span>of features work offline</span></div>
       <div><strong>0</strong><span>ads or tracking</span></div>
     </div>
   </div>
@@ -189,7 +189,9 @@ hide:
     <a href="manual/android/01-getting-started/" class="md-button">Go to getting started</a>
   </div>
   <p class="cta-footer">
-    <a href="privacy-policy/">Privacy Policy</a>
+    <a href="privacy-policy/">Privacy Policy</a> — no accounts, no analytics, no
+    data leaving your device. The only things that reach outside the app are
+    links you tap and your app store's own "rate this app" prompt.
   </p>
   <p class="cta-credit">
     Made with care by Baiju Muthukadan

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Uke (Ukulele Companion) - Privacy Policy
 
-Last updated: February 8, 2026
+Last updated: August 20, 2026
 
 ## Overview
 
@@ -15,7 +15,45 @@ Uke does **not**:
 - Collect, store, or transmit any personal information
 - Use analytics, tracking, or advertising SDKs
 - Require an account or login to use core features
-- Send any data to external servers (the app works fully offline)
+- Send any of your data to servers we control — there are none
+- Require an internet connection for any of its music features
+
+## Offline by Default
+
+Every feature that teaches, tunes, or records — the fretboard, chord library,
+tuner, metronome, songbook, practice tools — runs entirely on your device with
+no network access. The app has no backend and no account system, so there is
+nothing for it to sync.
+
+Two things reach outside the app, and both are started by you or by your
+device's own operating system:
+
+- **Links you tap.** The website, free-book, video-guide, and open-source
+  licence links under Settings hand a web address to your browser. The app
+  itself fetches nothing; from that point on you are on the linked site, under
+  its own privacy policy.
+- **The store review prompt.** See below.
+
+## Store Review Prompt
+
+Once you have opened the app on at least five separate days, and a week has
+passed since you installed it, the app may ask your device's app store to show
+its own "rate this app" card:
+
+- On Android this uses the Google Play In-App Review API, part of the Google
+  Play Store app already on your device.
+- On iOS this uses Apple's StoreKit review request.
+
+The rating and any review text you write go to Google or Apple under **their**
+privacy policies, not to us — the same as rating the app from the store listing
+directly. The app sends no data of its own along with the request, receives no
+information about you back, and never learns what rating you gave, or even
+whether the card appeared at all. The request is made at most three times in the
+app's lifetime, at least 90 days apart, and ignoring it costs you nothing.
+
+The counters that decide when to ask (how many separate days you have opened
+the app, when it was first launched, how many times it has asked) are stored
+only on your device.
 
 ## Microphone Access
 


### PR DESCRIPTION
Fixes #544.

The issue offered two routes: document the Play dependency as an accepted exception, or drop it in favour of a plain store link. This PR takes the first — #537 (review gating) is already fixed, so the second route's extra benefit no longer applies, and the issue itself frames this as "not a code defect". **No code or dependency changes here**; if you'd rather drop `com.google.android.play:review` entirely, say so and I'll open that as a separate PR.

## What was wrong

`docs/privacy-policy.md` said the app does not "Send any data to external servers (the app works fully offline)". Submitting a rating through the Play In-App Review API (or StoreKit on iOS) does leave the device. `SECURITY.md` went further, claiming "no network-dependent features" and that the `INTERNET` permission is required by no dependency.

## What changed

| File | Change |
|---|---|
| `docs/privacy-policy.md` | New **Offline by Default** and **Store Review Prompt** sections. Names both APIs, says the rating goes to Google/Apple under their policies, and states plainly that the app sends nothing alongside the request and never learns the rating. Uses the real gate values from `ReviewPromptEligibility` — five active days, a week since install, at most three requests 90 days apart. Also covers the outbound links under Settings. |
| `AGENTS.md` | New **Approved exceptions** table under the hard constraints, covering the Play dependency and the Settings links, plus the rule that separates them from a banned dependency: what a *user's tap* hands to the OS is fine, what the app fetches or uploads is not. Framed so a future agent neither deletes them as violations nor cites them as precedent. |
| `SECURITY.md` | Dropped "no network-dependent features"; corrected the `INTERNET` permission row. |
| `CONTRIBUTING.md`, `README.md`, `docs/index.md` | Qualified the unconditional offline wording and pointed at the exception. |

In-app strings (`onboarding_privacy_offline`, `settings_tagline`) are left alone — they claim the features work offline, which is still true, and changing them would mean re-translating 16 locales.

## Verification

Docs only, no behaviour change. `mkdocs build` produces the same 6 pre-existing warnings as `main` — none added — and the rendered privacy page carries the new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)