### PR TITLE
Test: Cover the untested data, settings and ViewModel layers

### DIFF
--- a/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
@@ -62,9 +62,8 @@ class CustomProgressionRepositoryTest {
         name: String,
         description: String = "legacy description",
         scaleType: String = "MAJOR",
-        degreeSpec: String = "0:_:I;5:_:IV;7:_:V",
         createdAt: Long = 1_000L,
-    ) = listOf(id, name, description, scaleType, degreeSpec, createdAt.toString()).joinToString("|||")
+    ) = listOf(id, name, description, scaleType, DEGREE_SPEC, createdAt.toString()).joinToString("|||")
 
     private fun writeRaw(
         key: String,
@@ -268,7 +267,7 @@ class CustomProgressionRepositoryTest {
 
     @Test
     fun legacyEntriesWithMalformedDegreesAreSkipped() {
-        writeRaw("old_bad", legacyEntry("a", "Bad", degreeSpec = "not:a:number"))
+        writeRaw("old_bad", "a|||Bad|||Desc|||MAJOR|||not:a:number|||1000")
         writeRaw("old_good", legacyEntry("b", "Survivor"))
 
         assertEquals(listOf("b"), repo.getAll().map { it.id })
@@ -292,6 +291,7 @@ class CustomProgressionRepositoryTest {
     }
 
     private companion object {
+        const val DEGREE_SPEC = "0:_:I;5:_:IV;7:_:V"
         const val PREFS_NAME = "custom_progressions"
         const val KEY_PROGRESSIONS = "progressions_json"
         const val BACKUP_KEY = "progressions_json_backup"

--- a/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
@@ -1,0 +1,300 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [CustomProgressionRepository].
+ *
+ * This is the one repository left out of `RepositorySerializationTest`, and the
+ * only one whose `getAll()` override falls through to a legacy pipe-format
+ * migration rather than to the base class's quarantine path. Both branches are
+ * covered here.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CustomProgressionRepositoryTest {
+    private lateinit var prefs: SharedPreferences
+    private lateinit var repo: CustomProgressionRepository
+
+    @Before
+    fun setUp() {
+        val app: Application = ApplicationProvider.getApplicationContext()
+        prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        repo = CustomProgressionRepository(app)
+    }
+
+    private fun degrees() =
+        listOf(
+            ChordDegree(interval = 0, quality = "", numeral = "I"),
+            ChordDegree(interval = 5, quality = "", numeral = "IV"),
+            ChordDegree(interval = 7, quality = "", numeral = "V"),
+        )
+
+    private fun progression(
+        id: String,
+        name: String = "Pattern $id",
+        createdAt: Long = 1_000L,
+        scaleType: ScaleType = ScaleType.MAJOR,
+    ) = CustomProgression(
+        id = id,
+        progression =
+            Progression(
+                name = name,
+                description = "Description of $id",
+                degrees = degrees(),
+                scaleType = scaleType,
+            ),
+        createdAt = createdAt,
+    )
+
+    /** The pre-JSON on-disk format: one preference key per progression. */
+    private fun legacyEntry(
+        id: String,
+        name: String,
+        description: String = "legacy description",
+        scaleType: String = "MAJOR",
+        degreeSpec: String = "0:_:I;5:_:IV;7:_:V",
+        createdAt: Long = 1_000L,
+    ) = listOf(id, name, description, scaleType, degreeSpec, createdAt.toString()).joinToString("|||")
+
+    private fun writeRaw(
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    // ── CRUD ─────────────────────────────────────────────────────────
+
+    @Test
+    fun roundTripsAProgressionWithAllFields() {
+        repo.save(progression("a", name = "Doo-wop", createdAt = 4_242L, scaleType = ScaleType.MINOR))
+
+        val stored = repo.getAll().single()
+        assertEquals("a", stored.id)
+        assertEquals("Doo-wop", stored.progression.name)
+        assertEquals("Description of a", stored.progression.description)
+        assertEquals(ScaleType.MINOR, stored.progression.scaleType)
+        assertEquals(degrees(), stored.progression.degrees)
+        assertEquals(4_242L, stored.createdAt)
+    }
+
+    @Test
+    fun savePrependsNewProgressionsAndUpdatesExistingOnesInPlace() {
+        repo.save(progression("a"))
+        repo.save(progression("b"))
+        assertEquals(listOf("b", "a"), repo.getAll().map { it.id })
+
+        repo.save(progression("a", name = "Renamed"))
+        assertEquals("order should survive an update", listOf("b", "a"), repo.getAll().map { it.id })
+        assertEquals(
+            "Renamed",
+            repo
+                .getAll()
+                .single { it.id == "a" }
+                .progression.name,
+        )
+    }
+
+    @Test
+    fun deleteRemovesById() {
+        repo.save(progression("a"))
+        repo.save(progression("b"))
+        repo.delete("a")
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun savedProgressionsSurviveANewRepositoryInstance() {
+        repo.save(progression("a", name = "Persisted"))
+        val fresh = CustomProgressionRepository(ApplicationProvider.getApplicationContext())
+        assertEquals(
+            "Persisted",
+            fresh
+                .getAll()
+                .single()
+                .progression.name,
+        )
+    }
+
+    @Test
+    fun prefsFileAndKeyNamesAreTheOnDiskContract() {
+        repo.save(progression("a"))
+        assertTrue(
+            "progressions must persist under progressions_json in custom_progressions",
+            prefs.getString(KEY_PROGRESSIONS, null)?.contains("\"a\"") == true,
+        )
+    }
+
+    // ── Import merge ─────────────────────────────────────────────────
+
+    @Test
+    fun importAllKeepsTheLocalCopyOfADuplicateId() {
+        repo.save(progression("a", name = "Local"))
+        repo.importAll(listOf(progression("a", name = "Incoming")))
+        assertEquals(
+            "Local",
+            repo
+                .getAll()
+                .single()
+                .progression.name,
+        )
+    }
+
+    @Test
+    fun importAllAddsUnknownIds() {
+        repo.save(progression("a"))
+        repo.importAll(listOf(progression("a"), progression("b")))
+        assertEquals(listOf("a", "b"), repo.getAll().map { it.id })
+    }
+
+    // ── Corrupt data ─────────────────────────────────────────────────
+
+    @Test
+    fun corruptPrimaryFallsBackToTheBackupCopy() {
+        repo.save(progression("a", name = "Recoverable"))
+        writeRaw(KEY_PROGRESSIONS, "}} not json {{")
+        assertEquals(
+            "Recoverable",
+            repo
+                .getAll()
+                .single()
+                .progression.name,
+        )
+    }
+
+    @Test
+    fun corruptPrimaryAndBackupWithNoLegacyEntriesReturnsEmptyWithoutQuarantining() {
+        // The getAll() override falls through to the legacy migration instead of
+        // the base class's quarantine branch, so an unrecoverable store here is
+        // silently dropped rather than preserved. Pinned, not fixed: adding
+        // quarantine means reconciling the two recovery strategies.
+        writeRaw(KEY_PROGRESSIONS, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+
+        assertTrue(repo.getAll().isEmpty())
+        assertNull(
+            "this repository never reaches the quarantine branch",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    // ── Legacy migration ─────────────────────────────────────────────
+
+    @Test
+    fun migratesLegacyPipeEntriesNewestFirst() {
+        writeRaw("old_a", legacyEntry("a", "Oldest", createdAt = 1_000L))
+        writeRaw("old_b", legacyEntry("b", "Newest", createdAt = 3_000L))
+        writeRaw("old_c", legacyEntry("c", "Middle", createdAt = 2_000L))
+
+        assertEquals(listOf("b", "c", "a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyMigrationPreservesEveryField() {
+        writeRaw(
+            "old_a",
+            legacyEntry("a", "Andalusian", description = "Flamenco staple", scaleType = "MINOR"),
+        )
+
+        val migrated = repo.getAll().single()
+        assertEquals("a", migrated.id)
+        assertEquals("Andalusian", migrated.progression.name)
+        assertEquals("Flamenco staple", migrated.progression.description)
+        assertEquals(ScaleType.MINOR, migrated.progression.scaleType)
+        assertEquals(1_000L, migrated.createdAt)
+        assertEquals(listOf(0, 5, 7), migrated.progression.degrees.map { it.interval })
+        assertEquals(listOf("I", "IV", "V"), migrated.progression.degrees.map { it.numeral })
+    }
+
+    @Test
+    fun legacyMigrationRemovesTheLegacyKeysAndWritesJson() {
+        writeRaw("old_a", legacyEntry("a", "Migrated"))
+        repo.getAll()
+
+        assertNull("the legacy key should be consumed", prefs.getString("old_a", null))
+        assertTrue(
+            "the migrated data should land in the JSON key",
+            prefs.getString(KEY_PROGRESSIONS, null)?.contains("Migrated") == true,
+        )
+    }
+
+    @Test
+    fun legacyMigrationAlsoDeletesTheBackupKeyItJustWrote() {
+        // Pinned weakness: the cleanup filters on `key != KEY_PROGRESSIONS` only,
+        // so it removes the backup that persist() wrote two lines earlier. The
+        // migrated data therefore has no recovery copy until the next save.
+        // FavoritesRepository excludes its backup key here; this one does not.
+        writeRaw("old_a", legacyEntry("a", "Migrated"))
+        repo.getAll()
+
+        assertNull(
+            "today the freshly written backup is deleted by the cleanup",
+            prefs.getString(BACKUP_KEY, null),
+        )
+    }
+
+    @Test
+    fun legacyMigrationRunsOnlyOnce() {
+        writeRaw("old_a", legacyEntry("a", "Migrated"))
+        assertEquals(1, repo.getAll().size)
+        assertEquals("a second read reuses the JSON store", 1, repo.getAll().size)
+    }
+
+    @Test
+    fun legacyEntriesWithTooFewFieldsAreSkippedWithoutLosingTheRest() {
+        writeRaw("old_bad", "a|||only|||three")
+        writeRaw("old_good", legacyEntry("b", "Survivor"))
+
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyEntriesWithAnUnknownScaleTypeAreSkipped() {
+        writeRaw("old_bad", legacyEntry("a", "Bad", scaleType = "KLINGON"))
+        writeRaw("old_good", legacyEntry("b", "Survivor"))
+
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyEntriesWithMalformedDegreesAreSkipped() {
+        writeRaw("old_bad", legacyEntry("a", "Bad", degreeSpec = "not:a:number"))
+        writeRaw("old_good", legacyEntry("b", "Survivor"))
+
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyEntriesWithANonNumericTimestampAreSkipped() {
+        writeRaw("old_bad", "a|||Name|||Desc|||MAJOR|||0:_:I|||yesterday")
+        writeRaw("old_good", legacyEntry("b", "Survivor"))
+
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyMigrationUnescapesPipesInNameAndDescription() {
+        writeRaw("old_a", legacyEntry("a", "Verse \\| Chorus", description = "A \\| B"))
+
+        val migrated = repo.getAll().single()
+        assertEquals("Verse | Chorus", migrated.progression.name)
+        assertEquals("A | B", migrated.progression.description)
+    }
+
+    private companion object {
+        const val PREFS_NAME = "custom_progressions"
+        const val KEY_PROGRESSIONS = "progressions_json"
+        const val BACKUP_KEY = "progressions_json_backup"
+        const val QUARANTINE_KEY = "progressions_json_quarantine"
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/data/JsonListRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/JsonListRepositoryTest.kt
@@ -1,0 +1,268 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for the [JsonListRepository] base class.
+ *
+ * This is the corrupt-data recovery path shared by every list repository:
+ * an unparseable primary falls back to the backup copy, and when both are
+ * unreadable the raw primary is quarantined instead of being thrown away.
+ *
+ * Worth knowing while reading these: all five production subclasses override
+ * `getAll()`, so the base implementation below — including the entire quarantine
+ * branch — is currently unreachable in the shipping app. These tests cover the
+ * contract the next repository to extend this class will inherit, and pin the
+ * three weaknesses noted inline so that changing them is a deliberate act.
+ */
+@RunWith(RobolectricTestRunner::class)
+class JsonListRepositoryTest {
+    @Serializable
+    private data class TestEntity(
+        val id: String,
+        val name: String,
+        val updatedAt: Long = 0L,
+    )
+
+    private class TestRepository(
+        context: Context,
+    ) : JsonListRepository<TestEntity>(
+            context,
+            PREFS_NAME,
+            DATA_KEY,
+            TestEntity.serializer(),
+        ) {
+        override fun entityId(item: TestEntity) = item.id
+
+        override fun entityTimestamp(item: TestEntity) = item.updatedAt
+    }
+
+    private lateinit var prefs: SharedPreferences
+    private lateinit var repo: TestRepository
+
+    @Before
+    fun setUp() {
+        val app: Application = ApplicationProvider.getApplicationContext()
+        // A dedicated prefs file: the production repositories scan prefs.all for
+        // legacy entries, so scratch keys must never share a file with real data.
+        prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        repo = TestRepository(app)
+    }
+
+    private fun entity(
+        id: String,
+        name: String = id,
+        updatedAt: Long = 0L,
+    ) = TestEntity(id = id, name = name, updatedAt = updatedAt)
+
+    private fun writeRaw(
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    // ── Save, delete, read ───────────────────────────────────────────
+
+    @Test
+    fun getAllReturnsEmptyWhenNothingWasPersisted() {
+        assertTrue("a fresh repository should be empty", repo.getAll().isEmpty())
+    }
+
+    @Test
+    fun saveInsertsNewItemsAtTheFrontOfTheList() {
+        repo.save(entity("a"))
+        repo.save(entity("b"))
+        repo.save(entity("c"))
+        assertEquals(listOf("c", "b", "a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun saveReplacesAnExistingItemInPlaceWithoutReordering() {
+        repo.save(entity("a"))
+        repo.save(entity("b"))
+        repo.save(entity("a", name = "renamed"))
+
+        val all = repo.getAll()
+        assertEquals("order should be preserved on update", listOf("b", "a"), all.map { it.id })
+        assertEquals("renamed", all.single { it.id == "a" }.name)
+    }
+
+    @Test
+    fun deleteRemovesOnlyTheMatchingId() {
+        repo.save(entity("a"))
+        repo.save(entity("b"))
+        repo.delete("a")
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun deleteOfAnUnknownIdLeavesTheListIntact() {
+        repo.save(entity("a"))
+        repo.delete("nope")
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun savedItemsSurviveANewRepositoryInstance() {
+        repo.save(entity("a", name = "kept"))
+        val fresh = TestRepository(ApplicationProvider.getApplicationContext())
+        assertEquals("kept", fresh.getAll().single().name)
+    }
+
+    // ── Import merge ─────────────────────────────────────────────────
+
+    @Test
+    fun importAllKeepsTheExistingCopyOfADuplicateId() {
+        repo.save(entity("a", name = "local"))
+        repo.importAll(listOf(entity("a", name = "incoming")))
+        assertEquals("local data is authoritative", "local", repo.getAll().single().name)
+    }
+
+    @Test
+    fun importAllAppendsUnknownIdsAfterExistingOnes() {
+        repo.save(entity("a"))
+        repo.importAll(listOf(entity("a"), entity("b"), entity("c")))
+        assertEquals(listOf("a", "b", "c"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun importAllOfAnEmptyListPreservesExistingItems() {
+        repo.save(entity("a"))
+        repo.importAll(emptyList())
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun importAllIntoAnEmptyRepositoryAddsEverything() {
+        repo.importAll(listOf(entity("a"), entity("b")))
+        assertEquals(listOf("a", "b"), repo.getAll().map { it.id })
+    }
+
+    // ── Backup rotation ──────────────────────────────────────────────
+
+    @Test
+    fun firstPersistSeedsTheBackupWithTheSameRawWhenNoPreviousValueExists() {
+        repo.save(entity("a"))
+        assertEquals(
+            "the first write has no previous good copy, so it backs up itself",
+            prefs.getString(DATA_KEY, null),
+            prefs.getString(BACKUP_KEY, null),
+        )
+    }
+
+    @Test
+    fun backupLagsExactlyOnePersistBehindThePrimary() {
+        repo.save(entity("a"))
+        val afterFirst = prefs.getString(DATA_KEY, null)
+        repo.save(entity("b"))
+
+        assertEquals("backup should hold the previous primary", afterFirst, prefs.getString(BACKUP_KEY, null))
+        assertTrue("primary should hold both items", repo.getAll().map { it.id }.containsAll(listOf("a", "b")))
+    }
+
+    @Test
+    fun backupAndQuarantineKeyNamesAreDerivedFromTheDataKey() {
+        // On-disk contract: renaming these orphans the recovery copies of every install.
+        repo.save(entity("a"))
+        writeRaw(DATA_KEY, "{{ not json")
+        writeRaw(BACKUP_KEY, "{{ also not json")
+        repo.getAll()
+
+        assertNotNull("expected a key named $BACKUP_KEY", prefs.getString(BACKUP_KEY, null))
+        assertNotNull("expected a key named $QUARANTINE_KEY", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    // ── Corrupt-data recovery ────────────────────────────────────────
+
+    @Test
+    fun getAllFallsBackToTheBackupWhenThePrimaryIsUnparseable() {
+        repo.save(entity("a", name = "good"))
+        writeRaw(DATA_KEY, "]]not json[[")
+
+        assertEquals("the backup copy should be served", "good", repo.getAll().single().name)
+        assertNull("a recoverable read must not quarantine", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    @Test
+    fun getAllQuarantinesTheRawPrimaryWhenBothCopiesAreUnparseable() {
+        val corrupt = """[{"id":"a","name":"truncated"""
+        writeRaw(DATA_KEY, corrupt)
+        writeRaw(BACKUP_KEY, "also broken")
+
+        assertTrue("an unreadable store reads as empty", repo.getAll().isEmpty())
+        assertEquals(
+            "the raw primary should be preserved for recovery",
+            corrupt,
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    @Test
+    fun getAllReturnsEmptyAndWritesNoQuarantineWhenNothingWasPersisted() {
+        assertTrue(repo.getAll().isEmpty())
+        assertNull("an absent store is not a corrupt one", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    @Test
+    fun anEmptyStringPrimaryIsTreatedAsCorruptRatherThanEmpty() {
+        writeRaw(DATA_KEY, "")
+        assertTrue(repo.getAll().isEmpty())
+        assertEquals("", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    @Test
+    fun aSecondCorruptionOverwritesTheFirstQuarantinedPayload() {
+        // Pinned weakness: the quarantine is a single slot with no timestamp or
+        // suffix, so a second unrecoverable read destroys the payload the
+        // mechanism exists to preserve. Fixing this means a new key scheme.
+        writeRaw(DATA_KEY, "first corruption")
+        writeRaw(BACKUP_KEY, "broken")
+        repo.getAll()
+        assertEquals("first corruption", prefs.getString(QUARANTINE_KEY, null))
+
+        writeRaw(DATA_KEY, "second corruption")
+        repo.getAll()
+        assertEquals(
+            "today the newer payload replaces the older one",
+            "second corruption",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    @Test
+    fun persistPromotesTheCorruptPrimaryIntoTheBackupSlot() {
+        // Pinned weakness: persist() copies whatever is in the primary key into
+        // the backup without checking that it parses. Once getAll() has already
+        // found the primary corrupt, the next save() therefore overwrites the
+        // last good copy with the corrupt one.
+        repo.save(entity("a", name = "good"))
+        writeRaw(DATA_KEY, "corrupt")
+        repo.save(entity("b"))
+
+        assertEquals(
+            "today the corrupt primary is promoted into the backup",
+            "corrupt",
+            prefs.getString(BACKUP_KEY, null),
+        )
+    }
+
+    private companion object {
+        const val PREFS_NAME = "json_list_repo_test"
+        const val DATA_KEY = "items"
+        const val BACKUP_KEY = "items_backup"
+        const val QUARANTINE_KEY = "items_quarantine"
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/domain/FrameGateExtTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/domain/FrameGateExtTest.kt
@@ -1,0 +1,105 @@
+package com.baijum.ukufretboard.domain
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [awaitEnterSuspending].
+ *
+ * The suspending wrapper exists so the audio path can wait for an in-flight DSP
+ * frame without busy-spinning on the main thread (#462). These tests use real
+ * time rather than a virtual clock — `kotlinx-coroutines-test` is not on the
+ * classpath — so every case passes an explicit short timeout and the whole
+ * class runs in well under a second.
+ */
+class FrameGateExtTest {
+    private val shortTimeoutMs = 50L
+
+    // ── Fast path ────────────────────────────────────────────────────
+
+    @Test
+    fun takesAFreeGateImmediately() =
+        runBlocking {
+            assertTrue("a free gate should be entered", FrameGate().awaitEnterSuspending(shortTimeoutMs))
+        }
+
+    @Test
+    fun aZeroTimeoutStillTakesAFreeGate() =
+        runBlocking {
+            // The tryEnter() fast path runs before withTimeoutOrNull, so a zero
+            // budget must not stop an uncontended entry.
+            assertTrue(FrameGate().awaitEnterSuspending(timeoutMs = 0L))
+        }
+
+    @Test
+    fun enteringHoldsTheGateAgainstTheNextTryEnter() =
+        runBlocking {
+            val gate = FrameGate()
+            assertTrue(gate.awaitEnterSuspending(shortTimeoutMs))
+            assertFalse("the gate should now be held", gate.tryEnter())
+        }
+
+    // ── Timeout ──────────────────────────────────────────────────────
+
+    @Test
+    fun returnsFalseWhenTheGateStaysBusy() =
+        runBlocking {
+            val gate = FrameGate()
+            assertTrue(gate.tryEnter())
+
+            val start = System.nanoTime()
+            val entered = gate.awaitEnterSuspending(shortTimeoutMs)
+            val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+            assertFalse("a held gate must not be entered", entered)
+            assertTrue("it should have waited out the timeout, took ${elapsedMs}ms", elapsedMs >= shortTimeoutMs)
+            assertTrue("it must not fall back to the 500ms default, took ${elapsedMs}ms", elapsedMs < 400)
+        }
+
+    @Test
+    fun aTimedOutAwaitDoesNotLeakAnEntry() =
+        runBlocking {
+            val gate = FrameGate()
+            assertTrue(gate.tryEnter())
+            assertFalse(gate.awaitEnterSuspending(shortTimeoutMs))
+
+            gate.exit()
+            assertTrue("the original holder's exit should free the gate", gate.tryEnter())
+            assertFalse("and only one caller may hold it", gate.tryEnter())
+        }
+
+    // ── Handover ─────────────────────────────────────────────────────
+
+    @Test
+    fun succeedsOnceAnotherCoroutineExits() =
+        runBlocking {
+            val gate = FrameGate()
+            assertTrue(gate.tryEnter())
+
+            // The poller yields via delay(1), so the releasing coroutine gets to run
+            // on the same event loop without needing a separate dispatcher.
+            val waiter = async { gate.awaitEnterSuspending(timeoutMs = 2_000L) }
+            launch {
+                delay(20)
+                gate.exit()
+            }
+
+            assertTrue("the waiter should take the gate once it is released", waiter.await())
+        }
+
+    @Test
+    fun theGateIsReusableAcrossSuccessiveFrames() =
+        runBlocking {
+            val gate = FrameGate()
+            repeat(3) { frame ->
+                assertTrue("frame $frame should enter", gate.awaitEnterSuspending(shortTimeoutMs))
+                gate.exit()
+            }
+            assertTrue("the gate should be free at the end", gate.tryEnter())
+        }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/AchievementContextAdapterTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/AchievementContextAdapterTest.kt
@@ -1,0 +1,137 @@
+package com.baijum.ukufretboard.viewmodel
+
+import com.baijum.ukufretboard.data.LearningStats
+import com.baijum.ukufretboard.domain.AchievementContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [toAchievementContext].
+ *
+ * This adapter is pure field-shuffling between two flat types that happen to
+ * declare their counters in different orders — `AchievementContext` has
+ * `quizCorrect` before `quizTotal` but `intervalTotal` before `intervalCorrect`,
+ * and `LearningStats` is built as `(total, correct, bestStreak)`. A transposed
+ * pair here would silently unlock the wrong achievements, so every field is
+ * seeded with its own distinct value and asserted individually.
+ */
+class AchievementContextAdapterTest {
+    private fun sentinelState() =
+        LearningProgressState(
+            completedLessons = 2,
+            totalLessons = 3,
+            passedLessonQuizzes = 5,
+            quizStatsOverall = LearningStats(total = 7, correct = 11, bestStreak = 13),
+            intervalStatsOverall = LearningStats(total = 17, correct = 19, bestStreak = 23),
+            noteQuizStats = LearningStats(total = 29, correct = 31, bestStreak = 37),
+            chordEarStatsOverall = LearningStats(total = 41, correct = 43, bestStreak = 47),
+            scalePracticeStatsOverall = LearningStats(total = 53, correct = 59, bestStreak = 61),
+            currentDayStreak = 67,
+            bestDayStreak = 71,
+        )
+
+    // ── Field mapping ────────────────────────────────────────────────
+
+    @Test
+    fun everyLearningProgressFieldMapsToItsAchievementCounterpart() {
+        val context = sentinelState().toAchievementContext()
+
+        assertEquals("currentStreak", 67, context.currentStreak)
+        assertEquals("bestStreak", 71, context.bestStreak)
+        assertEquals("completedLessons", 2, context.completedLessons)
+        assertEquals("totalLessons", 3, context.totalLessons)
+        assertEquals("quizCorrect", 11, context.quizCorrect)
+        assertEquals("quizTotal", 7, context.quizTotal)
+        assertEquals("quizBestStreak", 13, context.quizBestStreak)
+        assertEquals("intervalTotal", 17, context.intervalTotal)
+        assertEquals("intervalCorrect", 19, context.intervalCorrect)
+        assertEquals("chordEarTotal", 41, context.chordEarTotal)
+        assertEquals("chordEarCorrect", 43, context.chordEarCorrect)
+        assertEquals("scalePracticeTotal", 53, context.scalePracticeTotal)
+    }
+
+    @Test
+    fun quizCorrectAndQuizTotalAreNotTransposed() {
+        // The two types declare this pair in opposite orders; this is the one
+        // mapping a careless edit is most likely to swap.
+        val context =
+            LearningProgressState(
+                quizStatsOverall = LearningStats(total = 100, correct = 1, bestStreak = 0),
+            ).toAchievementContext()
+
+        assertEquals("quizTotal must come from LearningStats.total", 100, context.quizTotal)
+        assertEquals("quizCorrect must come from LearningStats.correct", 1, context.quizCorrect)
+    }
+
+    @Test
+    fun intervalTotalAndIntervalCorrectAreNotTransposed() {
+        val context =
+            LearningProgressState(
+                intervalStatsOverall = LearningStats(total = 100, correct = 1, bestStreak = 0),
+            ).toAchievementContext()
+
+        assertEquals(100, context.intervalTotal)
+        assertEquals(1, context.intervalCorrect)
+    }
+
+    @Test
+    fun chordEarTotalAndChordEarCorrectAreNotTransposed() {
+        val context =
+            LearningProgressState(
+                chordEarStatsOverall = LearningStats(total = 100, correct = 1, bestStreak = 0),
+            ).toAchievementContext()
+
+        assertEquals(100, context.chordEarTotal)
+        assertEquals(1, context.chordEarCorrect)
+    }
+
+    // ── Counts supplied by the caller ────────────────────────────────
+
+    @Test
+    fun songAndFavoriteCountsDefaultToZero() {
+        val context = sentinelState().toAchievementContext()
+        assertEquals("songs live outside the learning repository", 0, context.songsCount)
+        assertEquals("favorites live outside the learning repository", 0, context.favoritesCount)
+    }
+
+    @Test
+    fun explicitSongAndFavoriteCountsAreForwarded() {
+        val context = sentinelState().toAchievementContext(songsCount = 73, favoritesCount = 79)
+        assertEquals(73, context.songsCount)
+        assertEquals(79, context.favoritesCount)
+    }
+
+    // ── Deliberate omissions ─────────────────────────────────────────
+
+    @Test
+    fun aDefaultStateMapsToADefaultContext() {
+        assertEquals(AchievementContext(), LearningProgressState().toAchievementContext())
+    }
+
+    @Test
+    fun noteQuizAndPassedLessonQuizzesAreDeliberatelyNotMapped() {
+        // No achievement is keyed on either, so a state that differs only in
+        // these fields must produce an identical context.
+        val withoutExtras = LearningProgressState(currentDayStreak = 4)
+        val withExtras =
+            withoutExtras.copy(
+                passedLessonQuizzes = 99,
+                noteQuizStats = LearningStats(total = 99, correct = 99, bestStreak = 99),
+            )
+        assertEquals(withoutExtras.toAchievementContext(), withExtras.toAchievementContext())
+    }
+
+    @Test
+    fun perCategoryStatsAreDeliberatelyNotMapped() {
+        val withoutBreakdown =
+            LearningProgressState(
+                intervalStatsOverall = LearningStats(total = 10, correct = 5, bestStreak = 2),
+            )
+        val withBreakdown =
+            withoutBreakdown.copy(
+                intervalStatsByLevel = mapOf(1 to LearningStats(total = 10, correct = 5, bestStreak = 2)),
+                scalePracticeStatsByMode = mapOf("QUIZ" to LearningStats(total = 3, correct = 3, bestStreak = 3)),
+            )
+        assertEquals(withoutBreakdown.toAchievementContext(), withBreakdown.toAchievementContext())
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/CustomProgressionViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/CustomProgressionViewModelTest.kt
@@ -1,0 +1,215 @@
+package com.baijum.ukufretboard.viewmodel
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.baijum.ukufretboard.data.ChordDegree
+import com.baijum.ukufretboard.data.ScaleType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [CustomProgressionViewModel].
+ */
+@RunWith(RobolectricTestRunner::class)
+class CustomProgressionViewModelTest {
+    private lateinit var app: Application
+    private lateinit var vm: CustomProgressionViewModel
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        vm = CustomProgressionViewModel(app)
+    }
+
+    private fun degrees(vararg numerals: String) =
+        numerals.mapIndexed { index, numeral ->
+            ChordDegree(interval = index, quality = "", numeral = numeral)
+        }
+
+    private fun createAndGetId(
+        name: String,
+        description: String = "A description",
+        scaleType: ScaleType = ScaleType.MAJOR,
+    ): String {
+        vm.create(name, description, degrees("I", "IV", "V"), scaleType)
+        return vm.progressions.value
+            .single { it.progression.name == name }
+            .id
+    }
+
+    // ── Create ───────────────────────────────────────────────────────
+
+    @Test
+    fun createStoresTheProgressionAndExposesIt() {
+        vm.create("Doo-wop", "Fifties staple", degrees("I", "vi", "IV", "V"), ScaleType.MAJOR)
+
+        val stored = vm.progressions.value.single()
+        assertEquals("Doo-wop", stored.progression.name)
+        assertEquals("Fifties staple", stored.progression.description)
+        assertEquals(ScaleType.MAJOR, stored.progression.scaleType)
+        assertEquals(listOf("I", "vi", "IV", "V"), stored.progression.degrees.map { it.numeral })
+    }
+
+    @Test
+    fun createFallsBackToADefaultDescriptionWhenBlank() {
+        vm.create("Unnamed", "", degrees("I"), ScaleType.MAJOR)
+        assertEquals(
+            "Custom progression",
+            vm.progressions.value
+                .single()
+                .progression.description,
+        )
+    }
+
+    @Test
+    fun createTreatsAWhitespaceOnlyDescriptionAsBlank() {
+        // ifBlank, not ifEmpty: a description of spaces would otherwise ship as-is.
+        vm.create("Unnamed", "   \t  ", degrees("I"), ScaleType.MAJOR)
+        assertEquals(
+            "Custom progression",
+            vm.progressions.value
+                .single()
+                .progression.description,
+        )
+    }
+
+    @Test
+    fun createGeneratesDistinctIdsForIdenticalProgressions() {
+        vm.create("Same", "Same", degrees("I"), ScaleType.MAJOR)
+        vm.create("Same", "Same", degrees("I"), ScaleType.MAJOR)
+
+        val ids = vm.progressions.value.map { it.id }
+        assertEquals("identical progressions must still be distinct rows", 2, ids.toSet().size)
+    }
+
+    @Test
+    fun newestProgressionsComeFirst() {
+        createAndGetId("First")
+        createAndGetId("Second")
+        assertEquals(listOf("Second", "First"), vm.progressions.value.map { it.progression.name })
+    }
+
+    @Test
+    fun emptyDegreeListsAreStoredAsIs() {
+        // The ViewModel performs no validation; pinned so that adding it is deliberate.
+        vm.create("Empty", "No degrees", emptyList(), ScaleType.MAJOR)
+        assertTrue(
+            vm.progressions.value
+                .single()
+                .progression.degrees
+                .isEmpty(),
+        )
+    }
+
+    // ── Update ───────────────────────────────────────────────────────
+
+    @Test
+    fun updatePreservesTheIdAndCreatedAt() {
+        val id = createAndGetId("Original")
+        val createdAt =
+            vm.progressions.value
+                .single()
+                .createdAt
+
+        vm.update(id, "Renamed", "New description", degrees("ii", "V", "I"), ScaleType.MINOR)
+
+        val updated = vm.progressions.value.single()
+        assertEquals("the identity must survive an edit", id, updated.id)
+        assertEquals("createdAt must survive an edit", createdAt, updated.createdAt)
+        assertEquals("Renamed", updated.progression.name)
+        assertEquals("New description", updated.progression.description)
+        assertEquals(listOf("ii", "V", "I"), updated.progression.degrees.map { it.numeral })
+    }
+
+    @Test
+    fun updateCanChangeTheScaleType() {
+        val id = createAndGetId("Modal", scaleType = ScaleType.MAJOR)
+        vm.update(id, "Modal", "Now dorian", degrees("i", "IV"), ScaleType.DORIAN)
+
+        assertEquals(
+            ScaleType.DORIAN,
+            vm.progressions.value
+                .single()
+                .progression.scaleType,
+        )
+    }
+
+    @Test
+    fun updateFallsBackToADefaultDescriptionWhenBlank() {
+        val id = createAndGetId("Named")
+        vm.update(id, "Named", "  ", degrees("I"), ScaleType.MAJOR)
+
+        assertEquals(
+            "Custom progression",
+            vm.progressions.value
+                .single()
+                .progression.description,
+        )
+    }
+
+    @Test
+    fun updateOfAnUnknownIdIsANoOp() {
+        createAndGetId("Kept", description = "Untouched")
+        vm.update("no-such-id", "Ghost", "Ghost", degrees("I"), ScaleType.MAJOR)
+
+        val all = vm.progressions.value
+        assertEquals(1, all.size)
+        assertEquals("Kept", all.single().progression.name)
+        assertEquals("Untouched", all.single().progression.description)
+    }
+
+    @Test
+    fun updateLeavesOtherProgressionsAlone() {
+        val target = createAndGetId("Target")
+        createAndGetId("Bystander")
+
+        vm.update(target, "Edited", "Edited", degrees("I"), ScaleType.MAJOR)
+
+        assertEquals(
+            setOf("Edited", "Bystander"),
+            vm.progressions.value
+                .map { it.progression.name }
+                .toSet(),
+        )
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────
+
+    @Test
+    fun deleteRemovesTheProgression() {
+        val id = createAndGetId("Doomed")
+        createAndGetId("Kept")
+        vm.delete(id)
+
+        assertEquals(listOf("Kept"), vm.progressions.value.map { it.progression.name })
+    }
+
+    @Test
+    fun deleteOfAnUnknownIdLeavesTheListIntact() {
+        createAndGetId("Kept")
+        vm.delete("no-such-id")
+        assertEquals(1, vm.progressions.value.size)
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────
+
+    @Test
+    fun progressionsSurviveANewViewModelOverTheSameStorage() {
+        createAndGetId("Persisted")
+        assertEquals(
+            listOf("Persisted"),
+            CustomProgressionViewModel(app).progressions.value.map { it.progression.name },
+        )
+    }
+
+    @Test
+    fun deletionsSurviveANewViewModelOverTheSameStorage() {
+        val id = createAndGetId("Doomed")
+        vm.delete(id)
+        assertTrue(CustomProgressionViewModel(app).progressions.value.isEmpty())
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModelTest.kt
@@ -383,10 +383,22 @@ class FavoritesViewModelTest {
     }
 
     @Test
+    fun toChordVoicingResolvesNotesForLowG() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.LOW_G))
+
+        // Low-G drops the G string an octave but keeps every pitch class, and
+        // toChordVoicing maps frets to pitch classes only. Asserted explicitly
+        // rather than assumed, so that making the conversion octave-aware has to
+        // come back through this test.
+        assertEquals(listOf(7, 0, 4, 0), chord.notes.map { it?.pitchClass })
+        assertEquals(listOf("G", "C", "E", "C"), chord.notes.map { it?.name })
+    }
+
+    @Test
     fun toChordVoicingResolvesNotesForBaritone() {
-        // The testing guide asks for both-tuning coverage on chord logic. High-G
-        // and Low-G share pitch classes, so baritone is the tuning that actually
-        // exercises a different mapping.
+        // Baritone is the tuning whose pitch classes actually differ from High-G,
+        // so it is the one that exercises a genuinely different mapping.
         vm.addFavorite(2, "maj", listOf(0, 0, 0, 0))
         val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.BARITONE))
 

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/FavoritesViewModelTest.kt
@@ -1,0 +1,430 @@
+package com.baijum.ukufretboard.viewmodel
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.baijum.ukufretboard.data.FavoriteVoicing
+import com.baijum.ukufretboard.data.FavoritesRepository
+import com.baijum.ukufretboard.data.UkuleleTuning
+import com.baijum.ukufretboard.domain.ChordVoicing
+import com.baijum.ukufretboard.domain.UkuleleString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [FavoritesViewModel].
+ *
+ * Everything here hangs off [FavoriteVoicing.key] — it is the de-duplication
+ * identity, the folder-membership handle, and the sort key for a folder's manual
+ * order. The ViewModel resolves some lookups against its cached StateFlow and
+ * others straight through the repository, so several tests below use a second
+ * ViewModel instance to make that split visible.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FavoritesViewModelTest {
+    private lateinit var app: Application
+    private lateinit var vm: FavoritesViewModel
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        vm = FavoritesViewModel(app)
+    }
+
+    /** Seeds storage directly when a controlled addedAt is needed. */
+    private fun seed(voicing: FavoriteVoicing) {
+        FavoritesRepository(app).add(voicing)
+    }
+
+    private fun voicing(
+        root: Int,
+        symbol: String,
+        frets: List<Int>,
+        addedAt: Long,
+    ) = FavoriteVoicing(
+        rootPitchClass = root,
+        chordSymbol = symbol,
+        frets = frets,
+        addedAt = addedAt,
+    )
+
+    private fun createFolderAndGetId(name: String): String {
+        vm.createFolder(name)
+        return vm.folders.value
+            .single { it.name == name }
+            .id
+    }
+
+    private fun tuningOf(tuning: UkuleleTuning) =
+        tuning.pitchClasses.mapIndexed { i, pc ->
+            UkuleleString(name = tuning.stringNames[i], openPitchClass = pc, octave = tuning.octaves[i])
+        }
+
+    // ── Add and remove ───────────────────────────────────────────────
+
+    @Test
+    fun addFavoriteAppearsInTheFavoritesFlow() {
+        vm.addFavorite(0, "m7", listOf(0, 2, 3, 3))
+
+        val stored = vm.favorites.value.single()
+        assertEquals(0, stored.rootPitchClass)
+        assertEquals("m7", stored.chordSymbol)
+        assertEquals(listOf(0, 2, 3, 3), stored.frets)
+        assertEquals("0|m7|0,2,3,3", stored.key)
+    }
+
+    @Test
+    fun addingTheSameVoicingTwiceIsIgnored() {
+        vm.addFavorite(0, "m7", listOf(0, 2, 3, 3))
+        vm.addFavorite(0, "m7", listOf(0, 2, 3, 3))
+
+        assertEquals("favorites de-duplicate by key", 1, vm.favorites.value.size)
+    }
+
+    @Test
+    fun voicingsDifferingOnlyInFretsAreSeparateFavorites() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.addFavorite(0, "maj", listOf(5, 4, 3, 3))
+
+        assertEquals(2, vm.favorites.value.size)
+    }
+
+    @Test
+    fun theMostRecentlyAddedFavoriteComesFirst() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.addFavorite(9, "m", listOf(2, 0, 0, 0))
+        vm.addFavorite(5, "maj", listOf(2, 0, 1, 0))
+
+        assertEquals(listOf(5, 9, 0), vm.favorites.value.map { it.rootPitchClass })
+    }
+
+    @Test
+    fun theFavoritesListIsOrderedByInsertionNotByAddedAt() {
+        // add() prepends, so a voicing carrying an older addedAt — an imported one,
+        // say — still lands at the top of the list. Only getOrderedVoicings()
+        // consults addedAt, and then only for voicings with no manual order.
+        seed(voicing(0, "maj", listOf(0, 0, 0, 3), addedAt = 3_000L))
+        seed(voicing(9, "m", listOf(2, 0, 0, 0), addedAt = 1_000L))
+
+        val fresh = FavoritesViewModel(app)
+        assertEquals(listOf(9, 0), fresh.favorites.value.map { it.rootPitchClass })
+    }
+
+    @Test
+    fun removeFavoriteByFieldsRemovesTheMatchingVoicing() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.addFavorite(9, "m", listOf(2, 0, 0, 0))
+
+        vm.removeFavorite(0, "maj", listOf(0, 0, 0, 3))
+
+        assertEquals(listOf(9), vm.favorites.value.map { it.rootPitchClass })
+    }
+
+    @Test
+    fun removeFavoriteByFieldsIsANoOpWhenTheVoicingIsAbsent() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.removeFavorite(7, "sus4", listOf(0, 2, 3, 3))
+
+        assertEquals(1, vm.favorites.value.size)
+    }
+
+    @Test
+    fun removeFavoriteByInstanceRemovesIt() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.removeFavorite(vm.favorites.value.single())
+
+        assertTrue(vm.favorites.value.isEmpty())
+    }
+
+    @Test
+    fun favoritesSurviveANewViewModelOverTheSameStorage() {
+        vm.addFavorite(0, "m7", listOf(0, 2, 3, 3))
+        assertEquals(1, FavoritesViewModel(app).favorites.value.size)
+    }
+
+    // ── Lookups ──────────────────────────────────────────────────────
+
+    @Test
+    fun isFavoriteReportsMembership() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+
+        assertTrue(vm.isFavorite(0, "maj", listOf(0, 0, 0, 3)))
+        assertFalse(vm.isFavorite(0, "maj", listOf(5, 4, 3, 3)))
+        assertFalse(vm.isFavorite(7, "maj", listOf(0, 0, 0, 3)))
+    }
+
+    @Test
+    fun isFavoriteReadsThroughToStorageWhileTheFlowStaysStale() {
+        // isFavorite queries the repository, but removeFavorite(fields) and
+        // getFolderIdsForVoicing resolve against the cached flow. A second
+        // ViewModel writing to the same storage makes the split observable.
+        val other = FavoritesViewModel(app)
+        other.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+
+        assertTrue("isFavorite sees storage", vm.isFavorite(0, "maj", listOf(0, 0, 0, 3)))
+        assertTrue("the cached flow has not refreshed", vm.favorites.value.isEmpty())
+    }
+
+    @Test
+    fun getFolderIdsForVoicingReturnsEmptyForAnUnknownVoicing() {
+        assertTrue(vm.getFolderIdsForVoicing(0, "maj", listOf(0, 0, 0, 3)).isEmpty())
+    }
+
+    @Test
+    fun getFolderIdsForVoicingReturnsTheAssignedFolders() {
+        val folder = createFolderAndGetId("Practice")
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(folder))
+
+        assertEquals(listOf(folder), vm.getFolderIdsForVoicing(0, "maj", listOf(0, 0, 0, 3)))
+    }
+
+    // ── Save to folders ──────────────────────────────────────────────
+
+    @Test
+    fun saveFavoriteToFoldersCreatesTheVoicingAndAssignsFolders() {
+        val a = createFolderAndGetId("A")
+        val b = createFolderAndGetId("B")
+
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(a, b))
+
+        val stored = vm.favorites.value.single()
+        assertEquals("0|maj|0,0,0,3", stored.key)
+        assertEquals(setOf(a, b), stored.folderIds.toSet())
+    }
+
+    @Test
+    fun saveFavoriteToFoldersUpdatesFoldersOnAnExistingVoicing() {
+        val a = createFolderAndGetId("A")
+        val b = createFolderAndGetId("B")
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(a))
+        assertEquals(
+            listOf(a),
+            vm.favorites.value
+                .single()
+                .folderIds,
+        )
+
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(b))
+        assertEquals(
+            "reassigning must replace, not append",
+            listOf(b),
+            vm.favorites.value
+                .single()
+                .folderIds,
+        )
+    }
+
+    @Test
+    fun saveFavoriteToFoldersWithNoFoldersLeavesTheVoicingUnfiled() {
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), emptyList())
+
+        assertTrue(
+            vm.favorites.value
+                .single()
+                .folderIds
+                .isEmpty(),
+        )
+    }
+
+    @Test
+    fun saveFavoriteToFoldersDoesNotDuplicateAnExistingVoicing() {
+        val folder = createFolderAndGetId("A")
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(folder))
+
+        assertEquals(1, vm.favorites.value.size)
+    }
+
+    @Test
+    fun setFoldersReplacesTheAssignmentForAVoicing() {
+        val a = createFolderAndGetId("A")
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+
+        vm.setFolders(vm.favorites.value.single(), listOf(a))
+        assertEquals(
+            listOf(a),
+            vm.favorites.value
+                .single()
+                .folderIds,
+        )
+
+        vm.setFolders(vm.favorites.value.single(), emptyList())
+        assertTrue(
+            vm.favorites.value
+                .single()
+                .folderIds
+                .isEmpty(),
+        )
+    }
+
+    // ── Folders ──────────────────────────────────────────────────────
+
+    @Test
+    fun createRenameAndDeleteFolderRoundTripThroughTheFlow() {
+        val id = createFolderAndGetId("Practice")
+        assertEquals(listOf("Practice"), vm.folders.value.map { it.name })
+
+        vm.renameFolder(id, "Gig set")
+        assertEquals(listOf("Gig set"), vm.folders.value.map { it.name })
+
+        vm.deleteFolder(id)
+        assertTrue(vm.folders.value.isEmpty())
+    }
+
+    @Test
+    fun renameFolderOfAnUnknownIdIsANoOp() {
+        createFolderAndGetId("Practice")
+        vm.renameFolder("no-such-id", "Ignored")
+
+        assertEquals(listOf("Practice"), vm.folders.value.map { it.name })
+    }
+
+    @Test
+    fun deleteFolderStripsItsIdFromEveryVoicing() {
+        val doomed = createFolderAndGetId("Doomed")
+        val kept = createFolderAndGetId("Kept")
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(doomed, kept))
+        vm.saveFavoriteToFolders(9, "m", listOf(2, 0, 0, 0), listOf(doomed))
+
+        vm.deleteFolder(doomed)
+
+        assertTrue(
+            "no voicing may keep a dangling folder id",
+            vm.favorites.value.none { doomed in it.folderIds },
+        )
+        assertEquals(
+            listOf(kept),
+            vm.favorites.value
+                .single { it.rootPitchClass == 0 }
+                .folderIds,
+        )
+    }
+
+    @Test
+    fun deleteFolderKeepsTheVoicingsThemselves() {
+        val folder = createFolderAndGetId("Practice")
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(folder))
+
+        vm.deleteFolder(folder)
+
+        assertEquals("deleting a folder must not delete its chords", 1, vm.favorites.value.size)
+    }
+
+    @Test
+    fun foldersSurviveANewViewModelOverTheSameStorage() {
+        createFolderAndGetId("Practice")
+        assertEquals(listOf("Practice"), FavoritesViewModel(app).folders.value.map { it.name })
+    }
+
+    // ── Folder ordering ──────────────────────────────────────────────
+
+    @Test
+    fun getOrderedVoicingsReturnsEmptyForAnUnknownFolder() {
+        assertTrue(vm.getOrderedVoicings("no-such-folder").isEmpty())
+    }
+
+    @Test
+    fun getOrderedVoicingsReturnsOnlyTheFoldersOwnVoicings() {
+        val a = createFolderAndGetId("A")
+        val b = createFolderAndGetId("B")
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(a))
+        vm.saveFavoriteToFolders(9, "m", listOf(2, 0, 0, 0), listOf(b))
+
+        assertEquals(listOf("0|maj|0,0,0,3"), vm.getOrderedVoicings(a).map { it.key })
+    }
+
+    @Test
+    fun reorderInFolderDrivesGetOrderedVoicings() {
+        val folder = createFolderAndGetId("Practice")
+        vm.saveFavoriteToFolders(0, "maj", listOf(0, 0, 0, 3), listOf(folder))
+        vm.saveFavoriteToFolders(9, "m", listOf(2, 0, 0, 0), listOf(folder))
+        vm.saveFavoriteToFolders(5, "maj", listOf(2, 0, 1, 0), listOf(folder))
+
+        val desired = listOf("9|m|2,0,0,0", "5|maj|2,0,1,0", "0|maj|0,0,0,3")
+        vm.reorderInFolder(folder, desired)
+
+        assertEquals(desired, vm.getOrderedVoicings(folder).map { it.key })
+    }
+
+    @Test
+    fun getOrderedVoicingsPutsUnorderedVoicingsLastNewestFirst() {
+        val folder = createFolderAndGetId("Practice")
+        seed(voicing(0, "maj", listOf(0, 0, 0, 3), addedAt = 1_000L))
+        seed(voicing(9, "m", listOf(2, 0, 0, 0), addedAt = 2_000L))
+        seed(voicing(5, "maj", listOf(2, 0, 1, 0), addedAt = 3_000L))
+
+        val fresh = FavoritesViewModel(app)
+        fresh.favorites.value.forEach { fresh.setFolders(it, listOf(folder)) }
+        fresh.reorderInFolder(folder, listOf("0|maj|0,0,0,3"))
+
+        assertEquals(
+            listOf("0|maj|0,0,0,3", "5|maj|2,0,1,0", "9|m|2,0,0,0"),
+            fresh.getOrderedVoicings(folder).map { it.key },
+        )
+    }
+
+    // ── Voicing conversion ───────────────────────────────────────────
+
+    @Test
+    fun toChordVoicingResolvesNotesForHighG() {
+        vm.addFavorite(0, "maj", listOf(0, 0, 0, 3))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.HIGH_G))
+
+        // G C E A with the A string at fret 3 sounds G C E C.
+        assertEquals(listOf(7, 0, 4, 0), chord.notes.map { it?.pitchClass })
+        assertEquals(listOf("G", "C", "E", "C"), chord.notes.map { it?.name })
+    }
+
+    @Test
+    fun toChordVoicingResolvesNotesForBaritone() {
+        // The testing guide asks for both-tuning coverage on chord logic. High-G
+        // and Low-G share pitch classes, so baritone is the tuning that actually
+        // exercises a different mapping.
+        vm.addFavorite(2, "maj", listOf(0, 0, 0, 0))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.BARITONE))
+
+        assertEquals(listOf(2, 7, 11, 4), chord.notes.map { it?.pitchClass })
+    }
+
+    @Test
+    fun toChordVoicingMapsMutedStringsToNullNotes() {
+        vm.addFavorite(0, "maj", listOf(ChordVoicing.MUTED, 0, 0, 3))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.HIGH_G))
+
+        assertNull("a muted string has no note", chord.notes.first())
+        assertEquals(listOf(0, 4, 0), chord.notes.drop(1).map { it?.pitchClass })
+    }
+
+    @Test
+    fun toChordVoicingReportsTheFrettedRangeIgnoringOpenStrings() {
+        vm.addFavorite(0, "maj", listOf(5, 4, 3, 0))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.HIGH_G))
+
+        assertEquals(3, chord.minFret)
+        assertEquals(5, chord.maxFret)
+    }
+
+    @Test
+    fun toChordVoicingReportsZeroFretRangeForAnAllOpenShape() {
+        vm.addFavorite(7, "maj", listOf(0, 0, 0, 0))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.HIGH_G))
+
+        assertEquals("an open shape has no fretted range", 0, chord.minFret)
+        assertEquals(0, chord.maxFret)
+    }
+
+    @Test
+    fun toChordVoicingPreservesTheOriginalFrets() {
+        vm.addFavorite(0, "m7", listOf(0, 2, 3, 3))
+        val chord = vm.toChordVoicing(vm.favorites.value.single(), tuningOf(UkuleleTuning.HIGH_G))
+
+        assertEquals(listOf(0, 2, 3, 3), chord.frets)
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/LegacySettingsReaderTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/LegacySettingsReaderTest.kt
@@ -1,0 +1,282 @@
+package com.baijum.ukufretboard.viewmodel
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import com.baijum.ukufretboard.data.AppSettings
+import com.baijum.ukufretboard.data.ChordColorOption
+import com.baijum.ukufretboard.data.ChordDisplayStyle
+import com.baijum.ukufretboard.data.FretboardSettings
+import com.baijum.ukufretboard.data.PitchMonitorSettings
+import com.baijum.ukufretboard.data.ScalePracticeSettings
+import com.baijum.ukufretboard.data.SoundSettings
+import com.baijum.ukufretboard.data.ThemeMode
+import com.baijum.ukufretboard.data.TunerSettings
+import com.baijum.ukufretboard.data.UkuleleTuning
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [LegacySettingsReader], the one-shot migration from the pre-JSON
+ * per-key preference layout.
+ *
+ * Every key name below is deliberately spelled out rather than read from the
+ * reader. They are an on-disk contract with installs that predate `settings_json`,
+ * and the duplicated list is what makes `removeLegacyKeysRemovesEveryKeyThatReadConsumes`
+ * able to catch a key added to `read` but forgotten in the private `LEGACY_KEYS`.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LegacySettingsReaderTest {
+    private lateinit var prefs: SharedPreferences
+
+    @Before
+    fun setUp() {
+        val app: Application = ApplicationProvider.getApplicationContext()
+        prefs = app.getSharedPreferences("legacy_settings_reader_test", Context.MODE_PRIVATE)
+    }
+
+    private fun put(build: SharedPreferences.Editor.() -> Unit) {
+        prefs.edit().apply(build).commit()
+    }
+
+    /** Every key `read` consumes, each set to a non-default value. */
+    private fun seedAllLegacyKeys() =
+        put {
+            putBoolean("sound_enabled", false)
+            putFloat("sound_volume", 0.25f)
+            putInt("note_duration_ms", 900)
+            putInt("strum_delay_ms", 120)
+            putBoolean("strum_down", false)
+            putBoolean("play_on_tap", true)
+            putFloat("pm_noise_gate_filtering", 0.4f)
+            putString("theme_mode", "HIGH_CONTRAST")
+            putBoolean("show_explorer_tips", false)
+            putBoolean("show_learn_section", false)
+            putBoolean("show_reference_section", false)
+            putString("chord_display_style", "INLINE")
+            putString("chord_color", "PURPLE")
+            putBoolean("show_chord_diagram_rail", false)
+            putString("tuning", "BARITONE")
+            putBoolean("left_handed", true)
+            putInt("last_fret", 18)
+            putBoolean("show_note_names", false)
+            putBoolean("allow_muted_strings", true)
+            putInt("scale_practice_root", 9)
+            putString("scale_practice_scale", "Dorian")
+            putString("scale_practice_category", "Modes")
+            putInt("scale_practice_bpm", 140)
+            putInt("scale_practice_mode", 2)
+            putBoolean("scale_practice_fretboard", true)
+            putInt("scale_practice_direction", 1)
+            putBoolean("scale_practice_loop", true)
+            putInt("scale_practice_fret_position", 3)
+            putBoolean("tuner_spoken_feedback", true)
+            putBoolean("tuner_precision_mode", true)
+            putFloat("tuner_a4_reference", 432f)
+            putBoolean("tuner_auto_advance", true)
+            putBoolean("tuner_auto_start", true)
+            putBoolean("onboarding_completed", false)
+            putBoolean("explorer_tips_dismissed", false)
+        }
+
+    // ── Defaults ─────────────────────────────────────────────────────
+
+    @Test
+    fun readOnEmptyPrefsReturnsThePerKeyDefaults() {
+        val settings = LegacySettingsReader.read(prefs)
+
+        assertEquals(SoundSettings(), settings.sound)
+        assertEquals(FretboardSettings(), settings.fretboard)
+        assertEquals(ScalePracticeSettings(), settings.scalePractice)
+        assertEquals(TunerSettings(), settings.tuner)
+    }
+
+    @Test
+    fun aMigratingInstallIsTreatedAsHavingSeenOnboarding() {
+        // Deliberately the opposite of AppSettings()'s defaults: someone upgrading
+        // from the legacy layout has already been through onboarding and the tips.
+        val settings = LegacySettingsReader.read(prefs)
+
+        assertTrue("a legacy install must not be shown onboarding again", settings.onboardingCompleted)
+        assertTrue("a legacy install must not be shown explorer tips again", settings.explorerTipsDismissed)
+        assertFalse("a fresh install still sees onboarding", AppSettings().onboardingCompleted)
+    }
+
+    @Test
+    fun pitchMonitorSectionIsAlwaysTheDefault() {
+        // The noise gate moved to SoundSettings; nothing legacy feeds this section.
+        seedAllLegacyKeys()
+        assertEquals(PitchMonitorSettings(), LegacySettingsReader.read(prefs).pitchMonitor)
+    }
+
+    // ── Key mapping ──────────────────────────────────────────────────
+
+    @Test
+    fun readMapsEverySoundKey() {
+        seedAllLegacyKeys()
+        val sound = LegacySettingsReader.read(prefs).sound
+
+        assertFalse(sound.enabled)
+        assertEquals(0.25f, sound.volume, 1e-6f)
+        assertEquals(900, sound.noteDurationMs)
+        assertEquals(120, sound.strumDelayMs)
+        assertFalse(sound.strumDown)
+        assertTrue(sound.playOnTap)
+    }
+
+    @Test
+    fun noiseGateFilteringIsReadFromThePitchMonitorKey() {
+        // The setting moved from the Pitch Monitor section to Sound, but the
+        // legacy key name did not move with it.
+        put { putFloat("pm_noise_gate_filtering", 0.4f) }
+        assertEquals(0.4f, LegacySettingsReader.read(prefs).sound.noiseGateFiltering, 1e-6f)
+    }
+
+    @Test
+    fun readMapsEveryDisplayKey() {
+        seedAllLegacyKeys()
+        val display = LegacySettingsReader.read(prefs).display
+
+        assertEquals(ThemeMode.HIGH_CONTRAST, display.themeMode)
+        assertFalse(display.showExplorerTips)
+        assertFalse(display.showLearnSection)
+        assertFalse(display.showReferenceSection)
+        assertEquals(ChordDisplayStyle.INLINE, display.chordDisplayStyle)
+        assertEquals(ChordColorOption.PURPLE, display.chordColor)
+        assertFalse(display.showChordDiagramRail)
+    }
+
+    @Test
+    fun readMapsTheTuningKey() {
+        seedAllLegacyKeys()
+        assertEquals(UkuleleTuning.BARITONE, LegacySettingsReader.read(prefs).tuning.tuning)
+    }
+
+    @Test
+    fun readMapsEveryFretboardKey() {
+        seedAllLegacyKeys()
+        val fretboard = LegacySettingsReader.read(prefs).fretboard
+
+        assertTrue(fretboard.leftHanded)
+        assertEquals(18, fretboard.lastFret)
+        assertFalse(fretboard.showNoteNames)
+        assertTrue(fretboard.allowMutedStrings)
+    }
+
+    @Test
+    fun readMapsEveryScalePracticeKey() {
+        seedAllLegacyKeys()
+        val scale = LegacySettingsReader.read(prefs).scalePractice
+
+        assertEquals(9, scale.lastRoot)
+        assertEquals("Dorian", scale.lastScaleName)
+        assertEquals("Modes", scale.lastCategory)
+        assertEquals(140, scale.lastBpm)
+        assertEquals(2, scale.lastMode)
+        assertTrue(scale.showFretboard)
+        assertEquals(1, scale.lastDirection)
+        assertTrue(scale.loopPlayback)
+        assertEquals(3, scale.lastFretPosition)
+    }
+
+    @Test
+    fun readMapsEveryTunerKey() {
+        seedAllLegacyKeys()
+        val tuner = LegacySettingsReader.read(prefs).tuner
+
+        assertTrue(tuner.spokenFeedback)
+        assertTrue(tuner.precisionMode)
+        assertEquals(432f, tuner.a4Reference, 1e-6f)
+        assertTrue(tuner.autoAdvance)
+        assertTrue(tuner.autoStart)
+    }
+
+    @Test
+    fun readMapsTheOnboardingFlags() {
+        seedAllLegacyKeys()
+        val settings = LegacySettingsReader.read(prefs)
+
+        assertFalse(settings.onboardingCompleted)
+        assertFalse(settings.explorerTipsDismissed)
+    }
+
+    // ── Enum parsing ─────────────────────────────────────────────────
+
+    @Test
+    fun enumsAreReadByNameNotByLabel() {
+        put { putString("theme_mode", ThemeMode.HIGH_CONTRAST.label) }
+        assertEquals(
+            "the human-readable label must not be accepted as a stored value",
+            ThemeMode.SYSTEM,
+            LegacySettingsReader.read(prefs).display.themeMode,
+        )
+    }
+
+    @Test
+    fun unknownEnumNamesFallBackToTheSectionDefault() {
+        put {
+            putString("theme_mode", "NEON")
+            putString("chord_display_style", "SIDEWAYS")
+            putString("chord_color", "CHARTREUSE")
+            putString("tuning", "KLINGON")
+        }
+        val settings = LegacySettingsReader.read(prefs)
+
+        assertEquals(ThemeMode.SYSTEM, settings.display.themeMode)
+        assertEquals(ChordDisplayStyle.ABOVE, settings.display.chordDisplayStyle)
+        assertEquals(ChordColorOption.THEME, settings.display.chordColor)
+        assertEquals(UkuleleTuning.HIGH_G, settings.tuning.tuning)
+    }
+
+    @Test
+    fun blankEnumStringFallsBackToTheDefault() {
+        put { putString("theme_mode", "") }
+        assertEquals(ThemeMode.SYSTEM, LegacySettingsReader.read(prefs).display.themeMode)
+    }
+
+    @Test
+    fun missingScaleNameFallsBackToMajor() {
+        assertEquals("Major", LegacySettingsReader.read(prefs).scalePractice.lastScaleName)
+        assertEquals("", LegacySettingsReader.read(prefs).scalePractice.lastCategory)
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────
+
+    @Test
+    fun removeLegacyKeysRemovesEveryKeyThatReadConsumes() {
+        // If `read` gains a key that `LEGACY_KEYS` does not list, that key
+        // survives the migration and leaks stale data forever. The seed list
+        // above is the independent copy that makes this detectable.
+        seedAllLegacyKeys()
+        assertTrue("the seed did not write anything", prefs.all.isNotEmpty())
+
+        LegacySettingsReader.removeLegacyKeys(prefs)
+
+        assertTrue(
+            "these legacy keys survived the migration: ${prefs.all.keys}",
+            prefs.all.isEmpty(),
+        )
+    }
+
+    @Test
+    fun removeLegacyKeysLeavesUnrelatedKeysIntact() {
+        seedAllLegacyKeys()
+        put { putString("settings_json", "{}") }
+
+        LegacySettingsReader.removeLegacyKeys(prefs)
+
+        assertEquals(setOf("settings_json"), prefs.all.keys)
+    }
+
+    @Test
+    fun removeLegacyKeysOnEmptyPrefsIsANoOp() {
+        LegacySettingsReader.removeLegacyKeys(prefs)
+        assertTrue(prefs.all.isEmpty())
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SetlistViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SetlistViewModelTest.kt
@@ -1,0 +1,275 @@
+package com.baijum.ukufretboard.viewmodel
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [SetlistViewModel].
+ *
+ * The interesting part is the `currentSetlist` bookkeeping: every mutation has to
+ * refresh the open setlist when it is the one being changed, and leave it alone
+ * when it is not. A stale `currentSetlist` shows the user a setlist that no longer
+ * matches what was saved.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SetlistViewModelTest {
+    private lateinit var app: Application
+    private lateinit var vm: SetlistViewModel
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        vm = SetlistViewModel(app)
+    }
+
+    private fun createAndGetId(name: String): String {
+        vm.create(name)
+        return vm.setlists.value
+            .single { it.name == name }
+            .id
+    }
+
+    private fun songIdsOf(id: String) =
+        vm.setlists.value
+            .single { it.id == id }
+            .songIds
+
+    // ── Create, rename, delete ───────────────────────────────────────
+
+    @Test
+    fun createAddsTheSetlistToTheFlow() {
+        vm.create("Beach gig")
+        assertEquals(listOf("Beach gig"), vm.setlists.value.map { it.name })
+    }
+
+    @Test
+    fun newestSetlistsComeFirst() {
+        vm.create("First")
+        vm.create("Second")
+        assertEquals(listOf("Second", "First"), vm.setlists.value.map { it.name })
+    }
+
+    @Test
+    fun setlistsSurviveANewViewModelOverTheSameStorage() {
+        vm.create("Persisted")
+        assertEquals(listOf("Persisted"), SetlistViewModel(app).setlists.value.map { it.name })
+    }
+
+    @Test
+    fun renameUpdatesTheStoredSetlist() {
+        val id = createAndGetId("Old name")
+        vm.rename(id, "New name")
+
+        assertEquals(listOf("New name"), vm.setlists.value.map { it.name })
+        assertEquals(
+            "New name",
+            SetlistViewModel(app)
+                .setlists.value
+                .single()
+                .name,
+        )
+    }
+
+    @Test
+    fun renameOfAnUnknownIdIsANoOp() {
+        createAndGetId("Kept")
+        vm.rename("no-such-id", "Ignored")
+        assertEquals(listOf("Kept"), vm.setlists.value.map { it.name })
+    }
+
+    @Test
+    fun renameBumpsUpdatedAt() {
+        val id = createAndGetId("Gig")
+        val before =
+            vm.setlists.value
+                .single()
+                .updatedAt
+        vm.rename(id, "Gig v2")
+        assertTrue(
+            "updatedAt should not go backwards",
+            vm.setlists.value
+                .single()
+                .updatedAt >= before,
+        )
+    }
+
+    @Test
+    fun deleteRemovesTheSetlist() {
+        val id = createAndGetId("Doomed")
+        createAndGetId("Kept")
+        vm.delete(id)
+        assertEquals(listOf("Kept"), vm.setlists.value.map { it.name })
+    }
+
+    @Test
+    fun deleteOfAnUnknownIdLeavesTheListIntact() {
+        createAndGetId("Kept")
+        vm.delete("no-such-id")
+        assertEquals(1, vm.setlists.value.size)
+    }
+
+    // ── Open setlist bookkeeping ─────────────────────────────────────
+
+    @Test
+    fun openThenCloseClearsTheCurrentSetlist() {
+        val id = createAndGetId("Gig")
+        vm.open(vm.setlists.value.single { it.id == id })
+        assertNotNull(vm.currentSetlist.value)
+
+        vm.close()
+        assertNull(vm.currentSetlist.value)
+    }
+
+    @Test
+    fun renameRefreshesTheOpenSetlistWhenItIsTheOneRenamed() {
+        val id = createAndGetId("Old name")
+        vm.open(vm.setlists.value.single { it.id == id })
+        vm.rename(id, "New name")
+
+        assertEquals("the open setlist must not go stale", "New name", vm.currentSetlist.value?.name)
+    }
+
+    @Test
+    fun renameLeavesADifferentOpenSetlistAlone() {
+        val open = createAndGetId("Open one")
+        val other = createAndGetId("Other one")
+        vm.open(vm.setlists.value.single { it.id == open })
+        vm.rename(other, "Renamed")
+
+        assertEquals("Open one", vm.currentSetlist.value?.name)
+    }
+
+    @Test
+    fun deleteClosesTheSetlistWhenItWasTheOpenOne() {
+        val id = createAndGetId("Doomed")
+        vm.open(vm.setlists.value.single { it.id == id })
+        vm.delete(id)
+
+        assertNull("deleting the open setlist must close it", vm.currentSetlist.value)
+    }
+
+    @Test
+    fun deleteLeavesADifferentOpenSetlistAlone() {
+        val open = createAndGetId("Open one")
+        val other = createAndGetId("Other one")
+        vm.open(vm.setlists.value.single { it.id == open })
+        vm.delete(other)
+
+        assertEquals("Open one", vm.currentSetlist.value?.name)
+    }
+
+    // ── Songs ────────────────────────────────────────────────────────
+
+    @Test
+    fun addSongAppendsToTheEnd() {
+        val id = createAndGetId("Gig")
+        vm.addSong(id, "song-a")
+        vm.addSong(id, "song-b")
+
+        assertEquals(listOf("song-a", "song-b"), songIdsOf(id))
+    }
+
+    @Test
+    fun addSongIgnoresADuplicateSongId() {
+        val id = createAndGetId("Gig")
+        vm.addSong(id, "song-a")
+        vm.addSong(id, "song-a")
+
+        assertEquals(listOf("song-a"), songIdsOf(id))
+    }
+
+    @Test
+    fun addSongToAnUnknownSetlistIsANoOp() {
+        val id = createAndGetId("Gig")
+        vm.addSong("no-such-id", "song-a")
+        assertTrue(songIdsOf(id).isEmpty())
+    }
+
+    @Test
+    fun removeSongDropsTheSongAndKeepsTheRest() {
+        val id = createAndGetId("Gig")
+        listOf("a", "b", "c").forEach { vm.addSong(id, it) }
+        vm.removeSong(id, "b")
+
+        assertEquals(listOf("a", "c"), songIdsOf(id))
+    }
+
+    @Test
+    fun removeSongOfAnAbsentSongIsANoOp() {
+        val id = createAndGetId("Gig")
+        vm.addSong(id, "a")
+        vm.removeSong(id, "not-there")
+
+        assertEquals(listOf("a"), songIdsOf(id))
+    }
+
+    @Test
+    fun moveSongReordersTheSongList() {
+        val id = createAndGetId("Gig")
+        listOf("a", "b", "c").forEach { vm.addSong(id, it) }
+
+        vm.moveSong(id, fromIndex = 0, toIndex = 2)
+        assertEquals(listOf("b", "c", "a"), songIdsOf(id))
+
+        vm.moveSong(id, fromIndex = 2, toIndex = 0)
+        assertEquals(listOf("a", "b", "c"), songIdsOf(id))
+    }
+
+    @Test
+    fun moveSongIgnoresOutOfRangeIndices() {
+        val id = createAndGetId("Gig")
+        listOf("a", "b").forEach { vm.addSong(id, it) }
+
+        vm.moveSong(id, fromIndex = -1, toIndex = 0)
+        vm.moveSong(id, fromIndex = 0, toIndex = 5)
+        vm.moveSong(id, fromIndex = 9, toIndex = 9)
+
+        assertEquals(listOf("a", "b"), songIdsOf(id))
+    }
+
+    @Test
+    fun moveSongOnAnEmptySetlistIsANoOp() {
+        val id = createAndGetId("Gig")
+        vm.moveSong(id, fromIndex = 0, toIndex = 0)
+        assertTrue(songIdsOf(id).isEmpty())
+    }
+
+    @Test
+    fun songMutationsKeepTheOpenSetlistInSync() {
+        val id = createAndGetId("Gig")
+        vm.open(vm.setlists.value.single { it.id == id })
+
+        vm.addSong(id, "a")
+        assertEquals(listOf("a"), vm.currentSetlist.value?.songIds)
+
+        vm.addSong(id, "b")
+        vm.moveSong(id, fromIndex = 0, toIndex = 1)
+        assertEquals(listOf("b", "a"), vm.currentSetlist.value?.songIds)
+
+        vm.removeSong(id, "b")
+        assertEquals(listOf("a"), vm.currentSetlist.value?.songIds)
+    }
+
+    @Test
+    fun songMutationsOnAnotherSetlistLeaveTheOpenOneAlone() {
+        val open = createAndGetId("Open one")
+        val other = createAndGetId("Other one")
+        vm.open(vm.setlists.value.single { it.id == open })
+
+        vm.addSong(other, "a")
+        assertTrue(
+            "the open setlist should be untouched",
+            vm.currentSetlist.value
+                ?.songIds
+                ?.isEmpty() == true,
+        )
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
@@ -1,0 +1,314 @@
+package com.baijum.ukufretboard.viewmodel
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import com.baijum.ukufretboard.data.AppSettings
+import com.baijum.ukufretboard.data.ChordColorOption
+import com.baijum.ukufretboard.data.SoundSettings
+import com.baijum.ukufretboard.data.ThemeMode
+import com.baijum.ukufretboard.data.TuningSettings
+import com.baijum.ukufretboard.data.UkuleleTuning
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [SettingsViewModel].
+ *
+ * `loadSettings()` runs in a property initializer, so every test seeds the
+ * preferences *before* constructing the ViewModel, and reads back through a
+ * second instance when it needs to prove something was persisted rather than
+ * merely held in the StateFlow.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SettingsViewModelTest {
+    private lateinit var app: Application
+    private lateinit var prefs: SharedPreferences
+
+    @Before
+    fun setUp() {
+        app = ApplicationProvider.getApplicationContext()
+        prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    private fun newViewModel() = SettingsViewModel(app)
+
+    private fun storedJson(): String? = prefs.getString(KEY_SETTINGS, null)
+
+    private fun writeRaw(
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    // ── First run ────────────────────────────────────────────────────
+
+    @Test
+    fun defaultsAreUsedOnAFirstRunWithNoStoredData() {
+        assertEquals(AppSettings(), newViewModel().settings.value)
+    }
+
+    @Test
+    fun afirstRunDoesNotWriteAnythingUntilSomethingChanges() {
+        newViewModel()
+        assertNull("constructing the ViewModel should not persist defaults", storedJson())
+    }
+
+    // ── Section updates ──────────────────────────────────────────────
+
+    @Test
+    fun updateSoundPersistsAndLeavesOtherSectionsUntouched() {
+        val vm = newViewModel()
+        vm.updateSound { it.copy(enabled = false, volume = 0.3f) }
+
+        assertFalse(vm.settings.value.sound.enabled)
+        assertEquals(0.3f, vm.settings.value.sound.volume, 1e-6f)
+        assertEquals("other sections must not move", AppSettings().display, vm.settings.value.display)
+        assertEquals(AppSettings().tuner, vm.settings.value.tuner)
+    }
+
+    @Test
+    fun everySectionUpdaterPersistsAcrossViewModelInstances() {
+        val vm = newViewModel()
+        vm.updateSound { it.copy(noteDurationMs = 900) }
+        vm.updateDisplay { it.copy(themeMode = ThemeMode.HIGH_CONTRAST, chordColor = ChordColorOption.BLUE) }
+        vm.updateTuning { it.copy(tuning = UkuleleTuning.BARITONE) }
+        vm.updateFretboard { it.copy(leftHanded = true, lastFret = 18) }
+        vm.updateScalePractice { it.copy(lastBpm = 140, lastScaleName = "Dorian") }
+        vm.updateTuner { it.copy(spokenFeedback = true, a4Reference = 432f) }
+        vm.updatePitchMonitor { it.copy(placeholder = true) }
+
+        val reloaded = newViewModel().settings.value
+        assertEquals(900, reloaded.sound.noteDurationMs)
+        assertEquals(ThemeMode.HIGH_CONTRAST, reloaded.display.themeMode)
+        assertEquals(ChordColorOption.BLUE, reloaded.display.chordColor)
+        assertEquals(UkuleleTuning.BARITONE, reloaded.tuning.tuning)
+        assertTrue(reloaded.fretboard.leftHanded)
+        assertEquals(18, reloaded.fretboard.lastFret)
+        assertEquals(140, reloaded.scalePractice.lastBpm)
+        assertEquals("Dorian", reloaded.scalePractice.lastScaleName)
+        assertTrue(reloaded.tuner.spokenFeedback)
+        assertEquals(432f, reloaded.tuner.a4Reference, 1e-6f)
+        assertTrue(reloaded.pitchMonitor.placeholder)
+    }
+
+    @Test
+    fun theUpdaterReceivesTheCurrentSectionNotTheDefaultOne() {
+        val vm = newViewModel()
+        vm.updateSound { it.copy(volume = 0.5f) }
+        vm.updateSound { it.copy(noteDurationMs = 800) }
+
+        assertEquals("the second update must build on the first", 0.5f, vm.settings.value.sound.volume, 1e-6f)
+        assertEquals(800, vm.settings.value.sound.noteDurationMs)
+    }
+
+    // ── One-shot flags ───────────────────────────────────────────────
+
+    @Test
+    fun completeOnboardingPersistsAndIsIdempotent() {
+        val vm = newViewModel()
+        vm.completeOnboarding()
+        vm.completeOnboarding()
+
+        assertTrue(vm.settings.value.onboardingCompleted)
+        assertTrue(newViewModel().settings.value.onboardingCompleted)
+    }
+
+    @Test
+    fun dismissExplorerTipsPersists() {
+        newViewModel().dismissExplorerTips()
+        assertTrue(newViewModel().settings.value.explorerTipsDismissed)
+    }
+
+    // ── Restore and export ───────────────────────────────────────────
+
+    @Test
+    fun replaceAllOverwritesEverySectionAndPersists() {
+        val vm = newViewModel()
+        vm.updateSound { it.copy(volume = 0.1f) }
+
+        val restored =
+            AppSettings(
+                sound = SoundSettings(enabled = false, volume = 0.9f),
+                tuning = TuningSettings(UkuleleTuning.LOW_G),
+                onboardingCompleted = true,
+            )
+        vm.replaceAll(restored)
+
+        assertEquals(restored, vm.settings.value)
+        assertEquals("replaceAll must persist, not just publish", restored, newViewModel().settings.value)
+    }
+
+    @Test
+    fun exportSettingsReflectsTheLatestUpdate() {
+        val vm = newViewModel()
+        vm.updateFretboard { it.copy(lastFret = 20) }
+        assertEquals(20, vm.exportSettings().fretboard.lastFret)
+        assertEquals(vm.settings.value, vm.exportSettings())
+    }
+
+    // ── Stored payload ───────────────────────────────────────────────
+
+    @Test
+    fun prefsFileAndKeyNameAreTheOnDiskContract() {
+        newViewModel().updateSound { it.copy(enabled = false) }
+        assertNotNull("settings must persist under settings_json in app_settings", storedJson())
+    }
+
+    @Test
+    fun storedJsonUsesEnumNamesNotLabels() {
+        val vm = newViewModel()
+        vm.updateDisplay { it.copy(themeMode = ThemeMode.HIGH_CONTRAST) }
+        vm.updateTuning { it.copy(tuning = UkuleleTuning.BARITONE) }
+
+        val raw = storedJson().orEmpty()
+        assertTrue("expected the enum name in $raw", raw.contains("HIGH_CONTRAST"))
+        assertTrue("expected the enum name in $raw", raw.contains("BARITONE"))
+        assertFalse("labels must not reach the disk", raw.contains("High Contrast"))
+    }
+
+    @Test
+    fun unknownKeysInStoredJsonAreIgnored() {
+        // Forward compatibility with a newer version, and with an iOS-authored backup.
+        writeRaw(KEY_SETTINGS, """{"sound":{"enabled":false},"aFieldFromTheFuture":42}""")
+        assertFalse(
+            newViewModel()
+                .settings.value.sound.enabled,
+        )
+    }
+
+    @Test
+    fun partialStoredJsonFillsMissingSectionsWithDefaults() {
+        writeRaw(KEY_SETTINGS, """{"fretboard":{"lastFret":22}}""")
+        val settings = newViewModel().settings.value
+
+        assertEquals(22, settings.fretboard.lastFret)
+        assertEquals(AppSettings().sound, settings.sound)
+        assertEquals(AppSettings().display, settings.display)
+    }
+
+    @Test
+    fun corruptSettingsJsonSilentlyResetsToDefaults() {
+        // Pinned weakness: unlike every JsonListRepository, settings have no
+        // backup or quarantine key, so a single bad write loses every preference
+        // with no way to recover it.
+        writeRaw(KEY_SETTINGS, "}} not json {{")
+        assertEquals(
+            "today a corrupt payload resets to defaults",
+            AppSettings(),
+            newViewModel().settings.value,
+        )
+    }
+
+    @Test
+    fun aCorruptPayloadIsOverwrittenByTheNextUpdate() {
+        writeRaw(KEY_SETTINGS, "}} not json {{")
+        val vm = newViewModel()
+        vm.updateSound { it.copy(enabled = false) }
+
+        assertFalse(
+            newViewModel()
+                .settings.value.sound.enabled,
+        )
+    }
+
+    // ── Legacy migration ─────────────────────────────────────────────
+
+    @Test
+    fun legacyMigrationRunsWhenTheSoundEnabledKeyIsPresent() {
+        prefs
+            .edit()
+            .putBoolean("sound_enabled", false)
+            .putString("theme_mode", "DARK")
+            .putString("tuning", "BARITONE")
+            .commit()
+
+        val settings = newViewModel().settings.value
+        assertFalse(settings.sound.enabled)
+        assertEquals(ThemeMode.DARK, settings.display.themeMode)
+        assertEquals(UkuleleTuning.BARITONE, settings.tuning.tuning)
+    }
+
+    @Test
+    fun legacyMigrationWritesSettingsJsonAndRemovesTheLegacyKeys() {
+        prefs
+            .edit()
+            .putBoolean("sound_enabled", false)
+            .putString("theme_mode", "DARK")
+            .commit()
+        newViewModel()
+
+        assertNotNull("the migration should write the JSON payload", storedJson())
+        assertNull("legacy keys should be consumed", prefs.getString("theme_mode", null))
+        assertFalse("legacy keys should be consumed", prefs.contains("sound_enabled"))
+    }
+
+    @Test
+    fun legacyMigrationDoesNotRunASecondTime() {
+        prefs.edit().putBoolean("sound_enabled", false).commit()
+        newViewModel()
+
+        val afterMigration = storedJson()
+        val second = newViewModel()
+        assertEquals("the JSON payload should be reused as-is", afterMigration, storedJson())
+        assertFalse(second.settings.value.sound.enabled)
+    }
+
+    @Test
+    fun legacyMigrationMarksOnboardingAsAlreadyCompleted() {
+        prefs.edit().putBoolean("sound_enabled", true).commit()
+        val settings = newViewModel().settings.value
+
+        assertTrue("an upgrading user must not be shown onboarding", settings.onboardingCompleted)
+        assertTrue(settings.explorerTipsDismissed)
+    }
+
+    @Test
+    fun legacyMigrationIsSkippedWhenSoundEnabledIsAbsentEvenThoughOtherLegacyKeysExist() {
+        // Pinned weakness: migration is gated on one unrelated key. A legacy user
+        // who customised only their theme, tuning or fretboard — and never toggled
+        // sound — silently loses all of it on upgrade.
+        prefs
+            .edit()
+            .putString("theme_mode", "DARK")
+            .putString("tuning", "BARITONE")
+            .putBoolean("left_handed", true)
+            .commit()
+
+        val settings = newViewModel().settings.value
+        assertEquals(
+            "today a theme-only legacy install is not migrated",
+            ThemeMode.SYSTEM,
+            settings.display.themeMode,
+        )
+        assertEquals(UkuleleTuning.HIGH_G, settings.tuning.tuning)
+        assertFalse(settings.fretboard.leftHanded)
+        assertTrue("and the orphaned keys are left behind", prefs.contains("theme_mode"))
+    }
+
+    @Test
+    fun storedJsonWinsOverLegacyKeys() {
+        prefs.edit().putBoolean("sound_enabled", false).commit()
+        writeRaw(KEY_SETTINGS, """{"sound":{"enabled":true}}""")
+
+        assertTrue(
+            "the JSON payload is authoritative",
+            newViewModel()
+                .settings.value.sound.enabled,
+        )
+    }
+
+    private companion object {
+        const val PREFS_NAME = "app_settings"
+        const val KEY_SETTINGS = "settings_json"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/AppSettings.kt
@@ -126,7 +126,7 @@ enum class UkuleleTuning(
 ) {
     HIGH_G("High-G (Standard)", listOf("G", "C", "E", "A"), listOf(7, 0, 4, 9), listOf(4, 4, 4, 4)),
     LOW_G("Low-G", listOf("g", "C", "E", "A"), listOf(7, 0, 4, 9), listOf(3, 4, 4, 4)),
-    BARITONE("Baritone (DGBE)", listOf("D", "G", "B", "E"), listOf(2, 7, 11, 4), listOf(3, 3, 4, 4)),
+    BARITONE("Baritone (DGBE)", listOf("D", "G", "B", "E"), listOf(2, 7, 11, 4), listOf(3, 3, 3, 4)),
     D_TUNING("D-Tuning (ADF#B)", listOf("A", "D", "F#", "B"), listOf(9, 2, 6, 11), listOf(4, 4, 4, 4)),
     SLACK_KEY("Slack Key (GCEG)", listOf("G", "C", "E", "G"), listOf(7, 0, 4, 7), listOf(4, 4, 4, 4)),
     OPEN_A("Open A (AC#EA)", listOf("A", "C#", "E", "A"), listOf(9, 1, 4, 9), listOf(4, 4, 4, 4)),

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordSubstitutions.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/ChordSubstitutions.kt
@@ -50,7 +50,7 @@ object ChordSubstitutions {
             substitutions = listOf(
                 Substitution("I", "iii", "E and G", "C \u2192 Em (both contain E and G)"),
                 Substitution("I", "vi", "C and E", "C \u2192 Am (both contain C and E)"),
-                Substitution("IV", "ii", "D and F", "F \u2192 Dm (both contain D and F)"),
+                Substitution("IV", "ii", "F and A", "F \u2192 Dm (both contain F and A)"),
                 Substitution("V", "vii\u00B0", "B and D", "G \u2192 Bdim (both contain B and D)"),
             ),
         ),
@@ -62,8 +62,8 @@ object ChordSubstitutions {
                 "it always works because the chords are so closely related.",
             substitutions = listOf(
                 Substitution("I (C)", "vi (Am)", "C and E", "Replace C with Am for a darker feel"),
-                Substitution("IV (F)", "ii (Dm)", "D and F", "Replace F with Dm for a softer sound"),
-                Substitution("V (G)", "iii (Em)", "E and G", "Replace G with Em (less common, more subtle)"),
+                Substitution("IV (F)", "ii (Dm)", "F and A", "Replace F with Dm for a softer sound"),
+                Substitution("V (G)", "iii (Em)", "G and B", "Replace G with Em (less common, more subtle)"),
             ),
         ),
         SubstitutionCategory(

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/AppSettingsTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/AppSettingsTest.kt
@@ -214,7 +214,6 @@ class AppSettingsTest {
     }
 
     @Test
-    @Ignore // Enabled by "Fix: Correct the baritone B string octave".
     fun everyTuningStringMatchesItsScientificPitch() {
         // Expected MIDI numbers, spelled out from each tuning's documented note names.
         val expected =
@@ -234,7 +233,6 @@ class AppSettingsTest {
     }
 
     @Test
-    @Ignore // Enabled by "Fix: Correct the baritone B string octave".
     fun baritoneIsALinearTuningNotAReentrantOne() {
         // Baritone DGBE ascends D3 G3 B3 E4 like a guitar's top four strings.
         assertFalse(UkuleleTuning.BARITONE.isReentrant, "baritone tuning ascends linearly")

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/AppSettingsTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/AppSettingsTest.kt
@@ -1,0 +1,348 @@
+package com.baijum.ukufretboard.data
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.numericFloat
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [AppSettings] and its sections.
+ *
+ * Two things here are contracts rather than implementation details:
+ *
+ * 1. [UkuleleTuning]'s pitch classes and octaves drive `TunerNoteMapper`, the
+ *    fretboard display and pattern playback. A wrong octave makes the tuner aim
+ *    at the wrong frequency for that string.
+ * 2. Every enum constant name is persisted verbatim in `settings_json`, so a
+ *    rename silently resets that preference on every existing install.
+ */
+class AppSettingsTest {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+
+    /** The app's own convention, from `TunerNoteMapper.targetFrequency`. */
+    private fun midiOf(
+        pitchClass: Int,
+        octave: Int,
+    ) = (octave + 1) * 12 + pitchClass
+
+    private fun midiNotes(tuning: UkuleleTuning) =
+        tuning.pitchClasses.indices.map { midiOf(tuning.pitchClasses[it], tuning.octaves[it]) }
+
+    // ── Noise gate mapping ───────────────────────────────────────────
+
+    @Test
+    fun filteringToRmsMapsZeroToTheFloorAndOneToTheCeiling() {
+        assertEquals(0.002f, SoundSettings.filteringToRms(0f), 1e-6f, "floor moved")
+        assertEquals(0.053f, SoundSettings.filteringToRms(1f), 1e-6f, "ceiling moved")
+    }
+
+    @Test
+    fun filteringToRmsClampsInputsOutsideZeroToOne() {
+        assertEquals(0.002f, SoundSettings.filteringToRms(-5f), 1e-6f)
+        assertEquals(0.053f, SoundSettings.filteringToRms(42f), 1e-6f)
+        assertEquals(0.002f, SoundSettings.filteringToRms(Float.NEGATIVE_INFINITY), 1e-6f)
+        assertEquals(0.053f, SoundSettings.filteringToRms(Float.POSITIVE_INFINITY), 1e-6f)
+    }
+
+    @Test
+    fun filteringToRmsIsMonotonicAcrossTheSliderTravel() {
+        var previous = SoundSettings.filteringToRms(0f)
+        for (step in 1..100) {
+            val current = SoundSettings.filteringToRms(step / 100f)
+            assertTrue(current >= previous, "gate dipped at step $step: $current < $previous")
+            previous = current
+        }
+    }
+
+    @Test
+    fun filteringToRmsStaysInsideTheGateBoundsForAnyFiniteInput() {
+        runBlocking {
+            checkAll(Arb.numericFloat(-1e6f, 1e6f)) { filtering ->
+                val rms = SoundSettings.filteringToRms(filtering)
+                assertTrue(rms in 0.002f..0.053f, "gate escaped its bounds: $filtering -> $rms")
+            }
+        }
+    }
+
+    @Test
+    fun filteringToRmsPropagatesNaNStraightThroughTheClamp() {
+        // Float.coerceIn returns NaN for NaN because both comparisons are false, so a
+        // NaN slider value produces a NaN gate and every RMS comparison downstream
+        // becomes false — the gate never opens and the tuner appears deaf. Pinned
+        // rather than fixed: no code path currently writes NaN into the setting.
+        assertTrue(SoundSettings.filteringToRms(Float.NaN).isNaN(), "NaN handling changed")
+    }
+
+    @Test
+    fun defaultNoiseGateFilteringMapsInsideTheGateBounds() {
+        val rms = SoundSettings.filteringToRms(SoundSettings.DEFAULT_NOISE_GATE_FILTERING)
+        assertEquals(0.04025f, rms, 1e-6f, "the shipped default gate moved")
+    }
+
+    @Test
+    fun noiseGateBoundsSpanTheFullSliderTravel() {
+        assertEquals(0f, SoundSettings.MIN_NOISE_GATE_FILTERING)
+        assertEquals(1f, SoundSettings.MAX_NOISE_GATE_FILTERING)
+        assertTrue(
+            SoundSettings.DEFAULT_NOISE_GATE_FILTERING in
+                SoundSettings.MIN_NOISE_GATE_FILTERING..SoundSettings.MAX_NOISE_GATE_FILTERING,
+            "the default sits outside its own bounds",
+        )
+    }
+
+    // ── Tunings ──────────────────────────────────────────────────────
+
+    @Test
+    fun everyTuningHasFourStringsWithMatchingNameAndOctaveArity() {
+        for (tuning in UkuleleTuning.entries) {
+            assertEquals(4, tuning.pitchClasses.size, "${tuning.name} does not have 4 pitch classes")
+            assertEquals(4, tuning.stringNames.size, "${tuning.name} does not have 4 string names")
+            assertEquals(4, tuning.octaves.size, "${tuning.name} does not have 4 octaves")
+        }
+    }
+
+    @Test
+    fun everyTuningPitchClassIsInPitchClassRange() {
+        for (tuning in UkuleleTuning.entries) {
+            for (pitchClass in tuning.pitchClasses) {
+                assertTrue(pitchClass in 0..11, "${tuning.name} has pitch class $pitchClass")
+            }
+        }
+    }
+
+    @Test
+    fun everyTuningOctaveIsInAPlayableRange() {
+        for (tuning in UkuleleTuning.entries) {
+            for (octave in tuning.octaves) {
+                assertTrue(octave in 2..5, "${tuning.name} has implausible octave $octave")
+            }
+        }
+    }
+
+    @Test
+    fun everyTuningStringNameMatchesItsPitchClass() {
+        // Accept either enharmonic spelling: HALF_STEP_DOWN names a string "D#"
+        // while the standard spelling for that pitch class is "Eb". The string
+        // names are display text, so only the pitch they denote has to agree.
+        for (tuning in UkuleleTuning.entries) {
+            for (i in 0 until 4) {
+                val pitchClass = tuning.pitchClasses[i]
+                val accepted =
+                    setOf(
+                        Notes.NOTE_NAMES_SHARP[pitchClass],
+                        Notes.NOTE_NAMES_FLAT[pitchClass],
+                        Notes.NOTE_NAMES_STANDARD[pitchClass],
+                    ).map { it.uppercase() }
+                val actual = tuning.stringNames[i].uppercase()
+                assertTrue(
+                    actual in accepted,
+                    "${tuning.name} string $i is named $actual but sounds one of $accepted",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highGIsReentrantAndLowGIsNot() {
+        assertTrue(UkuleleTuning.HIGH_G.isReentrant, "standard high-G tuning is re-entrant")
+        assertFalse(UkuleleTuning.LOW_G.isReentrant, "low-G tuning ascends linearly")
+    }
+
+    @Test
+    fun lowGDiffersFromHighGOnlyInTheOctaveOfTheGString() {
+        assertEquals(UkuleleTuning.HIGH_G.pitchClasses, UkuleleTuning.LOW_G.pitchClasses)
+        assertEquals(listOf(4, 4, 4, 4), UkuleleTuning.HIGH_G.octaves)
+        assertEquals(listOf(3, 4, 4, 4), UkuleleTuning.LOW_G.octaves)
+    }
+
+    @Test
+    fun halfStepDownIsExactlyOneSemitoneBelowHighGOnEveryString() {
+        val standard = midiNotes(UkuleleTuning.HIGH_G)
+        val lowered = midiNotes(UkuleleTuning.HALF_STEP_DOWN)
+        for (i in standard.indices) {
+            assertEquals(
+                standard[i] - 1,
+                lowered[i],
+                "half-step-down string $i is not one semitone below high-G",
+            )
+        }
+    }
+
+    @Test
+    fun lowAOnlyDropsTheAStringAnOctave() {
+        val standard = midiNotes(UkuleleTuning.HIGH_G)
+        val lowA = midiNotes(UkuleleTuning.LOW_A)
+        assertEquals(standard.dropLast(1), lowA.dropLast(1), "only the A string should move")
+        assertEquals(standard.last() - 12, lowA.last(), "the A string should drop a full octave")
+    }
+
+    @Test
+    fun tuningEnumNamesAreTheOnDiskContract() {
+        assertEquals(
+            listOf(
+                "HIGH_G",
+                "LOW_G",
+                "BARITONE",
+                "D_TUNING",
+                "SLACK_KEY",
+                "OPEN_A",
+                "LOW_A",
+                "HALF_STEP_DOWN",
+            ),
+            UkuleleTuning.entries.map { it.name },
+            "settings_json stores the tuning by name; renaming one resets it on upgrade",
+        )
+    }
+
+    @Test
+    fun tuningLabelsAreUniqueAndNonBlank() {
+        val labels = UkuleleTuning.entries.map { it.label }
+        assertEquals(labels.size, labels.toSet().size, "duplicate tuning labels: $labels")
+        for (label in labels) {
+            assertTrue(label.isNotBlank(), "a tuning has a blank label")
+        }
+    }
+
+    @Test
+    @Ignore // Enabled by "Fix: Correct the baritone B string octave".
+    fun everyTuningStringMatchesItsScientificPitch() {
+        // Expected MIDI numbers, spelled out from each tuning's documented note names.
+        val expected =
+            mapOf(
+                UkuleleTuning.HIGH_G to listOf(67, 60, 64, 69), // G4 C4 E4 A4
+                UkuleleTuning.LOW_G to listOf(55, 60, 64, 69), // G3 C4 E4 A4
+                UkuleleTuning.BARITONE to listOf(50, 55, 59, 64), // D3 G3 B3 E4
+                UkuleleTuning.D_TUNING to listOf(69, 62, 66, 71), // A4 D4 F#4 B4
+                UkuleleTuning.SLACK_KEY to listOf(67, 60, 64, 67), // G4 C4 E4 G4
+                UkuleleTuning.OPEN_A to listOf(69, 61, 64, 69), // A4 C#4 E4 A4
+                UkuleleTuning.LOW_A to listOf(67, 60, 64, 57), // G4 C4 E4 A3
+                UkuleleTuning.HALF_STEP_DOWN to listOf(66, 59, 63, 68), // F#4 B3 D#4 G#4
+            )
+        for (tuning in UkuleleTuning.entries) {
+            assertEquals(expected.getValue(tuning), midiNotes(tuning), "${tuning.name} is mistuned")
+        }
+    }
+
+    @Test
+    @Ignore // Enabled by "Fix: Correct the baritone B string octave".
+    fun baritoneIsALinearTuningNotAReentrantOne() {
+        // Baritone DGBE ascends D3 G3 B3 E4 like a guitar's top four strings.
+        assertFalse(UkuleleTuning.BARITONE.isReentrant, "baritone tuning ascends linearly")
+    }
+
+    // ── Serialization ────────────────────────────────────────────────
+
+    @Test
+    fun appSettingsRoundTripsThroughJson() {
+        val original =
+            AppSettings(
+                sound = SoundSettings(enabled = false, volume = 0.4f, noiseGateFiltering = 0.25f),
+                display = DisplaySettings(themeMode = ThemeMode.HIGH_CONTRAST),
+                tuning = TuningSettings(UkuleleTuning.BARITONE),
+                fretboard = FretboardSettings(leftHanded = true, lastFret = 18),
+                tuner = TunerSettings(spokenFeedback = true, a4Reference = 432f),
+                onboardingCompleted = true,
+            )
+        val decoded =
+            json.decodeFromString(
+                AppSettings.serializer(),
+                json.encodeToString(AppSettings.serializer(), original),
+            )
+        assertEquals(original, decoded, "settings round trip lost data")
+    }
+
+    @Test
+    fun appSettingsDecodesPartialJsonUsingSectionDefaults() {
+        // This is what makes settings forward and backward compatible across
+        // versions and across an iOS-authored backup.
+        val decoded =
+            json.decodeFromString(
+                AppSettings.serializer(),
+                """{"sound":{"enabled":false}}""",
+            )
+        assertFalse(decoded.sound.enabled, "the stored field should win")
+        assertEquals(SoundSettings.DEFAULT_VOLUME, decoded.sound.volume, "volume should default")
+        assertEquals(DisplaySettings(), decoded.display, "an absent section should default")
+        assertEquals(TunerSettings(), decoded.tuner, "an absent section should default")
+    }
+
+    @Test
+    fun appSettingsIgnoresUnknownKeysFromANewerVersion() {
+        val decoded =
+            json.decodeFromString(
+                AppSettings.serializer(),
+                """{"sound":{"enabled":true,"futureField":7},"somethingNew":true}""",
+            )
+        assertTrue(decoded.sound.enabled, "a newer payload should still decode")
+    }
+
+    @Test
+    fun appSettingsJsonUsesEnumNamesNotLabels() {
+        val encoded =
+            json.encodeToString(
+                AppSettings.serializer(),
+                AppSettings(
+                    display = DisplaySettings(themeMode = ThemeMode.HIGH_CONTRAST),
+                    tuning = TuningSettings(UkuleleTuning.BARITONE),
+                ),
+            )
+        assertTrue(encoded.contains("HIGH_CONTRAST"), "theme should persist by name: $encoded")
+        assertTrue(encoded.contains("BARITONE"), "tuning should persist by name: $encoded")
+        assertFalse(encoded.contains("High Contrast"), "labels must not reach the disk")
+    }
+
+    // ── Defaults ─────────────────────────────────────────────────────
+
+    @Test
+    fun defaultAppSettingsTreatsOnboardingAsIncomplete() {
+        // Deliberately the opposite of LegacySettingsReader's defaults: a fresh
+        // install has not seen onboarding, a migrating one has.
+        val defaults = AppSettings()
+        assertFalse(defaults.onboardingCompleted, "a fresh install must see onboarding")
+        assertFalse(defaults.explorerTipsDismissed, "a fresh install must see explorer tips")
+    }
+
+    @Test
+    fun defaultsSitInsideTheirOwnDeclaredBounds() {
+        val defaults = AppSettings()
+        assertTrue(defaults.sound.volume in SoundSettings.MIN_VOLUME..SoundSettings.MAX_VOLUME)
+        assertTrue(
+            defaults.sound.noteDurationMs in
+                SoundSettings.MIN_NOTE_DURATION_MS..SoundSettings.MAX_NOTE_DURATION_MS,
+        )
+        assertTrue(
+            defaults.sound.strumDelayMs in
+                SoundSettings.MIN_STRUM_DELAY_MS..SoundSettings.MAX_STRUM_DELAY_MS,
+        )
+        assertTrue(
+            defaults.fretboard.lastFret in
+                FretboardSettings.MIN_LAST_FRET..FretboardSettings.MAX_LAST_FRET,
+        )
+        assertTrue(
+            defaults.scalePractice.lastBpm in
+                ScalePracticeSettings.MIN_BPM..ScalePracticeSettings.MAX_BPM,
+        )
+        assertTrue(
+            defaults.tuner.a4Reference in
+                TunerSettings.MIN_A4_REFERENCE..TunerSettings.MAX_A4_REFERENCE,
+        )
+    }
+
+    @Test
+    fun precisionInTuneZoneIsTighterThanTheStandardOne() {
+        assertTrue(
+            TunerSettings.PRECISION_IN_TUNE_CENTS < TunerSettings.STANDARD_IN_TUNE_CENTS,
+            "precision mode must narrow the in-tune zone",
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/CapoReferenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/CapoReferenceTest.kt
@@ -1,0 +1,199 @@
+package com.baijum.ukufretboard.data
+
+import com.baijum.ukufretboard.domain.ChordNameParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the [CapoReference] lesson data.
+ *
+ * Every table in the Capo Guide states a music-theory relationship — this shape
+ * at this fret sounds this key — and the app renders those claims verbatim.
+ * A typo in a fret string or a sounding key teaches the wrong thing with no
+ * runtime symptom, so the assertions here recompute each claim rather than
+ * checking that fields are merely non-blank.
+ */
+class CapoReferenceTest {
+    /** The guide writes accidentals with the typographic sharp and flat signs. */
+    private fun normalize(name: String) = name.replace('♯', '#').replace('♭', 'b').trim()
+
+    /** "C♯/D♭" lists one pitch under two spellings; either may be used. */
+    private fun rootsOf(keyName: String): Set<Int> =
+        keyName.split("/").mapNotNull { ChordNameParser.parse(normalize(it))?.rootPitchClass }.toSet()
+
+    private fun rootOf(chordName: String): Int? = ChordNameParser.parse(normalize(chordName))?.rootPitchClass
+
+    /** Sounding pitch classes of an open-position shape in standard tuning. */
+    private fun tonesOf(fretString: String): Set<Int> =
+        fretString
+            .mapIndexed { string, fret ->
+                (CapoReference.STANDARD_OPEN_PITCHES[string] + fret.digitToInt()) % 12
+            }.toSet()
+
+    // ── Tuning agreement ─────────────────────────────────────────────
+
+    @Test
+    fun standardOpenPitchesMatchHighGTuning() {
+        // Two copies of the same fact; this fails if either drifts.
+        assertEquals(
+            UkuleleTuning.HIGH_G.pitchClasses,
+            CapoReference.STANDARD_OPEN_PITCHES,
+            "the capo guide disagrees with the tuning table",
+        )
+    }
+
+    @Test
+    fun stringNamesMatchHighGTuning() {
+        assertEquals(UkuleleTuning.HIGH_G.stringNames, CapoReference.STRING_NAMES)
+    }
+
+    // ── Common positions ─────────────────────────────────────────────
+
+    @Test
+    fun everyCommonPositionSoundsItsShapeKeyTransposedByTheCapoFret() {
+        for (position in CapoReference.COMMON_POSITIONS) {
+            val shapeRoot = rootOf(position.shapeKey.substringBefore(" "))
+            assertNotNull(shapeRoot, "unparseable shape key: ${position.shapeKey}")
+            val expected = (shapeRoot + position.capoFret) % 12
+            assertTrue(
+                expected in rootsOf(position.soundingKey),
+                "${position.shapeKey} at fret ${position.capoFret} sounds pitch class " +
+                    "$expected, not ${position.soundingKey}",
+            )
+        }
+    }
+
+    @Test
+    fun commonPositionExampleChordsStartOnTheSoundingKey() {
+        for (position in CapoReference.COMMON_POSITIONS) {
+            val first = position.exampleChords.split(",").first()
+            val firstRoot = rootOf(first)
+            assertNotNull(firstRoot, "unparseable example chord: $first")
+            assertTrue(
+                firstRoot in rootsOf(position.soundingKey),
+                "${position.exampleChords} does not begin on ${position.soundingKey}",
+            )
+        }
+    }
+
+    @Test
+    fun commonPositionExampleChordsAreTheOneFourAndFiveOfTheSoundingKey() {
+        for (position in CapoReference.COMMON_POSITIONS) {
+            val roots = position.exampleChords.split(",").mapNotNull { rootOf(it) }
+            assertEquals(3, roots.size, "expected three example chords: ${position.exampleChords}")
+            assertEquals(
+                5,
+                (roots[1] - roots[0] + 12) % 12,
+                "${position.exampleChords}: second chord is not the IV",
+            )
+            assertEquals(
+                7,
+                (roots[2] - roots[0] + 12) % 12,
+                "${position.exampleChords}: third chord is not the V",
+            )
+        }
+    }
+
+    @Test
+    fun commonPositionCapoFretsArePlayable() {
+        for (position in CapoReference.COMMON_POSITIONS) {
+            assertTrue(
+                position.capoFret in 1..12,
+                "capo fret ${position.capoFret} is off the neck",
+            )
+        }
+    }
+
+    @Test
+    fun commonPositionsAreUniqueByShapeAndFret() {
+        val keys = CapoReference.COMMON_POSITIONS.map { it.shapeKey to it.capoFret }
+        assertEquals(keys.size, keys.toSet().size, "duplicate capo positions: $keys")
+    }
+
+    @Test
+    fun commonPositionsHaveNoBlankFields() {
+        for (position in CapoReference.COMMON_POSITIONS) {
+            assertTrue(position.shapeKey.isNotBlank(), "blank shape key")
+            assertTrue(position.soundingKey.isNotBlank(), "blank sounding key")
+            assertTrue(position.exampleChords.isNotBlank(), "blank example chords")
+        }
+    }
+
+    // ── Friendly shapes ──────────────────────────────────────────────
+
+    @Test
+    fun everyFriendlyShapeSpellsItsNamedChordInStandardTuning() {
+        for ((name, frets) in CapoReference.FRIENDLY_SHAPES) {
+            val parsed = ChordNameParser.parse(name)
+            assertNotNull(parsed, "unparseable friendly shape name: $name")
+            val expected =
+                parsed.formula.intervals
+                    .map { (parsed.rootPitchClass + it) % 12 }
+                    .toSet()
+            assertEquals(expected, tonesOf(frets), "the $name shape ($frets) does not sound $name")
+        }
+    }
+
+    @Test
+    fun friendlyShapeFretStringsAreFourSingleDigits() {
+        // The guide renders the raw string, so a two-digit fret would be ambiguous.
+        for ((name, frets) in CapoReference.FRIENDLY_SHAPES) {
+            assertEquals(4, frets.length, "$name has ${frets.length} frets, expected 4")
+            assertTrue(frets.all { it.isDigit() }, "$name has a non-digit fret: $frets")
+        }
+    }
+
+    @Test
+    fun friendlyShapesAreExactlyEightForTheTwoRowLayout() {
+        // CapoGuideView renders take(4) then drop(4) into two equally weighted rows.
+        assertEquals(8, CapoReference.FRIENDLY_SHAPES.size, "the two-row shape grid expects 8 shapes")
+    }
+
+    @Test
+    fun friendlyShapeNamesAreUnique() {
+        val names = CapoReference.FRIENDLY_SHAPES.map { it.first }
+        assertEquals(names.size, names.toSet().size, "duplicate friendly shapes: $names")
+    }
+
+    // ── Lesson prose ─────────────────────────────────────────────────
+
+    @Test
+    fun howItChangesPitchExamplesMatchTheCapoArithmetic() {
+        // The worked examples are embedded in prose, where they rot silently.
+        val examples = Regex("Capo (\\d+): (\\S+)").findAll(CapoReference.HOW_IT_CHANGES_PITCH).toList()
+        assertTrue(examples.isNotEmpty(), "the pitch lesson no longer lists worked examples")
+        for (match in examples) {
+            val fret = match.groupValues[1].toInt()
+            val named = match.groupValues[2].split("-").mapNotNull { rootOf(it) }
+            val expected = CapoReference.STANDARD_OPEN_PITCHES.map { (it + fret) % 12 }
+            assertEquals(expected, named, "the Capo $fret example is wrong")
+        }
+    }
+
+    @Test
+    fun lessonTextsAreNonBlank() {
+        for (text in listOf(
+            CapoReference.WHAT_IS_A_CAPO,
+            CapoReference.HOW_IT_CHANGES_PITCH,
+            CapoReference.WHEN_TO_USE,
+            CapoReference.TRY_IT_TIP,
+        )) {
+            assertTrue(text.isNotBlank(), "a capo lesson text is blank")
+        }
+    }
+
+    // ── Scenarios ────────────────────────────────────────────────────
+
+    @Test
+    fun scenariosHaveDistinctProblemsAndNonBlankSolutions() {
+        val problems = CapoReference.SCENARIOS.map { it.problem }
+        assertTrue(problems.isNotEmpty(), "the guide lists no scenarios")
+        assertEquals(problems.size, problems.toSet().size, "duplicate scenarios: $problems")
+        for (scenario in CapoReference.SCENARIOS) {
+            assertTrue(scenario.problem.isNotBlank(), "blank scenario problem")
+            assertTrue(scenario.solution.isNotBlank(), "blank scenario solution")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordSubstitutionsTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordSubstitutionsTest.kt
@@ -240,7 +240,6 @@ class ChordSubstitutionsTest {
     // ── Shared-note claims ───────────────────────────────────────────
 
     @Test
-    @Ignore // Enabled by "Fix: Correct the shared notes in three chord substitutions".
     fun everyNamedSharedNoteIsPresentInBothChords() {
         for (category in ChordSubstitutions.CATEGORIES) {
             for (row in category.substitutions) {
@@ -259,7 +258,6 @@ class ChordSubstitutionsTest {
     }
 
     @Test
-    @Ignore // Enabled by "Fix: Correct the shared notes in three chord substitutions".
     fun diatonicAndRelativeSharedNotesAreExactlyTheTriadIntersection() {
         for (index in 0..1) {
             for (row in rowsOf(index)) {

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordSubstitutionsTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordSubstitutionsTest.kt
@@ -1,0 +1,278 @@
+package com.baijum.ukufretboard.data
+
+import com.baijum.ukufretboard.domain.ChordNameParser
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the [ChordSubstitutions] lesson data.
+ *
+ * This is educational content rendered verbatim, so a wrong interval or a
+ * misnamed shared note teaches the wrong theory without any runtime symptom.
+ * Each assertion recomputes the claim from the chord formulas rather than
+ * trusting the prose.
+ */
+class ChordSubstitutionsTest {
+    /** The numerals used by categories 1 and 2, spelled in the key of C. */
+    private val numeralsInC =
+        mapOf(
+            "I" to "C",
+            "ii" to "Dm",
+            "iii" to "Em",
+            "IV" to "F",
+            "V" to "G",
+            "vi" to "Am",
+            "vii°" to "Bdim",
+        )
+
+    private val placeholder = "—"
+
+    private fun normalize(name: String) = name.replace('♯', '#').replace('♭', 'b').trim()
+
+    private fun rootOf(chordName: String): Int? = ChordNameParser.parse(normalize(chordName))?.rootPitchClass
+
+    /** Sounding pitch classes of a chord named in full (e.g. "Dm", "G7"). */
+    private fun tonesOf(chordName: String): Set<Int>? {
+        val parsed = ChordNameParser.parse(normalize(chordName)) ?: return null
+        return parsed.formula.intervals
+            .map { (parsed.rootPitchClass + it) % 12 }
+            .toSet()
+    }
+
+    /**
+     * Resolves the concrete chord a table cell refers to. The cells come in four
+     * shapes across the five categories: a bare numeral ("IV"), a numeral with the
+     * chord in parentheses ("before V (G)"), a chord with the numeral in
+     * parentheses ("G7 (V7)"), and an equation ("V/V = D7"). Returns null for the
+     * em-dash placeholder.
+     */
+    private fun chordFor(field: String): String? {
+        val trimmed = field.trim()
+        if (trimmed == placeholder) return null
+        if ("=" in trimmed) return chordFor(trimmed.substringAfter("="))
+        val beforeParens = trimmed.substringBefore("(").trim()
+        if (beforeParens.isNotEmpty() && parses(beforeParens)) return beforeParens
+        Regex("\\(([^)]+)\\)").find(trimmed)?.groupValues?.get(1)?.let {
+            if (parses(it)) return it.trim()
+        }
+        numeralsInC[trimmed]?.let { return it }
+        return trimmed.takeIf { parses(it) }
+    }
+
+    private fun parses(name: String) = ChordNameParser.parse(normalize(name)) != null
+
+    private fun notesNamedIn(sharedNotes: String): List<Int>? {
+        if (sharedNotes == placeholder) return null
+        val names = Regex("[A-G][#b♯♭]?").findAll(sharedNotes.substringBefore("(")).map { it.value }
+        val pitches = names.mapNotNull { rootOf(it) }.toList()
+        return pitches.takeIf { it.isNotEmpty() }
+    }
+
+    private fun rowsOf(index: Int) = ChordSubstitutions.CATEGORIES[index].substitutions
+
+    // ── Structure ────────────────────────────────────────────────────
+
+    @Test
+    fun categoryTitlesAreNumberedSequentiallyFromOne() {
+        ChordSubstitutions.CATEGORIES.forEachIndexed { index, category ->
+            assertTrue(
+                category.title.startsWith("${index + 1}."),
+                "category ${index + 1} is titled '${category.title}'",
+            )
+        }
+    }
+
+    @Test
+    fun everyCategoryHasNonBlankTitleExplanationAndSubstitutions() {
+        assertTrue(ChordSubstitutions.CATEGORIES.isNotEmpty(), "no substitution categories")
+        for (category in ChordSubstitutions.CATEGORIES) {
+            assertTrue(category.title.isNotBlank(), "blank category title")
+            assertTrue(category.explanation.isNotBlank(), "blank explanation in ${category.title}")
+            assertTrue(
+                category.substitutions.isNotEmpty(),
+                "${category.title} lists no substitutions",
+            )
+        }
+    }
+
+    @Test
+    fun everySubstitutionFieldIsNonBlank() {
+        for (category in ChordSubstitutions.CATEGORIES) {
+            for (row in category.substitutions) {
+                assertTrue(row.original.isNotBlank(), "blank original in ${category.title}")
+                assertTrue(row.substitute.isNotBlank(), "blank substitute in ${category.title}")
+                assertTrue(row.sharedNotes.isNotBlank(), "blank sharedNotes in ${category.title}")
+                assertTrue(row.exampleInC.isNotBlank(), "blank exampleInC in ${category.title}")
+            }
+        }
+    }
+
+    @Test
+    fun emptyFieldsUseTheEmDashPlaceholderNotAHyphenOrBlank() {
+        // The UI renders these directly; a bare "-" reads as a typo in the table.
+        for (category in ChordSubstitutions.CATEGORIES) {
+            for (row in category.substitutions) {
+                for (field in listOf(row.original, row.substitute, row.sharedNotes)) {
+                    assertTrue(field != "-" && field != "", "use $placeholder, not '$field'")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun noDuplicateSubstitutionRowsWithinACategory() {
+        for (category in ChordSubstitutions.CATEGORIES) {
+            val pairs = category.substitutions.map { it.original to it.substitute }
+            assertEquals(
+                pairs.size,
+                pairs.toSet().size,
+                "${category.title} repeats a substitution: $pairs",
+            )
+        }
+    }
+
+    @Test
+    fun everyNumeralUsedByTheFirstTwoCategoriesIsKnown() {
+        for (index in 0..1) {
+            for (row in rowsOf(index)) {
+                assertNotNull(chordFor(row.original), "unknown numeral: ${row.original}")
+                assertNotNull(chordFor(row.substitute), "unknown numeral: ${row.substitute}")
+            }
+        }
+    }
+
+    // ── Interval claims ──────────────────────────────────────────────
+
+    @Test
+    fun diatonicSubstitutionPairsShareExactlyTwoOfThreeNotes() {
+        for (row in rowsOf(0)) {
+            val original = tonesOf(chordFor(row.original)!!)!!
+            val substitute = tonesOf(chordFor(row.substitute)!!)!!
+            assertEquals(
+                2,
+                original.intersect(substitute).size,
+                "${row.original} -> ${row.substitute} does not share two notes",
+            )
+        }
+    }
+
+    @Test
+    fun relativeSwapsAreThreeSemitonesApart() {
+        for (row in rowsOf(1)) {
+            val from = rootOf(chordFor(row.original)!!)!!
+            val to = rootOf(chordFor(row.substitute)!!)!!
+            val distance = minOf((to - from + 12) % 12, (from - to + 12) % 12)
+            assertEquals(3, distance, "${row.original} -> ${row.substitute} is not a relative swap")
+        }
+    }
+
+    @Test
+    fun tritoneSubstitutesAreSixSemitonesFromTheirOriginal() {
+        for (row in rowsOf(2)) {
+            val from = rootOf(chordFor(row.original)!!)!!
+            val to = rootOf(chordFor(row.substitute)!!)!!
+            assertEquals(
+                6,
+                (to - from + 12) % 12,
+                "${row.original} -> ${row.substitute} is not a tritone apart",
+            )
+        }
+    }
+
+    @Test
+    fun tritoneSubstitutesShareTheTritoneOfTheOriginal() {
+        // The substitution works precisely because both dominants contain the
+        // same third and seventh, so the shared pair must itself be a tritone.
+        for (row in rowsOf(2)) {
+            val original = tonesOf(chordFor(row.original)!!)!!
+            val substitute = tonesOf(chordFor(row.substitute)!!)!!
+            val shared = original.intersect(substitute)
+            assertEquals(2, shared.size, "${row.original} -> ${row.substitute} shares ${shared.size} notes")
+            val (a, b) = shared.toList()
+            assertEquals(6, (a - b + 12) % 12, "the shared pair is not a tritone: $shared")
+        }
+    }
+
+    @Test
+    fun secondaryDominantsSitAFifthAboveTheChordTheyTonicize() {
+        for (row in rowsOf(4)) {
+            val target = rootOf(chordFor(row.original)!!)!!
+            val dominant = rootOf(chordFor(row.substitute)!!)!!
+            assertEquals(
+                7,
+                (dominant - target + 12) % 12,
+                "${row.substitute} is not the dominant of ${row.original}",
+            )
+        }
+    }
+
+    @Test
+    fun secondaryDominantsAreDominantSeventhChords() {
+        for (row in rowsOf(4)) {
+            val chord = chordFor(row.substitute)!!
+            val tones = tonesOf(chord)!!
+            val root = rootOf(chord)!!
+            val intervals = tones.map { (it - root + 12) % 12 }.toSet()
+            assertTrue(
+                intervals.containsAll(setOf(0, 4, 10)),
+                "$chord is not a dominant seventh (intervals $intervals)",
+            )
+        }
+    }
+
+    @Test
+    fun modalInterchangeChordsAreBorrowedFromTheParallelMinor() {
+        // Every category-4 substitute must exist in C natural minor.
+        val cMinorPitches = setOf(0, 2, 3, 5, 7, 8, 10)
+        for (row in rowsOf(3)) {
+            val chord = chordFor(row.substitute) ?: continue
+            val tones = tonesOf(chord) ?: continue
+            assertTrue(
+                cMinorPitches.containsAll(tones),
+                "$chord is not diatonic to C minor (tones $tones)",
+            )
+        }
+    }
+
+    // ── Shared-note claims ───────────────────────────────────────────
+
+    @Test
+    @Ignore // Enabled by "Fix: Correct the shared notes in three chord substitutions".
+    fun everyNamedSharedNoteIsPresentInBothChords() {
+        for (category in ChordSubstitutions.CATEGORIES) {
+            for (row in category.substitutions) {
+                val named = notesNamedIn(row.sharedNotes) ?: continue
+                val original = chordFor(row.original)?.let { tonesOf(it) } ?: continue
+                val substitute = chordFor(row.substitute)?.let { tonesOf(it) } ?: continue
+                for (note in named) {
+                    assertTrue(
+                        note in original && note in substitute,
+                        "${category.title}: ${row.original} -> ${row.substitute} claims to share " +
+                            "'${row.sharedNotes}', but pitch class $note is not in both chords",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    @Ignore // Enabled by "Fix: Correct the shared notes in three chord substitutions".
+    fun diatonicAndRelativeSharedNotesAreExactlyTheTriadIntersection() {
+        for (index in 0..1) {
+            for (row in rowsOf(index)) {
+                val named = notesNamedIn(row.sharedNotes)?.toSet() ?: continue
+                val original = tonesOf(chordFor(row.original)!!)!!
+                val substitute = tonesOf(chordFor(row.substitute)!!)!!
+                assertEquals(
+                    original.intersect(substitute),
+                    named,
+                    "${row.original} -> ${row.substitute} names the wrong shared notes " +
+                        "('${row.sharedNotes}')",
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/DataIntegrityTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/DataIntegrityTest.kt
@@ -255,4 +255,58 @@ class DataIntegrityTest {
                 "Glossary out of order: '${terms[i - 1]}' before '${terms[i]}'")
         }
     }
+
+    // ── ExplorerTips ──
+
+    @Test
+    fun explorerTipsAreNonEmpty() {
+        // ChordResultView picks a tip with `currentTimeMillis() % ALL.size`.
+        // An empty catalog is a divide-by-zero crash on the Explorer tab.
+        assertTrue(ExplorerTips.ALL.isNotEmpty(), "ExplorerTips must never be empty")
+    }
+
+    @Test
+    fun allExplorerTipsAreNonBlank() {
+        for (tip in ExplorerTips.ALL) {
+            assertTrue(tip.isNotBlank(), "ExplorerTips contains a blank tip")
+        }
+    }
+
+    @Test
+    fun allExplorerTipsAreTrimmed() {
+        for (tip in ExplorerTips.ALL) {
+            assertEquals(tip.trim(), tip, "Tip has stray whitespace: '$tip'")
+        }
+    }
+
+    @Test
+    fun explorerTipsHaveNoDuplicates() {
+        val tips = ExplorerTips.ALL
+        assertEquals(tips.size, tips.toSet().size, "ExplorerTips contains duplicates")
+    }
+
+    @Test
+    fun explorerTipsFitTheDidYouKnowCard() {
+        // The card is a fixed-height surface on the Explorer tab; an essay
+        // overflows it and a fragment looks like a rendering bug.
+        for (tip in ExplorerTips.ALL) {
+            assertTrue(tip.length in 40..200, "Tip length ${tip.length} is out of range: '$tip'")
+        }
+    }
+
+    @Test
+    fun explorerTipsEndWithSentencePunctuation() {
+        for (tip in ExplorerTips.ALL) {
+            assertTrue(tip.last() in ".!?", "Tip is not a complete sentence: '$tip'")
+        }
+    }
+
+    @Test
+    fun tipIndexArithmeticStaysInBoundsForAnyTimestamp() {
+        val timestamps = listOf(0L, 1L, 999L, 1_700_000_000_000L, Long.MAX_VALUE)
+        for (millis in timestamps) {
+            val index = (millis % ExplorerTips.ALL.size).toInt()
+            assertTrue(index in ExplorerTips.ALL.indices, "Index $index out of bounds for $millis")
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/FavoriteVoicingTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/FavoriteVoicingTest.kt
@@ -1,0 +1,163 @@
+package com.baijum.ukufretboard.data
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [FavoriteVoicing.key] and [FavoriteFolder].
+ *
+ * [FavoriteVoicing.key] is the identity used for de-duplication when adding a
+ * favorite, for merge-on-import, and for the per-folder display order. Both
+ * `FavoritesRepository` and `FavoritesViewModel` compare voicings by this string,
+ * so its exact shape is a cross-file contract rather than an implementation detail.
+ */
+class FavoriteVoicingTest {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+
+    private fun voicing(
+        root: Int = 0,
+        symbol: String = "m7",
+        frets: List<Int> = listOf(0, 2, 3, 3),
+    ) = FavoriteVoicing(rootPitchClass = root, chordSymbol = symbol, frets = frets)
+
+    // ── Key shape ────────────────────────────────────────────────────
+
+    @Test
+    fun keyConcatenatesRootSymbolAndFrets() {
+        assertEquals("0|m7|0,2,3,3", voicing().key, "key shape changed")
+    }
+
+    @Test
+    fun keyKeepsAnEmptyChordSymbolAsAnEmptySegment() {
+        assertEquals("7||0,2,3,2", voicing(root = 7, symbol = "", frets = listOf(0, 2, 3, 2)).key)
+    }
+
+    @Test
+    fun mutedStringsAppearInTheKeyAsNegativeOne() {
+        assertEquals("0|maj|-1,0,0,3", voicing(symbol = "maj", frets = listOf(-1, 0, 0, 3)).key)
+    }
+
+    @Test
+    fun emptyFretsProduceATrailingSeparator() {
+        assertEquals("5|sus2|", voicing(root = 5, symbol = "sus2", frets = emptyList()).key)
+    }
+
+    // ── Key identity ─────────────────────────────────────────────────
+
+    @Test
+    fun keyIgnoresAddedAtAndFolderIds() {
+        val a = voicing().copy(addedAt = 1_000L, folderIds = emptyList())
+        val b = voicing().copy(addedAt = 9_999_999L, folderIds = listOf("f1", "f2"))
+        assertEquals(a.key, b.key, "key must depend only on root, symbol and frets")
+    }
+
+    @Test
+    fun keyDistinguishesVoicingsThatDifferInAnyField() {
+        runBlocking {
+            checkAll(
+                Arb.int(0..11),
+                Arb.element("", "m", "m7", "sus2", "maj7"),
+                Arb.list(Arb.int(-1..22), 1..4),
+                Arb.int(0..11),
+                Arb.element("", "m", "m7", "sus2", "maj7"),
+                Arb.list(Arb.int(-1..22), 1..4),
+            ) { rootA, symA, fretsA, rootB, symB, fretsB ->
+                val a = voicing(rootA, symA, fretsA)
+                val b = voicing(rootB, symB, fretsB)
+                if (rootA == rootB && symA == symB && fretsA == fretsB) {
+                    assertEquals(a.key, b.key, "identical voicings must share a key")
+                } else {
+                    assertNotEquals(a.key, b.key, "distinct voicings collided on ${a.key}")
+                }
+            }
+        }
+    }
+
+    // ── Serialization ────────────────────────────────────────────────
+
+    @Test
+    fun keyIsNotWrittenToJson() {
+        // @Transient keeps `key` derived. If it were persisted, every stored favorite
+        // would carry a redundant field and a stale one could outlive its frets.
+        val encoded = json.encodeToString(FavoriteVoicing.serializer(), voicing())
+        assertFalse(encoded.contains("\"key\""), "key leaked into JSON: $encoded")
+    }
+
+    @Test
+    fun keyIsRecomputedWhenDecodedFromJson() {
+        val decoded =
+            json.decodeFromString(
+                FavoriteVoicing.serializer(),
+                """{"rootPitchClass":9,"chordSymbol":"m","frets":[2,0,0,0],"addedAt":12}""",
+            )
+        assertEquals("9|m|2,0,0,0", decoded.key, "key was not derived on decode")
+    }
+
+    @Test
+    fun decodingAPayloadContainingKeyNeedsIgnoreUnknownKeys() {
+        // Pins why every favorites repository configures ignoreUnknownKeys.
+        val raw = """{"rootPitchClass":0,"chordSymbol":"m7","frets":[0,2,3,3],"key":"stale"}"""
+        val decoded = json.decodeFromString(FavoriteVoicing.serializer(), raw)
+        assertEquals("0|m7|0,2,3,3", decoded.key, "a stored key must never win over the derived one")
+    }
+
+    @Test
+    fun voicingRoundTripsThroughJson() {
+        val original = voicing().copy(addedAt = 4_242L, folderIds = listOf("a", "b"))
+        val decoded =
+            json.decodeFromString(
+                FavoriteVoicing.serializer(),
+                json.encodeToString(FavoriteVoicing.serializer(), original),
+            )
+        assertEquals(original, decoded, "round trip lost data")
+        assertEquals(original.key, decoded.key)
+    }
+
+    @Test
+    fun addedAtDefaultsToTheCurrentTime() {
+        assertTrue(voicing().addedAt > 0L, "addedAt should be stamped from the platform clock")
+    }
+
+    // ── Folders ──────────────────────────────────────────────────────
+
+    @Test
+    fun favoriteFolderGeneratesDistinctIdsByDefault() {
+        assertNotEquals(FavoriteFolder(name = "A").id, FavoriteFolder(name = "A").id)
+    }
+
+    @Test
+    fun favoriteFolderRoundTripsVoicingOrderThroughJson() {
+        val folder =
+            FavoriteFolder(
+                id = "folder-1",
+                name = "Practice",
+                createdAt = 77L,
+                voicingOrder = listOf("0|m7|0,2,3,3", "7||0,2,3,2"),
+            )
+        val decoded =
+            json.decodeFromString(
+                FavoriteFolder.serializer(),
+                json.encodeToString(FavoriteFolder.serializer(), folder),
+            )
+        assertEquals(folder, decoded, "folder round trip lost data")
+    }
+
+    @Test
+    fun folderVoicingOrderDefaultsToEmpty() {
+        assertTrue(FavoriteFolder(name = "New").voicingOrder.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/IntRangeSerializerTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/IntRangeSerializerTest.kt
@@ -1,0 +1,130 @@
+package com.baijum.ukufretboard.data
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [IntRangeSerializer].
+ *
+ * The two field names it emits are an on-disk contract: every stored custom strum
+ * and fingerpicking pattern persists its `suggestedBpm` through this serializer,
+ * so renaming a field orphans that data on every existing install.
+ */
+class IntRangeSerializerTest {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+
+    private fun encode(range: IntRange) = json.encodeToString(IntRangeSerializer, range)
+
+    private fun decode(raw: String) = json.decodeFromString(IntRangeSerializer, raw)
+
+    // ── Wire format ──────────────────────────────────────────────────
+
+    @Test
+    fun serializesToStartAndEndInclusiveFields() {
+        assertEquals("""{"start":80,"endInclusive":120}""", encode(80..120), "wire format changed")
+    }
+
+    @Test
+    fun decodesTheDocumentedWireFormat() {
+        val decoded = decode("""{"start":80,"endInclusive":120}""")
+        assertEquals(80, decoded.first)
+        assertEquals(120, decoded.last)
+    }
+
+    @Test
+    fun fieldOrderInTheInputDoesNotMatter() {
+        val decoded = decode("""{"endInclusive":120,"start":80}""")
+        assertEquals(80, decoded.first)
+        assertEquals(120, decoded.last)
+    }
+
+    // ── Round trips ──────────────────────────────────────────────────
+
+    @Test
+    fun roundTripPreservesFirstAndLast() {
+        val decoded = decode(encode(40..200))
+        assertEquals(40, decoded.first)
+        assertEquals(200, decoded.last)
+    }
+
+    @Test
+    fun roundTripsASingleValueRange() {
+        val decoded = decode(encode(5..5))
+        assertEquals(5, decoded.first)
+        assertEquals(5, decoded.last)
+    }
+
+    @Test
+    fun roundTripsNegativeAndCrossZeroRanges() {
+        val negative = decode(encode(-9..-3))
+        assertEquals(-9, negative.first)
+        assertEquals(-3, negative.last)
+
+        val crossZero = decode(encode(-4..4))
+        assertEquals(-4, crossZero.first)
+        assertEquals(4, crossZero.last)
+    }
+
+    @Test
+    fun roundTripsTheExtremeIntBounds() {
+        val decoded = decode(encode(Int.MIN_VALUE..Int.MAX_VALUE))
+        assertEquals(Int.MIN_VALUE, decoded.first)
+        assertEquals(Int.MAX_VALUE, decoded.last)
+    }
+
+    @Test
+    fun emptyRangePreservesItsOriginalBounds() {
+        // Assert the bounds, not the range: every empty IntRange compares equal
+        // (5..1 == 3..1), so assertEquals on the range would pass even if the
+        // serializer round-tripped completely different numbers.
+        val decoded = decode(encode(5..1))
+        assertEquals(5, decoded.first, "start was not preserved")
+        assertEquals(1, decoded.last, "endInclusive was not preserved")
+    }
+
+    // ── Malformed input ──────────────────────────────────────────────
+
+    @Test
+    fun missingEndInclusiveDecodesAsZeroRatherThanThrowing() {
+        // The hand-rolled decodeStructure loop performs no required-field check,
+        // so a truncated payload silently yields a range ending at 0 instead of
+        // failing. Pinned so that adding validation is a deliberate change.
+        val decoded = decode("""{"start":5}""")
+        assertEquals(5, decoded.first)
+        assertEquals(0, decoded.last, "missing endInclusive should default to 0 today")
+    }
+
+    @Test
+    fun missingBothFieldsDecodesAsTheEmptyZeroRange() {
+        val decoded = decode("{}")
+        assertEquals(0, decoded.first)
+        assertEquals(0, decoded.last)
+    }
+
+    // ── Use through a real holder ────────────────────────────────────
+
+    @Test
+    fun suggestedBpmRoundTripsInsideAStrumPattern() {
+        val pattern =
+            StrumPattern(
+                name = "Island",
+                description = "The island strum",
+                difficulty = Difficulty.BEGINNER,
+                beats = listOf(StrumBeat(StrumDirection.DOWN), StrumBeat(StrumDirection.UP)),
+                notation = "D U",
+                suggestedBpm = 90..110,
+            )
+        val decoded =
+            json.decodeFromString(
+                StrumPattern.serializer(),
+                json.encodeToString(StrumPattern.serializer(), pattern),
+            )
+        assertEquals(90, decoded.suggestedBpm.first, "suggestedBpm start lost")
+        assertEquals(110, decoded.suggestedBpm.last, "suggestedBpm end lost")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/MelodyNoteTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/MelodyNoteTest.kt
@@ -1,0 +1,147 @@
+package com.baijum.ukufretboard.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [NoteDuration], [MelodyNote] and [Melody].
+ *
+ * `MelodyRepository` persists each note as a pipe-delimited record containing
+ * `duration.name`, so the enum constant names are an on-disk contract: renaming
+ * one drops every note of that duration from every saved melody.
+ */
+class MelodyNoteTest {
+    // ── NoteDuration arithmetic ──────────────────────────────────────
+
+    @Test
+    fun beatsHalveFromWholeToSixteenth() {
+        assertEquals(4f, NoteDuration.WHOLE.beats)
+        assertEquals(2f, NoteDuration.HALF.beats)
+        assertEquals(1f, NoteDuration.QUARTER.beats)
+        assertEquals(0.5f, NoteDuration.EIGHTH.beats)
+        assertEquals(0.25f, NoteDuration.SIXTEENTH.beats)
+    }
+
+    @Test
+    fun eachDurationIsExactlyTwiceTheNextShorterOne() {
+        val ordered =
+            listOf(
+                NoteDuration.WHOLE,
+                NoteDuration.HALF,
+                NoteDuration.QUARTER,
+                NoteDuration.EIGHTH,
+                NoteDuration.SIXTEENTH,
+            )
+        for (i in 0 until ordered.size - 1) {
+            assertEquals(
+                ordered[i].beats,
+                ordered[i + 1].beats * 2f,
+                "${ordered[i].name} is not twice ${ordered[i + 1].name}",
+            )
+        }
+    }
+
+    @Test
+    fun wholeEqualsSixteenSixteenthsAndFourQuarters() {
+        assertEquals(NoteDuration.WHOLE.beats, NoteDuration.SIXTEENTH.beats * 16f)
+        assertEquals(NoteDuration.WHOLE.beats, NoteDuration.QUARTER.beats * 4f)
+    }
+
+    @Test
+    fun quarterIsOneBeatSoBeatsConvertDirectlyToMilliseconds() {
+        // Playback multiplies beats by the per-beat duration at the melody's tempo.
+        val msPerBeat = 60_000f / 120
+        assertEquals(500f, NoteDuration.QUARTER.beats * msPerBeat, "a quarter at 120bpm is 500ms")
+        assertEquals(2000f, NoteDuration.WHOLE.beats * msPerBeat, "a whole at 120bpm is 2000ms")
+    }
+
+    @Test
+    fun everyDurationHasPositiveBeats() {
+        for (duration in NoteDuration.entries) {
+            assertTrue(duration.beats > 0f, "${duration.name} has non-positive beats")
+        }
+    }
+
+    // ── On-disk contract ─────────────────────────────────────────────
+
+    @Test
+    fun durationNamesAreTheOnDiskContract() {
+        assertEquals(
+            listOf("WHOLE", "HALF", "QUARTER", "EIGHTH", "SIXTEENTH"),
+            NoteDuration.entries.map { it.name },
+            "MelodyRepository persists duration.name; renaming one loses saved notes",
+        )
+    }
+
+    @Test
+    fun durationLabelsAreUniqueAndNonBlank() {
+        val labels = NoteDuration.entries.map { it.label }
+        assertEquals(labels.size, labels.toSet().size, "duplicate labels: $labels")
+        for (label in labels) {
+            assertTrue(label.isNotBlank(), "a duration has a blank label")
+        }
+    }
+
+    // ── MelodyNote ───────────────────────────────────────────────────
+
+    @Test
+    fun melodyNoteDefaultsToAnUnassignedQuarterInOctaveFour() {
+        val note = MelodyNote(pitchClass = 0)
+        assertEquals(4, note.octave)
+        assertEquals(NoteDuration.QUARTER, note.duration)
+        assertNull(note.stringIndex, "a fresh note is not assigned to a string")
+        assertNull(note.fret, "a fresh note is not assigned to a fret")
+    }
+
+    @Test
+    fun aRestIsAMelodyNoteWithNullPitchClass() {
+        assertNull(MelodyNote(pitchClass = null).pitchClass, "a rest carries no pitch")
+    }
+
+    @Test
+    fun notesWithTheSameFieldsAreEqual() {
+        assertEquals(
+            MelodyNote(pitchClass = 7, octave = 3, duration = NoteDuration.HALF),
+            MelodyNote(pitchClass = 7, octave = 3, duration = NoteDuration.HALF),
+        )
+    }
+
+    @Test
+    fun octaveIsPartOfNoteIdentity() {
+        assertNotEquals(MelodyNote(pitchClass = 0, octave = 3), MelodyNote(pitchClass = 0, octave = 4))
+    }
+
+    // ── Melody ───────────────────────────────────────────────────────
+
+    @Test
+    fun melodyGeneratesDistinctIdsByDefault() {
+        assertNotEquals(
+            Melody(name = "A", notes = emptyList()).id,
+            Melody(name = "A", notes = emptyList()).id,
+        )
+    }
+
+    @Test
+    fun melodyDefaultsToOneHundredTwentyBpm() {
+        assertEquals(120, Melody(name = "A", notes = emptyList()).bpm)
+    }
+
+    @Test
+    fun melodyStampsCreatedAtFromThePlatformClock() {
+        assertTrue(Melody(name = "A", notes = emptyList()).createdAt > 0L)
+    }
+
+    @Test
+    fun melodyPreservesNoteOrder() {
+        val notes =
+            listOf(
+                MelodyNote(pitchClass = 0),
+                MelodyNote(pitchClass = null),
+                MelodyNote(pitchClass = 7, duration = NoteDuration.EIGHTH),
+            )
+        assertEquals(notes, Melody(name = "Tune", notes = notes).notes, "note order must be stable")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/NavSectionTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/NavSectionTest.kt
@@ -1,0 +1,68 @@
+package com.baijum.ukufretboard.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [NavSection], whose [NavSection.id] values are a persistence contract.
+ *
+ * The selected section is stored by id across configuration changes and process
+ * death, so an id that changes meaning silently reopens the wrong screen for
+ * every user who was last on it.
+ */
+class NavSectionTest {
+    // ── fromId ───────────────────────────────────────────────────────
+
+    @Test
+    fun fromIdRoundTripsEveryEntry() {
+        for (section in NavSection.entries) {
+            assertEquals(section, NavSection.fromId(section.id), "fromId lost ${section.name}")
+        }
+    }
+
+    @Test
+    fun fromIdReturnsNullForUnknownIds() {
+        assertNull(NavSection.fromId(-1), "-1 is not a section")
+        assertNull(NavSection.fromId(32), "32 is past the last section")
+        assertNull(NavSection.fromId(Int.MAX_VALUE), "Int.MAX_VALUE is not a section")
+        assertNull(NavSection.fromId(Int.MIN_VALUE), "Int.MIN_VALUE is not a section")
+    }
+
+    @Test
+    fun idTwentyFourIsRetiredAndResolvesToNull() {
+        // Deliberate gap, not an oversight: the section that held id 24 was removed
+        // and the id was never reused. FretboardScreen falls back to EXPLORER on a
+        // null lookup, so a saved state pointing here reopens Explorer rather than
+        // crashing. Reusing 24 would silently reopen the new screen instead.
+        assertNull(NavSection.fromId(24), "id 24 is retired and must stay unassigned")
+    }
+
+    // ── Id allocation ────────────────────────────────────────────────
+
+    @Test
+    fun idsAreUniqueAcrossEntries() {
+        val ids = NavSection.entries.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "duplicate ids: $ids")
+    }
+
+    @Test
+    fun idsCoverZeroThroughThirtyOneExceptTwentyFour() {
+        val expected = ((0..31).toSet() - 24)
+        assertEquals(expected, NavSection.entries.map { it.id }.toSet(), "id allocation drifted")
+    }
+
+    @Test
+    fun entryDeclarationOrderMatchesAscendingId() {
+        val ids = NavSection.entries.map { it.id }
+        assertEquals(ids.sorted(), ids, "entries are declared out of id order: $ids")
+    }
+
+    @Test
+    fun idsAreNonNegative() {
+        for (section in NavSection.entries) {
+            assertTrue(section.id >= 0, "${section.name} has a negative id ${section.id}")
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ScalePracticeEnumsTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ScalePracticeEnumsTest.kt
@@ -1,0 +1,129 @@
+package com.baijum.ukufretboard.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [PracticeMode], [PlayDirection] and [FretPosition].
+ *
+ * `ScalePracticeSettings` persists `lastMode`, `lastDirection` and
+ * `lastFretPosition` as **ordinals**, read back through `entries.getOrElse`.
+ * Reordering any of these enums therefore silently changes what a user's saved
+ * preference means, which is why the ordinal assertions below exist.
+ */
+class ScalePracticeEnumsTest {
+    // ── FretPosition.range ───────────────────────────────────────────
+
+    @Test
+    fun allReturnsNoRangeMeaningNoFilter() {
+        assertNull(FretPosition.ALL.range(), "ALL must not restrict the fretboard")
+        assertNull(FretPosition.ALL.range(22), "ALL ignores lastFret")
+    }
+
+    @Test
+    fun openCoversTheNutThroughFretFour() {
+        assertEquals(0..4, FretPosition.OPEN.range())
+    }
+
+    @Test
+    fun midCoversFourThroughEight() {
+        assertEquals(4..8, FretPosition.MID.range())
+    }
+
+    @Test
+    fun highStartsAtSevenAndRunsToTheLastFret() {
+        assertEquals(7..12, FretPosition.HIGH.range(12))
+        assertEquals(7..22, FretPosition.HIGH.range(22))
+    }
+
+    @Test
+    fun onlyHighRespondsToTheLastFretArgument() {
+        assertEquals(FretPosition.OPEN.range(12), FretPosition.OPEN.range(22))
+        assertEquals(FretPosition.MID.range(12), FretPosition.MID.range(22))
+        assertTrue(
+            FretPosition.HIGH.range(12) != FretPosition.HIGH.range(22),
+            "HIGH must extend with the fretboard",
+        )
+    }
+
+    @Test
+    fun positionsDeliberatelyOverlapAtFretsFourSevenAndEight() {
+        // The overlap is intentional: a scale shape near a boundary should be
+        // reachable from either position rather than being cut in half.
+        assertTrue(4 in FretPosition.OPEN.range()!! && 4 in FretPosition.MID.range()!!)
+        assertTrue(7 in FretPosition.MID.range()!! && 7 in FretPosition.HIGH.range(12)!!)
+        assertTrue(8 in FretPosition.MID.range()!! && 8 in FretPosition.HIGH.range(12)!!)
+    }
+
+    @Test
+    fun everyFretUpToTheLastIsCoveredByAtLeastOnePosition() {
+        for (lastFret in FretboardSettings.MIN_LAST_FRET..FretboardSettings.MAX_LAST_FRET) {
+            val covered =
+                buildSet {
+                    addAll(FretPosition.OPEN.range(lastFret)!!)
+                    addAll(FretPosition.MID.range(lastFret)!!)
+                    addAll(FretPosition.HIGH.range(lastFret)!!)
+                }
+            assertEquals(
+                (0..lastFret).toSet(),
+                covered,
+                "positions leave a gap when lastFret is $lastFret",
+            )
+        }
+    }
+
+    // ── Ordinals: the on-disk contract ───────────────────────────────
+
+    @Test
+    fun practiceModeOrdinalsAreTheOnDiskContract() {
+        assertEquals(
+            listOf("PLAY_ALONG", "QUIZ", "EAR_TRAINING"),
+            PracticeMode.entries.map { it.name },
+            "ScalePracticeSettings.lastMode stores this ordinal",
+        )
+    }
+
+    @Test
+    fun playDirectionOrdinalsAreTheOnDiskContract() {
+        assertEquals(
+            listOf("ASCENDING", "DESCENDING", "BOTH"),
+            PlayDirection.entries.map { it.name },
+            "ScalePracticeSettings.lastDirection stores this ordinal",
+        )
+    }
+
+    @Test
+    fun fretPositionOrdinalsAreTheOnDiskContract() {
+        assertEquals(
+            listOf("ALL", "OPEN", "MID", "HIGH"),
+            FretPosition.entries.map { it.name },
+            "ScalePracticeSettings.lastFretPosition stores this ordinal",
+        )
+    }
+
+    @Test
+    fun theDefaultSettingsOrdinalsResolveToTheFirstEntryOfEachEnum() {
+        val defaults = ScalePracticeSettings()
+        assertEquals(PracticeMode.PLAY_ALONG, PracticeMode.entries[defaults.lastMode])
+        assertEquals(PlayDirection.ASCENDING, PlayDirection.entries[defaults.lastDirection])
+        assertEquals(FretPosition.ALL, FretPosition.entries[defaults.lastFretPosition])
+    }
+
+    // ── Labels ───────────────────────────────────────────────────────
+
+    @Test
+    fun labelsAreUniqueAndNonBlankWithinEachEnum() {
+        for (labels in listOf(
+            PracticeMode.entries.map { it.label },
+            PlayDirection.entries.map { it.label },
+            FretPosition.entries.map { it.label },
+        )) {
+            assertEquals(labels.size, labels.toSet().size, "duplicate labels: $labels")
+            for (label in labels) {
+                assertTrue(label.isNotBlank(), "blank label in $labels")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds tests for the code that had none, concentrated in the paths that handle user data on disk. Sixteen new test files plus one extended, no new dependencies, no changes to how anything behaves — except two data bugs the tests uncovered.

Shared tests go 1,003 → 1,135; Android unit tests 242 → 405.

## Coverage

Nine classes had no test at all and are now near-fully covered:

| Class | Line coverage |
|---|---|
| `LegacySettingsReader` | 100% |
| `SettingsViewModel` | 100% |
| `FavoritesViewModel` | 100% |
| `SetlistViewModel` | 100% |
| `CustomProgressionViewModel` | 100% |
| `JsonListRepository` | 100% |
| `CustomProgressionRepository` | 98% |
| `AchievementContextAdapter` | 100% |
| `FrameGateExt` | 100% |

On the shared side, eleven `data/` files had no test. The gaps worth closing were the ones holding on-disk contracts: `FavoriteVoicing.key` is the de-duplication identity both the repository and the ViewModel compare by, `IntRangeSerializer` emits the field names every stored `suggestedBpm` depends on, `NoteDuration.name` is what `MelodyRepository` writes into each saved melody, and `ScalePracticeSettings` persists three enums by ordinal. Shared instruction coverage is now 94.6%.

`CapoReference` and `ChordSubstitutions` are educational content the app renders verbatim, so those tests recompute each claim from the chord formulas rather than checking that fields are non-blank — every capo position's shape plus fret really does sound its stated key, every friendly shape's fret string really does spell its named chord, and the worked examples embedded in the lesson prose match the capo arithmetic.

## Two bugs found and fixed

**Baritone B string octave.** `BARITONE` declared octaves `3,3,4,4` against pitch classes D-G-B-E. Under the app's own convention in `TunerNoteMapper.targetFrequency` that spells D3 G3 **B4** E4, putting the B string an octave above where it belongs and above the E string beside it. The tuner aimed at 493.9 Hz instead of 246.9 Hz, so it could never match the note a player was actually sounding; `PatternPlayer` pitched that string an octave high, the fretboard and tuner showed the wrong octave, and `isReentrant` reported this linear tuning as re-entrant. The other seven tunings were already correct.

**Three wrong "shared notes" strings.** F major is F-A-C and Dm is D-F-A, so `IV → ii` shares F and A — not "D and F", since D is not in an F major triad. G is G-B-D and Em is E-G-B, so `V → iii` shares G and B, not "E and G". Three rows across two categories were teaching the wrong theory. The other ten rows were correct.

Both fixes are separate commits. Their assertions were written correct-but-`@Ignore`d in the test commits, then enabled by the fix. Each was checked for discrimination — reverting to the old data makes them fail (`50, 55, 71, 64` instead of `50, 55, 59, 64`; `expected:<[5, 9]> but was:<[2, 5]>`).

## Weaknesses pinned rather than fixed

Each has a test asserting today's behavior and a comment explaining why, so changing any of them is a deliberate act:

- The `JsonListRepository` quarantine is a single slot — a second corruption overwrites the payload the mechanism exists to preserve.
- `persist()` copies the primary into the backup without checking it parses, so after a corrupt read the next save destroys the last good copy.
- `CustomProgressionRepository`'s legacy migration deletes the backup key it wrote two lines earlier (`FavoritesRepository` excludes its own; the two custom-pattern repos share the bug).
- Settings have no backup key at all, so one bad write silently resets every preference.
- Legacy settings migration is gated on the unrelated `sound_enabled` key — a user who only ever changed their theme loses it on upgrade.
- `filteringToRms` passes NaN straight through `coerceIn`.

Also worth noting: `JsonListRepository.getAll()` is currently dead code in the shipping app, since all five subclasses override it. Those tests cover the contract the next repository will inherit.

## Not done

`ChordImageSharer` is not unit-testable in this harness and was dropped from scope. `FileProvider` fails because `testOptions.unitTests.isIncludeAndroidResources` is off; enabling it resolves that and leaves all existing tests passing, but file I/O then hits `NoClassDefFoundError: JazzerInternal` — the Jazzer agent instruments `file.outputStream()` and Robolectric's `SandboxClassLoader` cannot resolve its runtime class. It needs an instrumented test instead. The build change was reverted so this PR stays tests-only.

The three coroutine/audio ViewModels (`Tuner` 879 LOC, `Melody` 683, `PitchMonitor` 579) are still uncovered — they need either `kotlinx-coroutines-test` or the extract-to-shared refactor already used for `MetronomeStateLogic` and `PitchMonitorStateMachine`. Deliberately out of scope here.

## Verification

`scripts/preflight.sh` passes — ktlint ratchet, shared KMP tests, Android unit tests, Android lint. `./gradlew detekt` passes. The shared module still compiles for `iosSimulatorArm64`; iOS references only the baritone label and enum name, neither of which changed.

Instrumented tests were not run — no UI or accessibility surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Baritone ukulele tuning so the third string uses the proper octave.
  * Fixed shared-note descriptions in chord substitution lessons.
  * Improved confidence in settings migration, saved data recovery, favorites, setlists, custom progressions, and learning progress behavior.

* **Quality Improvements**
  * Added comprehensive automated coverage for music theory content, tunings, serialization, navigation, practice settings, and core app workflows.
  * Added validation for lesson content, capo examples, chord substitutions, and educational tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->