### PR TITLE
Fix: Keep a corrupt list payload out of the backup slot

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -70,12 +70,24 @@ abstract class JsonListRepository<T>(
         persist(merged)
     }
 
+    /**
+     * Writes the list, rotating the outgoing payload into the backup slot.
+     *
+     * The backup only advances to a payload that is known to parse: promoting a
+     * corrupt primary would destroy the last good copy, which is the one thing
+     * the backup exists to hold. When neither copy is readable the backup is
+     * re-seeded with the payload being written, so the next corruption has
+     * something to recover from.
+     */
     protected fun persist(items: List<T>) {
         val raw = json.encodeToString(ListSerializer(serializer), items)
-        val previousGood = prefs.getString(key, null)
-        prefs.edit()
-            .putString(backupKey, previousGood ?: raw)
-            .putString(key, raw)
-            .apply()
+        val lastGood = prefs.getString(key, null)?.takeIf { tryParse(it) != null }
+        val editor = prefs.edit().putString(key, raw)
+        if (lastGood != null) {
+            editor.putString(backupKey, lastGood)
+        } else if (tryParse(prefs.getString(backupKey, null)) == null) {
+            editor.putString(backupKey, raw)
+        }
+        editor.apply()
     }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/JsonListRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/JsonListRepositoryTest.kt
@@ -23,9 +23,10 @@ import org.robolectric.RobolectricTestRunner
  *
  * Worth knowing while reading these: all five production subclasses override
  * `getAll()`, so the base implementation below — including the entire quarantine
- * branch — is currently unreachable in the shipping app. These tests cover the
- * contract the next repository to extend this class will inherit, and pin the
- * three weaknesses noted inline so that changing them is a deliberate act.
+ * branch — is currently unreachable in the shipping app. `persist()` is shared by
+ * all of them, though, so the rotation tests below cover live behaviour. These
+ * tests also pin the remaining weakness noted inline so that changing it is a
+ * deliberate act.
  */
 @RunWith(RobolectricTestRunner::class)
 class JsonListRepositoryTest {
@@ -243,18 +244,39 @@ class JsonListRepositoryTest {
     }
 
     @Test
-    fun persistPromotesTheCorruptPrimaryIntoTheBackupSlot() {
-        // Pinned weakness: persist() copies whatever is in the primary key into
-        // the backup without checking that it parses. Once getAll() has already
-        // found the primary corrupt, the next save() therefore overwrites the
-        // last good copy with the corrupt one.
+    fun persistLeavesTheBackupAloneWhenThePrimaryIsUnparseable() {
+        // The backup only advances to a payload that parses. Promoting a corrupt
+        // primary would destroy the last good copy — the one thing it exists to hold.
+        repo.save(entity("a", name = "good"))
+        val lastGood = prefs.getString(BACKUP_KEY, null)
+        writeRaw(DATA_KEY, "corrupt")
+        repo.save(entity("b"))
+
+        assertEquals("the corrupt primary must not be promoted", lastGood, prefs.getString(BACKUP_KEY, null))
+    }
+
+    @Test
+    fun aSaveOverACorruptPrimaryLeavesTheStoreRecoverableAfterTheNextCorruption() {
         repo.save(entity("a", name = "good"))
         writeRaw(DATA_KEY, "corrupt")
         repo.save(entity("b"))
 
+        // Second corruption: the surviving backup is what keeps the data alive.
+        writeRaw(DATA_KEY, "corrupt again")
+
+        assertEquals("the backup should still serve the last good copy", listOf("a"), repo.getAll().map { it.id })
+        assertNull("a recoverable read must not quarantine", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    @Test
+    fun persistReseedsTheBackupWhenNeitherStoredCopyIsParseable() {
+        writeRaw(DATA_KEY, "corrupt")
+        writeRaw(BACKUP_KEY, "also corrupt")
+        repo.save(entity("a"))
+
         assertEquals(
-            "today the corrupt primary is promoted into the backup",
-            "corrupt",
+            "with nothing worth keeping, the backup is re-seeded with the new payload",
+            prefs.getString(DATA_KEY, null),
             prefs.getString(BACKUP_KEY, null),
         )
     }


### PR DESCRIPTION
Fixes #553.

## The bug

`JsonListRepository.persist()` rotated the backup unconditionally:

```kotlin
val previousGood = prefs.getString(key, null)
prefs.edit()
    .putString(backupKey, previousGood ?: raw)
    .putString(key, raw)
    .apply()
```

`previousGood` was trusted without checking that it parses. Once `getAll()` had already found the primary unreadable and fallen back, the very next `save()` copied that corrupt string into `${key}_backup` — destroying the last good copy, which is the one thing the backup exists to hold. The next corruption then had nothing to fall back to and the data was quarantined instead of recovered.

`getAll()`'s fallback branch is overridden by all five subclasses today, but `persist()` is shared by all of them, so this rotation was live.

## The fix

The backup now only advances to a payload that is known to parse. When neither stored copy is readable there is nothing worth keeping, so the backup is re-seeded with the payload being written and the next corruption again has somewhere to fall back to.

This mirrors the rotation rule `SettingsRepository.save()` already follows (#555).

Two files, one commit — the settings-side changes that were originally in this PR are now split out into #559.

## Verification

Three new tests in `JsonListRepositoryTest`, replacing `persistPromotesTheCorruptPrimaryIntoTheBackupSlot` which pinned the old behaviour:

- `persistLeavesTheBackupAloneWhenThePrimaryIsUnparseable`
- `aSaveOverACorruptPrimaryLeavesTheStoreRecoverableAfterTheNextCorruption` — walks the full issue scenario through to a second corruption
- `persistReseedsTheBackupWhenNeitherStoredCopyIsParseable`

All three were confirmed to discriminate: re-introducing the original `persist()` body makes exactly those three fail, and nothing else.

`scripts/preflight.sh` green (ktlint ratchet, shared KMP tests, Android unit tests, lint) and `:app:detekt` clean. No UI changes, so no accessibility surface is touched.

## Note on the two repositories' re-seed rules

They now differ slightly, which is worth a deliberate decision rather than drift:

- `JsonListRepository` (here): re-seeds when `tryParse(backup) == null`
- `SettingsRepository` (already on `main` from #555): re-seeds when `!prefs.contains(backup)`

The first also heals a backup that exists but is corrupt; the second waits until the following save. I left `SettingsRepository` alone to keep this PR to the issue — happy to unify either way as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)