### PR TITLE
Fix: Save settings only from the state the update actually published

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/LegacySettingsReader.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/LegacySettingsReader.kt
@@ -1,18 +1,6 @@
-package com.baijum.ukufretboard.viewmodel
+package com.baijum.ukufretboard.data
 
 import android.content.SharedPreferences
-import com.baijum.ukufretboard.data.AppSettings
-import com.baijum.ukufretboard.data.ChordColorOption
-import com.baijum.ukufretboard.data.ChordDisplayStyle
-import com.baijum.ukufretboard.data.DisplaySettings
-import com.baijum.ukufretboard.data.FretboardSettings
-import com.baijum.ukufretboard.data.PitchMonitorSettings
-import com.baijum.ukufretboard.data.ScalePracticeSettings
-import com.baijum.ukufretboard.data.SoundSettings
-import com.baijum.ukufretboard.data.ThemeMode
-import com.baijum.ukufretboard.data.TunerSettings
-import com.baijum.ukufretboard.data.TuningSettings
-import com.baijum.ukufretboard.data.UkuleleTuning
 
 /**
  * Reads legacy individual-key SharedPreferences and constructs an [AppSettings].

--- a/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
@@ -3,7 +3,6 @@ package com.baijum.ukufretboard.data
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
-import com.baijum.ukufretboard.viewmodel.LegacySettingsReader
 import kotlinx.serialization.json.Json
 
 /**

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/SettingsViewModel.kt
@@ -14,7 +14,7 @@ import com.baijum.ukufretboard.data.TuningSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 
 /**
  * ViewModel that manages all application settings.
@@ -49,81 +49,91 @@ class SettingsViewModel(
      *   and returns the updated [SoundSettings].
      */
     fun updateSound(transform: (SoundSettings) -> SoundSettings) {
-        _settings.update { current ->
-            current.copy(sound = transform(current.sound)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(sound = transform(current.sound))
+            },
+        )
     }
 
     /**
      * Updates the display settings by applying a transformation function.
      */
     fun updateDisplay(transform: (DisplaySettings) -> DisplaySettings) {
-        _settings.update { current ->
-            current.copy(display = transform(current.display)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(display = transform(current.display))
+            },
+        )
     }
 
     /**
      * Updates the tuning settings by applying a transformation function.
      */
     fun updateTuning(transform: (TuningSettings) -> TuningSettings) {
-        _settings.update { current ->
-            current.copy(tuning = transform(current.tuning)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(tuning = transform(current.tuning))
+            },
+        )
     }
 
     /**
      * Updates the fretboard settings by applying a transformation function.
      */
     fun updateFretboard(transform: (FretboardSettings) -> FretboardSettings) {
-        _settings.update { current ->
-            current.copy(fretboard = transform(current.fretboard)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(fretboard = transform(current.fretboard))
+            },
+        )
     }
 
     /**
      * Updates the scale practice settings by applying a transformation function.
      */
     fun updateScalePractice(transform: (ScalePracticeSettings) -> ScalePracticeSettings) {
-        _settings.update { current ->
-            current.copy(scalePractice = transform(current.scalePractice)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(scalePractice = transform(current.scalePractice))
+            },
+        )
     }
 
     /**
      * Updates the tuner settings by applying a transformation function.
      */
     fun updateTuner(transform: (TunerSettings) -> TunerSettings) {
-        _settings.update { current ->
-            current.copy(tuner = transform(current.tuner)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(tuner = transform(current.tuner))
+            },
+        )
     }
 
     /**
      * Updates the pitch monitor settings by applying a transformation function.
      */
     fun updatePitchMonitor(transform: (PitchMonitorSettings) -> PitchMonitorSettings) {
-        _settings.update { current ->
-            current.copy(pitchMonitor = transform(current.pitchMonitor)).also { saveSettings(it) }
-        }
+        saveSettings(
+            _settings.updateAndGet { current ->
+                current.copy(pitchMonitor = transform(current.pitchMonitor))
+            },
+        )
     }
 
     /**
      * Marks onboarding as completed so the wizard is not shown again.
      */
     fun completeOnboarding() {
-        _settings.update { current ->
-            current.copy(onboardingCompleted = true).also { saveSettings(it) }
-        }
+        saveSettings(_settings.updateAndGet { it.copy(onboardingCompleted = true) })
     }
 
     /**
      * Dismisses the Explorer tips card so it is not shown again.
      */
     fun dismissExplorerTips() {
-        _settings.update { current ->
-            current.copy(explorerTipsDismissed = true).also { saveSettings(it) }
-        }
+        saveSettings(_settings.updateAndGet { it.copy(explorerTipsDismissed = true) })
     }
 
     /**
@@ -140,5 +150,15 @@ class SettingsViewModel(
      */
     fun exportSettings(): AppSettings = _settings.value
 
+    /**
+     * Persists [s] via the repository.
+     *
+     * Always called on the value [MutableStateFlow.updateAndGet] actually
+     * published, never from inside the update lambda: that lambda is a
+     * compare-and-set body and re-runs on contention, so a save placed there
+     * would write candidate states that lost the race. Because
+     * [SettingsRepository.save] rotates the outgoing payload into the backup,
+     * one such stray write costs both the primary and the last good copy.
+     */
     private fun saveSettings(s: AppSettings) = repository.save(s)
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/LegacySettingsReaderTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/LegacySettingsReaderTest.kt
@@ -1,19 +1,9 @@
-package com.baijum.ukufretboard.viewmodel
+package com.baijum.ukufretboard.data
 
 import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
-import com.baijum.ukufretboard.data.AppSettings
-import com.baijum.ukufretboard.data.ChordColorOption
-import com.baijum.ukufretboard.data.ChordDisplayStyle
-import com.baijum.ukufretboard.data.FretboardSettings
-import com.baijum.ukufretboard.data.PitchMonitorSettings
-import com.baijum.ukufretboard.data.ScalePracticeSettings
-import com.baijum.ukufretboard.data.SoundSettings
-import com.baijum.ukufretboard.data.ThemeMode
-import com.baijum.ukufretboard.data.TunerSettings
-import com.baijum.ukufretboard.data.UkuleleTuning
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
@@ -298,6 +298,28 @@ class SettingsViewModelTest {
         assertEquals("}} not json {{", prefs.getString(KEY_QUARANTINE, null))
     }
 
+    @Test
+    fun theBackupSelfHealsOnTheSaveAfterBothCopiesWereCorrupt() {
+        writeRaw(KEY_SETTINGS, "}} not json {{")
+        writeRaw(KEY_BACKUP, "also not json")
+
+        newViewModel().updateSound { it.copy(enabled = false) }
+        val firstValidPayload = storedJson()
+        assertNotEquals(
+            "the save after a double corruption cannot promote the unparseable primary",
+            firstValidPayload,
+            backupJson(),
+        )
+
+        newViewModel().updateFretboard { it.copy(lastFret = 20) }
+
+        assertEquals(
+            "the next save rotates the recovered primary in, so the backup stops holding garbage",
+            firstValidPayload,
+            backupJson(),
+        )
+    }
+
     // ── Legacy migration ─────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Split out of #558, which is now just the #553 fix. These two changes are backup-integrity adjacent rather than part of that issue, so they belong on their own.

Independent of #558 — this branch is cut from `main` and the two touch disjoint files.

## 1. Saving from inside a compare-and-set lambda

Every `updateX()` in `SettingsViewModel` ran `saveSettings()` from inside the `MutableStateFlow.update` lambda:

```kotlin
_settings.update { current ->
    current.copy(sound = transform(current.sound)).also { saveSettings(it) }
}
```

`update` is a CAS loop — the lambda re-runs on contention, and `also { saveSettings(it) }` fires on every attempt, including the ones that lose the race. So a candidate state that was never published could still reach disk.

That matters more than a normal lost update, because `SettingsRepository.save()` rotates the outgoing payload into the backup. One stray write costs the primary *and* the last good copy in a single step.

Switched to `updateAndGet()` and moved the save outside the lambda, so it only ever runs on the value that was actually published.

**On testing:** I have not added a test that reproduces the race — forcing reliable contention on a `MutableStateFlow` CAS retry isn't practical here, and a test that only passes intermittently would be worse than none. The change is a structural fix; the accompanying test covers the backup-rotation behaviour it protects, not the race itself. Flagging that explicitly so it's a known gap rather than an assumed-covered one.

## 2. `LegacySettingsReader` layering

`SettingsRepository` (in `data/`) reached up into `viewmodel/` to read legacy individual-key settings. The reader only touches `SharedPreferences` and `AppSettings` — no ViewModel concerns — so it moves down beside its one caller. Recorded as a real `git mv`, so the diff shows as a rename; the only content change is dropping twelve now-redundant imports across the reader and its test.

## Verification

`scripts/preflight.sh` green on this branch standalone (ktlint ratchet, shared KMP tests, Android unit tests, lint), `:app:detekt` clean. New test `theBackupSelfHealsOnTheSaveAfterBothCopiesWereCorrupt` in `SettingsViewModelTest`. No UI changes, so no accessibility surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)