### PR TITLE
Fix: Re-seed a corrupt settings backup on the same save

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
@@ -58,7 +58,9 @@ class SettingsRepository(
      *
      * The backup only advances to a payload that is known to parse: promoting a
      * corrupt primary would destroy the last good copy, which is the one thing
-     * the backup exists to hold.
+     * the backup exists to hold. When neither copy is readable the backup is
+     * re-seeded with the payload being written, so the next corruption has
+     * something to recover from.
      */
     fun save(settings: AppSettings) {
         val raw = json.encodeToString(AppSettings.serializer(), settings)
@@ -66,7 +68,7 @@ class SettingsRepository(
         val editor = prefs.edit().putString(KEY_SETTINGS, raw)
         if (lastGood != null) {
             editor.putString(KEY_SETTINGS_BACKUP, lastGood)
-        } else if (!prefs.contains(KEY_SETTINGS_BACKUP)) {
+        } else if (tryParse(prefs.getString(KEY_SETTINGS_BACKUP, null)) == null) {
             editor.putString(KEY_SETTINGS_BACKUP, raw)
         }
         editor.apply()

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
@@ -299,24 +299,34 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun theBackupSelfHealsOnTheSaveAfterBothCopiesWereCorrupt() {
+    fun theBackupIsReseededOnTheSaveThatFollowsADoubleCorruption() {
         writeRaw(KEY_SETTINGS, "}} not json {{")
         writeRaw(KEY_BACKUP, "also not json")
 
         newViewModel().updateSound { it.copy(enabled = false) }
-        val firstValidPayload = storedJson()
-        assertNotEquals(
-            "the save after a double corruption cannot promote the unparseable primary",
-            firstValidPayload,
+
+        // Neither stored copy was worth keeping, so the backup does not wait a
+        // second save to stop holding garbage.
+        assertEquals(
+            "with nothing worth keeping, the backup is re-seeded with the new payload",
+            storedJson(),
             backupJson(),
         )
+    }
 
-        newViewModel().updateFretboard { it.copy(lastFret = 20) }
+    @Test
+    fun aReseededBackupSurvivesTheNextCorruption() {
+        writeRaw(KEY_SETTINGS, "}} not json {{")
+        writeRaw(KEY_BACKUP, "also not json")
+        newViewModel().updateSound { it.copy(enabled = false) }
 
-        assertEquals(
-            "the next save rotates the recovered primary in, so the backup stops holding garbage",
-            firstValidPayload,
-            backupJson(),
+        // The point of re-seeding: the store is recoverable again straight away.
+        writeRaw(KEY_SETTINGS, "corrupt again")
+
+        assertFalse(
+            "the re-seeded backup is what keeps the setting alive",
+            newViewModel()
+                .settings.value.sound.enabled,
         )
     }
 


### PR DESCRIPTION
Follow-up to the divergence flagged in #558. `SettingsRepository` and `JsonListRepository` protect their payloads the same way but disagreed on one branch of the rotation rule; this closes that gap.

## The divergence

Both stores rotate the outgoing primary into a backup, and both refuse to promote a primary that doesn't parse. They differed only on when to *re-seed* a backup that is not worth keeping:

| | re-seed condition |
|---|---|
| `JsonListRepository.persist()` | `tryParse(backup) == null` |
| `SettingsRepository.save()` (before this PR) | `!prefs.contains(backup)` |

`contains` asks whether the key exists, not whether it holds anything readable. So a backup that was present but corrupt was left in place.

## Why it mattered

After a double corruption the settings store stayed unrecoverable for one extra save:

1. Both `settings_json` and its backup are corrupt. `load()` quarantines and returns defaults.
2. The user changes a setting. The primary is now valid again — but the backup still holds garbage, because the key existed.
3. A corruption in *that* window has nothing to fall back to.
4. Only the save after that rotates a good primary into the backup.

Settings are the one store a user cannot re-create by hand, so leaving a known-useless backup in place for a whole extra write cycle is the wrong side to err on.

## The change

One condition, plus its doc comment. Behaviour is unchanged when the backup is absent or valid — only the present-but-unparseable case moves, and it moves toward recovery.

I kept this to the behavioural unification. The two `save`/`persist` bodies are now near-identical in shape but operate on different types (`AppSettings` vs `List<T>`), so factoring out a shared helper is a real but separate refactor — happy to do it if you'd like.

## Verification

`theBackupSelfHealsOnTheSaveAfterBothCopiesWereCorrupt` pinned the old two-save behaviour and would have failed, so it is replaced by two tests describing the new contract:

- `theBackupIsReseededOnTheSaveThatFollowsADoubleCorruption` — the backup stops holding garbage immediately
- `aReseededBackupSurvivesTheNextCorruption` — walks through to a second corruption and shows the setting survives

Both confirmed to discriminate: restoring `!prefs.contains(...)` fails exactly those two and nothing else in the 29-test class. The existing `aCorruptPrimaryIsNotPromotedIntoTheBackupByTheNextSave` still covers the protective case where the backup is valid.

`scripts/preflight.sh` green (ktlint ratchet, shared KMP tests, Android unit tests, lint) and `:app:detekt` clean. No UI changes, so no accessibility surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)