### PR TITLE
Refactor: Extract the shared backup rotation rule

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/BackupRotation.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/BackupRotation.kt
@@ -1,0 +1,48 @@
+package com.baijum.ukufretboard.data
+
+import android.content.SharedPreferences
+
+/**
+ * Writes [raw] to [key] and rotates the outgoing payload into [backupKey].
+ *
+ * The backup only ever advances to a payload that [isReadable] accepts.
+ * Promoting a copy that can no longer be read would destroy the last good one,
+ * which is the single thing the backup exists to hold: once the primary is
+ * corrupt, the backup is what the next read recovers from. When neither stored
+ * copy is readable there is nothing worth preserving, so the backup is re-seeded
+ * with [raw] and the next corruption again has somewhere to fall back to.
+ *
+ * Both stores that need this — [SettingsRepository] and [JsonListRepository] —
+ * differ only in how they encode and parse their payload, so the rule itself
+ * lives here rather than being written out once per store. It was written out
+ * twice before, and the two copies drifted: one re-seeded on whether the backup
+ * key existed, the other on whether it parsed (#553, #560).
+ *
+ * [isReadable] is called at most twice and never on the common path where the
+ * primary parses, so a store whose payload is expensive to parse pays for the
+ * check only when something has already gone wrong.
+ */
+internal fun SharedPreferences.writeWithBackupRotation(
+    key: String,
+    backupKey: String,
+    raw: String,
+    isReadable: (String) -> Boolean,
+) {
+    val lastGood = getString(key, null)?.takeIf(isReadable)
+    val editor = edit().putString(key, raw)
+    if (lastGood != null) {
+        editor.putString(backupKey, lastGood)
+    } else if (!holdsReadable(backupKey, isReadable)) {
+        editor.putString(backupKey, raw)
+    }
+    editor.apply()
+}
+
+/**
+ * True when [key] holds a payload that [isReadable] accepts. A missing key is
+ * not readable, so an absent backup is re-seeded the same way a corrupt one is.
+ */
+private fun SharedPreferences.holdsReadable(
+    key: String,
+    isReadable: (String) -> Boolean,
+): Boolean = getString(key, null)?.let(isReadable) == true

--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -73,21 +73,14 @@ abstract class JsonListRepository<T>(
     /**
      * Writes the list, rotating the outgoing payload into the backup slot.
      *
-     * The backup only advances to a payload that is known to parse: promoting a
-     * corrupt primary would destroy the last good copy, which is the one thing
-     * the backup exists to hold. When neither copy is readable the backup is
-     * re-seeded with the payload being written, so the next corruption has
-     * something to recover from.
+     * See [writeWithBackupRotation] for the rule the backup follows.
      */
     protected fun persist(items: List<T>) {
-        val raw = json.encodeToString(ListSerializer(serializer), items)
-        val lastGood = prefs.getString(key, null)?.takeIf { tryParse(it) != null }
-        val editor = prefs.edit().putString(key, raw)
-        if (lastGood != null) {
-            editor.putString(backupKey, lastGood)
-        } else if (tryParse(prefs.getString(backupKey, null)) == null) {
-            editor.putString(backupKey, raw)
-        }
-        editor.apply()
+        prefs.writeWithBackupRotation(
+            key = key,
+            backupKey = backupKey,
+            raw = json.encodeToString(ListSerializer(serializer), items),
+            isReadable = { tryParse(it) != null },
+        )
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
@@ -56,22 +56,15 @@ class SettingsRepository(
     /**
      * Writes the settings, rotating the outgoing payload into the backup slot.
      *
-     * The backup only advances to a payload that is known to parse: promoting a
-     * corrupt primary would destroy the last good copy, which is the one thing
-     * the backup exists to hold. When neither copy is readable the backup is
-     * re-seeded with the payload being written, so the next corruption has
-     * something to recover from.
+     * See [writeWithBackupRotation] for the rule the backup follows.
      */
     fun save(settings: AppSettings) {
-        val raw = json.encodeToString(AppSettings.serializer(), settings)
-        val lastGood = prefs.getString(KEY_SETTINGS, null)?.takeIf { tryParse(it) != null }
-        val editor = prefs.edit().putString(KEY_SETTINGS, raw)
-        if (lastGood != null) {
-            editor.putString(KEY_SETTINGS_BACKUP, lastGood)
-        } else if (tryParse(prefs.getString(KEY_SETTINGS_BACKUP, null)) == null) {
-            editor.putString(KEY_SETTINGS_BACKUP, raw)
-        }
-        editor.apply()
+        prefs.writeWithBackupRotation(
+            key = KEY_SETTINGS,
+            backupKey = KEY_SETTINGS_BACKUP,
+            raw = json.encodeToString(AppSettings.serializer(), settings),
+            isReadable = { tryParse(it) != null },
+        )
     }
 
     private fun tryParse(raw: String?): AppSettings? {


### PR DESCRIPTION
> **Stacked on #560** — based on `unify-settings-backup-reseed-rule`, not `main`, because that PR touches the exact code being extracted here. Review/merge #560 first; I'll retarget this to `main` once it lands. The diff shown is just this commit.

Closes out the duplication noted in #560.

## Why

`SettingsRepository.save()` and `JsonListRepository.persist()` implemented the same rotation rule over different payload types. Written out twice, they drifted — one re-seeded on whether the backup key *existed*, the other on whether it *parsed*. That was #560. And the promote-a-corrupt-primary bug behind #553 had to be found and fixed in each store separately, because there was no single place for it to be wrong.

Three PRs in a row have now touched these two bodies in lockstep. That's the signal.

## What

Both stores differ only in how they encode and parse, and both reduce to strings at the `SharedPreferences` boundary — so the rule itself needs no generics. It moves into one extension parameterised by a readability predicate:

```kotlin
internal fun SharedPreferences.writeWithBackupRotation(
    key: String,
    backupKey: String,
    raw: String,
    isReadable: (String) -> Boolean,
)
```

Each call site becomes a four-argument call. Neither store can drift from the other now without the change being visible in one place.

## No behaviour change

Deliberately preserved: `isReadable` is still evaluated **lazily**. The obvious way to write this — hoisting `backupIsWorthKeeping` into a `val` — would parse the backup payload on *every* save, including the common path where the primary is fine. For settings that's a parse per toggle; for song lists it's a parse of a potentially large array. The `else if` keeps the check on the failure path only.

## Verification

A pure refactor needs proof the tests actually reach the new code from both call sites, not just that they still pass. I broke the helper two ways and checked which tests noticed:

| Injected fault | Tests that failed |
|---|---|
| Promote the primary without checking it parses | 3 in `JsonListRepositoryTest` + 3 in `SettingsViewModelTest` |
| Never re-seed when neither copy is readable | 4 in `JsonListRepositoryTest` + 4 in `SettingsViewModelTest` |

Both faults are caught from **both** stores, which is what confirms both call sites genuinely route through the helper and both of its branches remain covered. Restored, all 50 pass.

`scripts/preflight.sh` green (ktlint ratchet, shared KMP tests, Android unit tests, lint) and `:app:detekt` clean. No new tests — the point is that the existing ones now exercise shared code.

## Still duplicated

The **read** side. `SettingsRepository.load()` and `JsonListRepository.getAll()` have the same try-primary / fall-back-to-backup / quarantine shape, and carry the same drift risk. I left it alone because unifying it is not the same shape of change: it needs a three-way outcome (readable / absent / unrecoverable) to serve settings' legacy-migration tail and lists' empty case, plus per-store log tags. Worth doing, but as its own PR with its own argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)