### PR TITLE
Refactor: Extract the shared backup fallback rule

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/BackupRead.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/BackupRead.kt
@@ -1,0 +1,60 @@
+package com.baijum.ukufretboard.data
+
+import android.content.SharedPreferences
+import android.util.Log
+
+/**
+ * The outcome of reading a payload that is protected by a backup slot.
+ *
+ * The three cases are kept apart because callers genuinely treat them
+ * differently: a store with nothing written yet may still have a legacy layout
+ * to migrate, whereas one whose copies are both unreadable has already lost its
+ * data and can only start over.
+ */
+internal sealed interface BackupRead<out T> {
+    /** A payload was read, from either the primary slot or the backup. */
+    data class Loaded<T>(
+        val value: T,
+    ) : BackupRead<T>
+
+    /** Nothing has ever been written to the primary slot. */
+    data object Absent : BackupRead<Nothing>
+
+    /** Both copies were unreadable. The primary's raw bytes have been quarantined. */
+    data object Unrecoverable : BackupRead<Nothing>
+}
+
+/**
+ * Reads [key], falling back to [backupKey] when the primary payload cannot be
+ * parsed by [tryParse].
+ *
+ * When neither copy is readable the primary's raw bytes are moved to
+ * [quarantineKey] rather than left to be overwritten by the next save, so they
+ * survive for a support request instead of disappearing silently. Quarantining
+ * is the only write this function performs.
+ *
+ * This is the read half of the scheme whose write half is
+ * [writeWithBackupRotation]; the two are meant to be changed together, which is
+ * why neither is written out per store. See that function for why the rule
+ * lives in one place.
+ */
+internal fun <T> SharedPreferences.readWithBackupFallback(
+    key: String,
+    backupKey: String,
+    quarantineKey: String,
+    tag: String,
+    tryParse: (String?) -> T?,
+): BackupRead<T> {
+    val raw = getString(key, null) ?: return BackupRead.Absent
+
+    tryParse(raw)?.let { return BackupRead.Loaded(it) }
+
+    tryParse(getString(backupKey, null))?.let { recovered ->
+        Log.w(tag, "$key unparseable; recovered from $backupKey")
+        return BackupRead.Loaded(recovered)
+    }
+
+    Log.e(tag, "$key and its backup are both unparseable; quarantining")
+    edit().putString(quarantineKey, raw).apply()
+    return BackupRead.Unrecoverable
+}

--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -1,7 +1,6 @@
 package com.baijum.ukufretboard.data
 
 import android.content.Context
-import android.util.Log
 import com.baijum.ukufretboard.domain.mergeKeepExisting
 import com.baijum.ukufretboard.domain.mergeNewerWins
 import kotlinx.serialization.KSerializer
@@ -29,16 +28,27 @@ abstract class JsonListRepository<T>(
     protected val backupKey get() = "${key}_backup"
     private val quarantineKey get() = "${key}_quarantine"
 
+    /**
+     * Reads the list, falling back to the backup copy when the primary payload
+     * cannot be parsed. See [readWithBackupFallback] for the rule.
+     *
+     * An empty list is the answer both to a store that was never written and to
+     * one whose copies are both unreadable: unlike settings there is no legacy
+     * layout to migrate, so the two cases lead to the same place.
+     */
     open fun getAll(): List<T> {
-        val raw = prefs.getString(key, null) ?: return emptyList()
-        tryParse(raw)?.let { return it }
-
-        val backupRaw = prefs.getString(backupKey, null)
-        tryParse(backupRaw)?.let { return it }
-
-        Log.e("JsonListRepository", "Both primary and backup keys unparseable for '$key'; quarantining data")
-        prefs.edit().putString(quarantineKey, raw).apply()
-        return emptyList()
+        val read =
+            prefs.readWithBackupFallback(
+                key = key,
+                backupKey = backupKey,
+                quarantineKey = quarantineKey,
+                tag = TAG,
+                tryParse = ::tryParse,
+            )
+        return when (read) {
+            is BackupRead.Loaded -> read.value
+            BackupRead.Absent, BackupRead.Unrecoverable -> emptyList()
+        }
     }
 
     protected fun tryParse(raw: String?): List<T>? {
@@ -82,5 +92,9 @@ abstract class JsonListRepository<T>(
             raw = json.encodeToString(ListSerializer(serializer), items),
             isReadable = { tryParse(it) != null },
         )
+    }
+
+    private companion object {
+        const val TAG = "JsonListRepository"
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
@@ -2,7 +2,6 @@ package com.baijum.ukufretboard.data
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
 import kotlinx.serialization.json.Json
 
 /**
@@ -35,23 +34,32 @@ class SettingsRepository(
      * support request rather than disappearing silently.
      */
     fun load(): AppSettings {
-        val raw = prefs.getString(KEY_SETTINGS, null)
-        if (raw != null) {
-            tryParse(raw)?.let { return it }
+        val read =
+            prefs.readWithBackupFallback(
+                key = KEY_SETTINGS,
+                backupKey = KEY_SETTINGS_BACKUP,
+                quarantineKey = KEY_SETTINGS_QUARANTINE,
+                tag = TAG,
+                tryParse = ::tryParse,
+            )
+        return when (read) {
+            is BackupRead.Loaded -> read.value
 
-            tryParse(prefs.getString(KEY_SETTINGS_BACKUP, null))?.let { recovered ->
-                Log.w(TAG, "$KEY_SETTINGS unparseable; recovered from $KEY_SETTINGS_BACKUP")
-                return recovered
-            }
+            // Both copies are gone; the raw bytes are quarantined and defaults
+            // are all that is left to offer.
+            BackupRead.Unrecoverable -> AppSettings()
 
-            Log.e(TAG, "$KEY_SETTINGS and its backup are both unparseable; quarantining")
-            prefs.edit().putString(KEY_SETTINGS_QUARANTINE, raw).apply()
-            return AppSettings()
+            // Never written in this layout, so a legacy one may still be there.
+            BackupRead.Absent -> legacyOrDefaults()
         }
-
-        if (!prefs.contains(KEY_LEGACY_SOUND_ENABLED)) return AppSettings()
-        return migrateLegacySettings()
     }
+
+    /**
+     * Settings from the pre-JSON individual-key layout, if any were ever
+     * written; otherwise a fresh set of defaults.
+     */
+    private fun legacyOrDefaults(): AppSettings =
+        if (prefs.contains(KEY_LEGACY_SOUND_ENABLED)) migrateLegacySettings() else AppSettings()
 
     /**
      * Writes the settings, rotating the outgoing payload into the backup slot.

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -187,12 +187,11 @@
         <error line="309" column="92" source="standard:function-signature" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt">
-        <error line="24" column="33" source="standard:statement-wrapping" />
-        <error line="24" column="58" source="standard:statement-wrapping" />
-        <error line="24" column="81" source="standard:statement-wrapping" />
-        <error line="27" column="5" source="standard:blank-line-before-declaration" />
-        <error line="65" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="76" column="14" source="standard:chain-method-continuation" />
+        <error line="23" column="33" source="standard:statement-wrapping" />
+        <error line="23" column="58" source="standard:statement-wrapping" />
+        <error line="23" column="81" source="standard:statement-wrapping" />
+        <error line="26" column="5" source="standard:blank-line-before-declaration" />
+        <error line="75" column="22" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/LearningProgressRepository.kt">
         <error line="20" column="34" source="standard:class-signature" />


### PR DESCRIPTION
> **Stacked on #561**, which is stacked on #560. Merge order: #560 → #561 → this. I'll retarget as each lands. The diff shown is just this commit.

Closes out the read-side duplication I flagged in #561. With this, both halves of the backup scheme live in one place.

## Why

`SettingsRepository.load()` and `JsonListRepository.getAll()` implemented the same rule over different payload types — try the primary, fall back to the backup, quarantine the raw bytes when neither parses. Same drift risk that produced #560 on the write side.

## The three-way outcome

This is why the read side needed more than a nullable return, and why I split it out from #561 rather than bundling it.

Returning `T?` collapses two cases that callers genuinely distinguish:

- **`Absent`** — nothing ever written. Settings must then check for a *legacy* individual-key layout to migrate.
- **`Unrecoverable`** — something was written, but both copies are unreadable. The data is gone; quarantine the bytes and start over.

Conflate them and the settings legacy migration either stops running or starts running over corrupt data. So the helper returns a small sealed `BackupRead<T>`:

```kotlin
internal sealed interface BackupRead<out T> {
    data class Loaded<T>(val value: T) : BackupRead<T>
    data object Absent : BackupRead<Nothing>
    data object Unrecoverable : BackupRead<Nothing>
}
```

Lists map `Absent` and `Unrecoverable` to the same empty list — but they do so *explicitly*, because they have no legacy layout, not because the distinction was unavailable.

## Two incidental behaviour changes

Both toward consistency, neither asserted on by any test:

- Lists now log a warning when a read is served from the backup. Settings already did; lists recovered silently.
- The list quarantine message adopts the settings wording, and the tag moves from a string literal to a `TAG` constant.

## Verification

Same fault-injection approach as #561 — for a refactor, passing tests prove nothing on their own, so I broke each branch and checked *which* tests noticed:

| Injected fault | Tests that failed |
|---|---|
| Never fall back to the backup | 2 in `JsonListRepositoryTest` + 3 in `SettingsViewModelTest` |
| Skip the quarantine write | 4 in `JsonListRepositoryTest` + 2 in `SettingsViewModelTest` |
| Collapse `Absent` into `Unrecoverable` | 4 legacy-migration tests in `SettingsViewModelTest` |

The first two are caught from **both** stores, confirming both call sites route through the helper. The third is caught only by settings — correctly, since lists treat the two cases alike — and it is the evidence that the sealed type is load-bearing rather than ceremony. I re-ran it after refactoring the call site into `legacyOrDefaults()`, and it still discriminates. All 50 pass restored.

`scripts/preflight.sh` green and `:app:detekt` clean.

## Note on the ktlint baseline

This edit shifts line numbers in `JsonListRepository.kt`, and the baseline is line-sensitive. I re-pointed **only that file's entries** by hand rather than regenerating the baseline, which would silently drop entries for untouched files. Same violations, new line numbers — except one `chain-method-continuation` entry, dropped because the chain it referred to (`prefs.edit().putString(...).apply()`) moved into the helper.

## Still not addressed

All five `JsonListRepository` subclasses override `getAll()` without calling `super`, so the base read path — including quarantine — remains unreachable in the shipping app, exactly as #553 noted. `SetlistRepository` in particular has its own fallback that never quarantines. Bringing those overrides onto the shared path is a behaviour change per store, so it wants its own PR and its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of saved settings and lists when stored data is corrupted.
  * Automatically falls back to a backup copy when the primary data cannot be read.
  * Preserves corrupted data separately for troubleshooting and restores default or legacy settings when recovery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->