### PR TITLE
Fix: Migrate legacy settings when any legacy key is present

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/LegacySettingsReader.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/LegacySettingsReader.kt
@@ -7,6 +7,19 @@ import android.content.SharedPreferences
  * Used once during migration to JSON-based storage.
  */
 internal object LegacySettingsReader {
+    /**
+     * True when [prefs] still holds any key from the pre-JSON layout.
+     *
+     * Every one of [LEGACY_KEYS] is equally good evidence that this install
+     * predates `settings_json`, so the whole set is probed rather than a single
+     * representative. Gating on one key means an install that never wrote that
+     * particular key is read as "nothing to migrate" and silently falls back to
+     * defaults -- most of these keys are only written when the user changes the
+     * setting away from its default, so that is the common case, not a corner
+     * one.
+     */
+    fun hasLegacySettings(prefs: SharedPreferences): Boolean = LEGACY_KEYS.any(prefs::contains)
+
     fun read(prefs: SharedPreferences): AppSettings =
         AppSettings(
             sound =

--- a/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SettingsRepository.kt
@@ -59,7 +59,7 @@ class SettingsRepository(
      * written; otherwise a fresh set of defaults.
      */
     private fun legacyOrDefaults(): AppSettings =
-        if (prefs.contains(KEY_LEGACY_SOUND_ENABLED)) migrateLegacySettings() else AppSettings()
+        if (LegacySettingsReader.hasLegacySettings(prefs)) migrateLegacySettings() else AppSettings()
 
     /**
      * Writes the settings, rotating the outgoing payload into the backup slot.
@@ -101,6 +101,5 @@ class SettingsRepository(
         const val KEY_SETTINGS = "settings_json"
         const val KEY_SETTINGS_BACKUP = "settings_json_backup"
         const val KEY_SETTINGS_QUARANTINE = "settings_json_quarantine"
-        const val KEY_LEGACY_SOUND_ENABLED = "sound_enabled"
     }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/SettingsViewModelTest.kt
@@ -382,10 +382,10 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun legacyMigrationIsSkippedWhenSoundEnabledIsAbsentEvenThoughOtherLegacyKeysExist() {
-        // Pinned weakness: migration is gated on one unrelated key. A legacy user
-        // who customised only their theme, tuning or fretboard — and never toggled
-        // sound — silently loses all of it on upgrade.
+    fun legacyMigrationRunsWhenOnlyKeysOtherThanSoundEnabledArePresent() {
+        // Most legacy keys are written only when the user moves a setting off its
+        // default, so gating on any single one drops the customisations of
+        // everyone who never touched that particular setting.
         prefs
             .edit()
             .putString("theme_mode", "DARK")
@@ -394,14 +394,11 @@ class SettingsViewModelTest {
             .commit()
 
         val settings = newViewModel().settings.value
-        assertEquals(
-            "today a theme-only legacy install is not migrated",
-            ThemeMode.SYSTEM,
-            settings.display.themeMode,
-        )
-        assertEquals(UkuleleTuning.HIGH_G, settings.tuning.tuning)
-        assertFalse(settings.fretboard.leftHanded)
-        assertTrue("and the orphaned keys are left behind", prefs.contains("theme_mode"))
+
+        assertEquals(ThemeMode.DARK, settings.display.themeMode)
+        assertEquals(UkuleleTuning.BARITONE, settings.tuning.tuning)
+        assertTrue(settings.fretboard.leftHanded)
+        assertFalse("the migrated keys are cleaned up", prefs.contains("theme_mode"))
     }
 
     @Test


### PR DESCRIPTION
Fixes #556.

## The bug

The migration was gated on a single key:

```kotlin
if (prefs.contains("sound_enabled")) migrateLegacySettings() else AppSettings()
```

`sound_enabled` is one of the 35 keys `LegacySettingsReader` consumes, and — like most of them — it is only written once the user moves that setting off its default. So a legacy install that customised anything *else* was read as having nothing to migrate.

A user who set a dark theme, baritone tuning and left-handed mode but never touched the sound toggle lost all three on upgrade: theme reverted to System, tuning to High-G, left-handed off. The legacy keys were never cleaned up either, so they sat orphaned in the preference file forever.

Left-handed mode is an accessibility setting. Silently resetting it is not the kind of thing a user should have to notice and re-discover.

## The fix

Gate on whether *any* key in `LEGACY_KEYS` is present. The check lives next to that list in `LegacySettingsReader`, which already owns the definition of what counts as legacy, rather than re-stating a key name in the repository. The now-unused `KEY_LEGACY_SOUND_ENABLED` constant is removed.

## Verification

`legacyMigrationIsSkippedWhenSoundEnabledIsAbsentEvenThoughOtherLegacyKeysExist` pinned the broken behaviour and asserted the settings were lost, so it is replaced by `legacyMigrationRunsWhenOnlyKeysOtherThanSoundEnabledArePresent` — same scenario from the issue, now asserting the settings survive and the legacy keys are cleaned up.

Checked in both directions:

- Reverting the gate to `sound_enabled` fails exactly that one test, and nothing else.
- Widening it too far (gate always true) fails `afirstRunDoesNotWriteAnythingUntilSomethingChanges` and `defaultsAreUsedOnAFirstRunWithNoStoredData`, so a fresh install still cannot be mistaken for a legacy one.

That second direction is worth noting: I initially added a test for it and then **removed** it, because those two existing tests already cover it exactly — it failed alongside them without discriminating anything they didn't. A duplicate test in a 29-test class is noise, not safety.

`scripts/preflight.sh` green (ktlint ratchet, shared KMP tests, Android unit tests, lint) and `:app:detekt` clean. No UI changes, so no accessibility surface is touched — though the bug itself was costing users an accessibility setting.

## Note on the issue text

#556 points at `SettingsViewModel.loadSettings()`. That code has since moved to `SettingsRepository.legacyOrDefaults()` (via #559 and #562); the bug and the suggested fix are unchanged, only the location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy settings detection so saved preferences are migrated even when sound settings are absent.
  * Restored legacy theme, tuning, and fretboard settings during migration.
  * Removed migrated legacy preferences after successful migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->