### PR TITLE
Fix: Quarantine unreadable payloads in every list store

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
@@ -23,15 +23,7 @@ class ChordSheetRepository(context: Context) : JsonListRepository<ChordSheet>(
         persist(merged)
     }
 
-    override fun getAll(): List<ChordSheet> {
-        val raw = prefs.getString(KEY_SHEETS, null)
-        if (raw != null) {
-            return tryParse(raw)
-                ?: tryParse(prefs.getString(backupKey, null))
-                ?: migrateLegacyPipeEntries()
-        }
-        return migrateLegacyPipeEntries()
-    }
+    override fun getAll(): List<ChordSheet> = readOrElse(::migrateLegacyPipeEntries)
 
     /**
      * Returns the set of all distinct labels used across every saved chord sheet.

--- a/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/ChordSheetRepository.kt
@@ -43,13 +43,13 @@ class ChordSheetRepository(context: Context) : JsonListRepository<ChordSheet>(
 
     private fun migrateLegacyPipeEntries(): List<ChordSheet> {
         val entries = prefs.all.entries
-            .filter { it.key != KEY_SHEETS }
+            .filter { it.key !in ownKeys }
             .mapNotNull { (_, value) -> deserializeLegacy(value as? String) }
             .sortedByDescending { it.updatedAt }
         if (entries.isNotEmpty()) {
             persist(entries)
             val editor = prefs.edit()
-            prefs.all.keys.filter { it != KEY_SHEETS }.forEach { editor.remove(it) }
+            prefs.all.keys.filter { it !in ownKeys }.forEach { editor.remove(it) }
             editor.apply()
         }
         return entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
@@ -45,13 +45,13 @@ class CustomFingerpickingPatternRepository(context: Context) : JsonListRepositor
 
     private fun migrateLegacyPipeEntries(): List<CustomFingerpickingPattern> {
         val entries = prefs.all.entries
-            .filter { it.key != KEY_PATTERNS }
+            .filter { it.key !in ownKeys }
             .mapNotNull { (_, value) -> deserializeLegacy(value as? String) }
             .sortedByDescending { it.createdAt }
         if (entries.isNotEmpty()) {
             persist(entries)
             val editor = prefs.edit()
-            prefs.all.keys.filter { it != KEY_PATTERNS }.forEach { editor.remove(it) }
+            prefs.all.keys.filter { it !in ownKeys }.forEach { editor.remove(it) }
             editor.apply()
         }
         return entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt
@@ -33,15 +33,7 @@ class CustomFingerpickingPatternRepository(context: Context) : JsonListRepositor
     override fun entityId(item: CustomFingerpickingPattern) = item.id
     override fun entityTimestamp(item: CustomFingerpickingPattern) = item.createdAt
 
-    override fun getAll(): List<CustomFingerpickingPattern> {
-        val raw = prefs.getString(KEY_PATTERNS, null)
-        if (raw != null) {
-            return tryParse(raw)
-                ?: tryParse(prefs.getString(backupKey, null))
-                ?: migrateLegacyPipeEntries()
-        }
-        return migrateLegacyPipeEntries()
-    }
+    override fun getAll(): List<CustomFingerpickingPattern> = readOrElse(::migrateLegacyPipeEntries)
 
     private fun migrateLegacyPipeEntries(): List<CustomFingerpickingPattern> {
         val entries = prefs.all.entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
@@ -47,13 +47,13 @@ class CustomProgressionRepository(context: Context) : JsonListRepository<CustomP
 
     private fun migrateLegacyPipeEntries(): List<CustomProgression> {
         val entries = prefs.all.entries
-            .filter { it.key != KEY_PROGRESSIONS }
+            .filter { it.key !in ownKeys }
             .mapNotNull { (_, value) -> deserializeLegacy(value as? String) }
             .sortedByDescending { it.createdAt }
         if (entries.isNotEmpty()) {
             persist(entries)
             val editor = prefs.edit()
-            prefs.all.keys.filter { it != KEY_PROGRESSIONS }.forEach { editor.remove(it) }
+            prefs.all.keys.filter { it !in ownKeys }.forEach { editor.remove(it) }
             editor.apply()
         }
         return entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt
@@ -35,15 +35,7 @@ class CustomProgressionRepository(context: Context) : JsonListRepository<CustomP
     override fun entityId(item: CustomProgression) = item.id
     override fun entityTimestamp(item: CustomProgression) = item.createdAt
 
-    override fun getAll(): List<CustomProgression> {
-        val raw = prefs.getString(KEY_PROGRESSIONS, null)
-        if (raw != null) {
-            return tryParse(raw)
-                ?: tryParse(prefs.getString(backupKey, null))
-                ?: migrateLegacyPipeEntries()
-        }
-        return migrateLegacyPipeEntries()
-    }
+    override fun getAll(): List<CustomProgression> = readOrElse(::migrateLegacyPipeEntries)
 
     private fun migrateLegacyPipeEntries(): List<CustomProgression> {
         val entries = prefs.all.entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
@@ -33,15 +33,7 @@ class CustomStrumPatternRepository(context: Context) : JsonListRepository<Custom
     override fun entityId(item: CustomStrumPattern) = item.id
     override fun entityTimestamp(item: CustomStrumPattern) = item.createdAt
 
-    override fun getAll(): List<CustomStrumPattern> {
-        val raw = prefs.getString(KEY_PATTERNS, null)
-        if (raw != null) {
-            return tryParse(raw)
-                ?: tryParse(prefs.getString(backupKey, null))
-                ?: migrateLegacyPipeEntries()
-        }
-        return migrateLegacyPipeEntries()
-    }
+    override fun getAll(): List<CustomStrumPattern> = readOrElse(::migrateLegacyPipeEntries)
 
     private fun migrateLegacyPipeEntries(): List<CustomStrumPattern> {
         val entries = prefs.all.entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt
@@ -45,13 +45,13 @@ class CustomStrumPatternRepository(context: Context) : JsonListRepository<Custom
 
     private fun migrateLegacyPipeEntries(): List<CustomStrumPattern> {
         val entries = prefs.all.entries
-            .filter { it.key != KEY_PATTERNS }
+            .filter { it.key !in ownKeys }
             .mapNotNull { (_, value) -> deserializeLegacy(value as? String) }
             .sortedByDescending { it.createdAt }
         if (entries.isNotEmpty()) {
             persist(entries)
             val editor = prefs.edit()
-            prefs.all.keys.filter { it != KEY_PATTERNS }.forEach { editor.remove(it) }
+            prefs.all.keys.filter { it !in ownKeys }.forEach { editor.remove(it) }
             editor.apply()
         }
         return entries

--- a/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
@@ -28,15 +28,14 @@ class FavoritesRepository(context: Context) {
     /**
      * Returns all saved favorites, sorted by time added (newest first).
      */
-    fun getAll(): List<FavoriteVoicing> {
-        val raw = prefs.getString(KEY_FAVORITES, null)
-        if (raw != null) {
-            return tryParseVoicings(raw)
-                ?: tryParseVoicings(prefs.getString(BACKUP_KEY_FAVORITES, null))
-                ?: migrateLegacyVoicings()
-        }
-        return migrateLegacyVoicings()
-    }
+    fun getAll(): List<FavoriteVoicing> =
+        prefs.readListOrMigrate(
+            key = KEY_FAVORITES,
+            backupKey = BACKUP_KEY_FAVORITES,
+            quarantineKey = QUARANTINE_KEY_FAVORITES,
+            tryParse = ::tryParseVoicings,
+            migrate = ::migrateLegacyVoicings,
+        )
 
     /**
      * Adds a voicing to favorites. No-op if already saved.
@@ -113,15 +112,14 @@ class FavoritesRepository(context: Context) {
 
     // ── Folder management ───────────────────────────────────────────
 
-    fun getAllFolders(): List<FavoriteFolder> {
-        val raw = folderPrefs.getString(KEY_FOLDERS, null)
-        if (raw != null) {
-            return tryParseFolders(raw)
-                ?: tryParseFolders(folderPrefs.getString(BACKUP_KEY_FOLDERS, null))
-                ?: migrateLegacyFolders()
-        }
-        return migrateLegacyFolders()
-    }
+    fun getAllFolders(): List<FavoriteFolder> =
+        folderPrefs.readListOrMigrate(
+            key = KEY_FOLDERS,
+            backupKey = BACKUP_KEY_FOLDERS,
+            quarantineKey = QUARANTINE_KEY_FOLDERS,
+            tryParse = ::tryParseFolders,
+            migrate = ::migrateLegacyFolders,
+        )
 
     fun saveFolder(folder: FavoriteFolder) {
         val items = getAllFolders().toMutableList()
@@ -206,6 +204,36 @@ class FavoritesRepository(context: Context) {
             .apply()
     }
 
+    /**
+     * Applies the shared backup-and-quarantine rule to one of this repository's
+     * two stores, falling back to [migrate] when neither stored copy is
+     * readable.
+     *
+     * This class predates [JsonListRepository] and keeps its own storage, so it
+     * cannot inherit `readOrElse`; routing through the same helper is what
+     * stops the two from drifting apart again.
+     */
+    private fun <T> SharedPreferences.readListOrMigrate(
+        key: String,
+        backupKey: String,
+        quarantineKey: String,
+        tryParse: (String?) -> List<T>?,
+        migrate: () -> List<T>,
+    ): List<T> {
+        val read =
+            readWithBackupFallback(
+                key = key,
+                backupKey = backupKey,
+                quarantineKey = quarantineKey,
+                tag = TAG,
+                tryParse = tryParse,
+            )
+        return when (read) {
+            is BackupRead.Loaded -> read.value
+            BackupRead.Absent, BackupRead.Unrecoverable -> migrate()
+        }
+    }
+
     private fun tryParseVoicings(raw: String?): List<FavoriteVoicing>? {
         if (raw == null) return null
         return try {
@@ -228,14 +256,14 @@ class FavoritesRepository(context: Context) {
 
     private fun migrateLegacyVoicings(): List<FavoriteVoicing> {
         val entries = prefs.all.entries
-            .filter { it.key != KEY_FAVORITES && it.key != BACKUP_KEY_FAVORITES }
+            .filter { it.key !in VOICING_KEYS }
             .mapNotNull { (_, value) -> deserializeLegacyVoicing(value as? String) }
             .sortedByDescending { it.addedAt }
         if (entries.isNotEmpty()) {
             persistVoicings(entries)
             val editor = prefs.edit()
             prefs.all.keys
-                .filter { it != KEY_FAVORITES && it != BACKUP_KEY_FAVORITES }
+                .filter { it !in VOICING_KEYS }
                 .forEach { editor.remove(it) }
             editor.apply()
         }
@@ -244,14 +272,14 @@ class FavoritesRepository(context: Context) {
 
     private fun migrateLegacyFolders(): List<FavoriteFolder> {
         val entries = folderPrefs.all.entries
-            .filter { it.key != KEY_FOLDERS && it.key != BACKUP_KEY_FOLDERS }
+            .filter { it.key !in FOLDER_KEYS }
             .mapNotNull { (_, value) -> deserializeLegacyFolder(value as? String) }
             .sortedBy { it.name }
         if (entries.isNotEmpty()) {
             persistFolders(entries)
             val editor = folderPrefs.edit()
             folderPrefs.all.keys
-                .filter { it != KEY_FOLDERS && it != BACKUP_KEY_FOLDERS }
+                .filter { it !in FOLDER_KEYS }
                 .forEach { editor.remove(it) }
             editor.apply()
         }
@@ -311,11 +339,24 @@ class FavoritesRepository(context: Context) {
     }
 
     companion object {
+        private const val TAG = "FavoritesRepository"
         private const val PREFS_NAME = "chord_favorites"
         private const val KEY_FAVORITES = "favorites_json"
         private const val BACKUP_KEY_FAVORITES = "favorites_json_backup"
+        private const val QUARANTINE_KEY_FAVORITES = "favorites_json_quarantine"
         private const val FOLDER_PREFS_NAME = "favorite_folders"
         private const val KEY_FOLDERS = "folders_json"
         private const val BACKUP_KEY_FOLDERS = "folders_json_backup"
+        private const val QUARANTINE_KEY_FOLDERS = "folders_json_quarantine"
+
+        /**
+         * The keys each store owns. The legacy migrations sweep out everything
+         * else, so anything this class writes for itself has to be listed here
+         * or the sweep takes it -- see `JsonListRepository.ownKeys`.
+         */
+        private val VOICING_KEYS =
+            setOf(KEY_FAVORITES, BACKUP_KEY_FAVORITES, QUARANTINE_KEY_FAVORITES)
+        private val FOLDER_KEYS =
+            setOf(KEY_FOLDERS, BACKUP_KEY_FOLDERS, QUARANTINE_KEY_FOLDERS)
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -44,10 +44,28 @@ abstract class JsonListRepository<T>(
      * cannot be parsed. See [readWithBackupFallback] for the rule.
      *
      * An empty list is the answer both to a store that was never written and to
-     * one whose copies are both unreadable: unlike settings there is no legacy
-     * layout to migrate, so the two cases lead to the same place.
+     * one whose copies are both unreadable: with no legacy layout to migrate,
+     * the two cases lead to the same place.
      */
-    open fun getAll(): List<T> {
+    open fun getAll(): List<T> = readOrElse { emptyList() }
+
+    /**
+     * Reads the stored list, calling [fallback] when neither stored copy yields
+     * one.
+     *
+     * Every subclass overrides [getAll] to reach a legacy on-disk format when
+     * the JSON store has nothing to give. Handing that migration to this
+     * function keeps them on the recovery path instead of replacing it: before
+     * it existed each override went straight to its migration, so the
+     * quarantine below was written but never reached (#564).
+     *
+     * [fallback] answers both "never written" and "written, now unreadable",
+     * because a store with a legacy layout to try has the same thing to try in
+     * either case. Only the second leaves quarantined bytes behind, and
+     * [readWithBackupFallback] has already written them by the time [fallback]
+     * runs -- which is why the migrations must leave [ownKeys] alone.
+     */
+    protected fun readOrElse(fallback: () -> List<T>): List<T> {
         val read =
             prefs.readWithBackupFallback(
                 key = key,
@@ -58,7 +76,7 @@ abstract class JsonListRepository<T>(
             )
         return when (read) {
             is BackupRead.Loaded -> read.value
-            BackupRead.Absent, BackupRead.Unrecoverable -> emptyList()
+            BackupRead.Absent, BackupRead.Unrecoverable -> fallback()
         }
     }
 

--- a/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt
@@ -29,6 +29,17 @@ abstract class JsonListRepository<T>(
     private val quarantineKey get() = "${key}_quarantine"
 
     /**
+     * Every key this store writes into its own preferences file.
+     *
+     * The legacy migrations sweep the file clean once they have consumed it, on
+     * the assumption that anything which is not the primary key is a leftover
+     * per-entry record. Anything the store writes for itself has to be named
+     * here or the sweep takes it too -- including the backup that [persist]
+     * wrote moments earlier (#554).
+     */
+    protected val ownKeys: Set<String> get() = setOf(key, backupKey, quarantineKey)
+
+    /**
      * Reads the list, falling back to the backup copy when the primary payload
      * cannot be parsed. See [readWithBackupFallback] for the rule.
      *

--- a/app/src/main/java/com/baijum/ukufretboard/data/SetlistRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/SetlistRepository.kt
@@ -25,12 +25,21 @@ class SetlistRepository(context: Context) : JsonListRepository<Setlist>(
         persist(merged)
     }
 
+    /**
+     * Unlike the other stores this one consults its legacy format *before* the
+     * backup: a primary that kotlinx cannot read may still be readable
+     * org.json, in which case migrating it in place beats recovering whatever
+     * older copy the backup happens to hold.
+     *
+     * Only once that has failed does the shared rule take over. It re-reads the
+     * primary and re-parses it, which is wasted work -- but only on a store
+     * that is already broken, and it is what makes the quarantine happen.
+     */
     override fun getAll(): List<Setlist> {
         val raw = prefs.getString(KEY_SETLISTS, null) ?: return emptyList()
-        return tryParse(raw)
-            ?: migrateLegacyOrgJson(raw)
-            ?: tryParse(prefs.getString(backupKey, null))
-            ?: emptyList()
+        tryParse(raw)?.let { return it }
+        migrateLegacyOrgJson(raw)?.let { return it }
+        return readOrElse { emptyList() }
     }
 
     private fun migrateLegacyOrgJson(raw: String): List<Setlist>? {

--- a/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
@@ -228,17 +228,22 @@ class CustomProgressionRepositoryTest {
     }
 
     @Test
-    fun legacyMigrationAlsoDeletesTheBackupKeyItJustWrote() {
-        // Pinned weakness: the cleanup filters on `key != KEY_PROGRESSIONS` only,
-        // so it removes the backup that persist() wrote two lines earlier. The
-        // migrated data therefore has no recovery copy until the next save.
-        // FavoritesRepository excludes its backup key here; this one does not.
+    fun migratedDataSurvivesACorruptionBeforeTheNextSave() {
+        // The cleanup sweeps out every key the store does not own, and the
+        // backup persist() writes during the migration is one of the store's
+        // own. Deleting it would leave the migrated data with no recovery copy
+        // until the user's next save (#554).
         writeRaw("old_a", legacyEntry("a", "Migrated"))
         repo.getAll()
+        writeRaw(KEY_PROGRESSIONS, "}} not json {{")
 
-        assertNull(
-            "today the freshly written backup is deleted by the cleanup",
-            prefs.getString(BACKUP_KEY, null),
+        assertEquals(
+            "the migration's own backup should still be there to recover from",
+            "Migrated",
+            repo
+                .getAll()
+                .single()
+                .progression.name,
         )
     }
 

--- a/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/CustomProgressionRepositoryTest.kt
@@ -16,9 +16,9 @@ import org.robolectric.RobolectricTestRunner
  * Tests for [CustomProgressionRepository].
  *
  * This is the one repository left out of `RepositorySerializationTest`, and the
- * only one whose `getAll()` override falls through to a legacy pipe-format
- * migration rather than to the base class's quarantine path. Both branches are
- * covered here.
+ * fullest example of the shape every list store shares: a JSON primary, a
+ * backup, a quarantine slot, and a legacy pipe-format migration behind all
+ * three. Every one of those branches is covered here.
  */
 @RunWith(RobolectricTestRunner::class)
 class CustomProgressionRepositoryTest {
@@ -172,17 +172,56 @@ class CustomProgressionRepositoryTest {
     }
 
     @Test
-    fun corruptPrimaryAndBackupWithNoLegacyEntriesReturnsEmptyWithoutQuarantining() {
-        // The getAll() override falls through to the legacy migration instead of
-        // the base class's quarantine branch, so an unrecoverable store here is
-        // silently dropped rather than preserved. Pinned, not fixed: adding
-        // quarantine means reconciling the two recovery strategies.
+    fun corruptPrimaryAndBackupQuarantineTheUnreadableBytes() {
         writeRaw(KEY_PROGRESSIONS, "}} not json {{")
         writeRaw(BACKUP_KEY, "also broken")
 
-        assertTrue(repo.getAll().isEmpty())
-        assertNull(
-            "this repository never reaches the quarantine branch",
+        assertTrue("nothing is readable, so the store reads as empty", repo.getAll().isEmpty())
+        assertEquals(
+            "the primary's bytes should be preserved for a support request",
+            "}} not json {{",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    @Test
+    fun quarantinedBytesAreNotOverwrittenByTheNextSave() {
+        // The point of the quarantine is that it outlives the write that would
+        // otherwise have destroyed the evidence: getAll() reads empty, the user
+        // adds something, and persist() overwrites both the primary and the
+        // unreadable backup.
+        writeRaw(KEY_PROGRESSIONS, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+        repo.getAll()
+
+        repo.save(progression("a", name = "Added after the loss"))
+
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+        assertEquals(
+            "}} not json {{",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    @Test
+    fun anUnrecoverableStoreStillFallsThroughToTheLegacyMigration() {
+        // Quarantining is not a dead end: the legacy pipe entries are still the
+        // next place to look, and the migration's own cleanup must leave the
+        // bytes it just quarantined alone.
+        writeRaw(KEY_PROGRESSIONS, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+        writeRaw("old_a", legacyEntry("a", "Recovered from the legacy format"))
+
+        assertEquals(
+            "Recovered from the legacy format",
+            repo
+                .getAll()
+                .single()
+                .progression.name,
+        )
+        assertEquals(
+            "the migration cleanup should not sweep away the quarantine",
+            "}} not json {{",
             prefs.getString(QUARANTINE_KEY, null),
         )
     }

--- a/app/src/test/java/com/baijum/ukufretboard/data/UnreadablePayloadQuarantineTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/UnreadablePayloadQuarantineTest.kt
@@ -1,0 +1,147 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * What each list store does when neither stored copy of its payload can be
+ * read.
+ *
+ * Every store used to answer that question for itself, and every one of them
+ * answered it by throwing the bytes away. The recovery contract they were meant
+ * to follow lived in `JsonListRepository.getAll()`, which each subclass
+ * overrode, so the quarantine slot was written by code nothing called (#564).
+ * One test per store, because routing them onto the shared rule changes what
+ * each of them does on disk.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UnreadablePayloadQuarantineTest {
+    private lateinit var context: Application
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    /** Leaves both stored copies of [key] unreadable. */
+    private fun corruptBothCopies(
+        prefsName: String,
+        key: String,
+    ): SharedPreferences {
+        val prefs = context.getSharedPreferences(prefsName, 0)
+        prefs
+            .edit()
+            .putString(key, CORRUPT)
+            .putString("${key}_backup", "ALSO UNREADABLE")
+            .commit()
+        return prefs
+    }
+
+    @Test
+    fun chordSheetUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("chord_sheets", "sheets_json")
+
+        assertTrue(ChordSheetRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("sheets_json_quarantine", null))
+    }
+
+    @Test
+    fun setlistUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("setlists", "setlist_data")
+
+        assertTrue(SetlistRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("setlist_data_quarantine", null))
+    }
+
+    @Test
+    fun strumPatternUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("custom_strum_patterns", "patterns_json")
+
+        assertTrue(CustomStrumPatternRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("patterns_json_quarantine", null))
+    }
+
+    @Test
+    fun fingerpickingPatternUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("custom_fingerpicking_patterns", "patterns_json")
+
+        assertTrue(CustomFingerpickingPatternRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("patterns_json_quarantine", null))
+    }
+
+    @Test
+    fun favoritesUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("chord_favorites", "favorites_json")
+
+        assertTrue(FavoritesRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("favorites_json_quarantine", null))
+    }
+
+    @Test
+    fun favoriteFoldersUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("favorite_folders", "folders_json")
+
+        assertTrue(FavoritesRepository(context).getAllFolders().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("folders_json_quarantine", null))
+    }
+
+    @Test
+    fun quarantinedBytesOutliveTheSaveThatFollowsTheLoss() {
+        val prefs = corruptBothCopies("chord_sheets", "sheets_json")
+        val repo = ChordSheetRepository(context)
+        repo.getAll()
+
+        repo.save(
+            ChordSheet(
+                id = "cs1",
+                title = "Added after the loss",
+                artist = "",
+                content = "",
+                createdAt = 1L,
+                updatedAt = 2L,
+            ),
+        )
+
+        assertEquals(listOf("cs1"), repo.getAll().map { it.id })
+        assertEquals(
+            "the save overwrites both copies, so only the quarantine still holds the original",
+            CORRUPT,
+            prefs.getString("sheets_json_quarantine", null),
+        )
+    }
+
+    @Test
+    fun setlistLegacyOrgJsonIsPreferredOverTheBackup() {
+        // The setlist store consults its legacy org.json format before the
+        // backup, so a primary that kotlinx cannot read but org.json can is
+        // migrated in place rather than rolled back to an older copy. org.json
+        // accepts unquoted keys and single-quoted strings; kotlinx does not.
+        val legacy = "[{id:'s1',name:'Legacy',songIds:['a'],createdAt:100,updatedAt:200}]"
+        val backup = """[{"id":"s2","name":"FromBackup","songIds":[],"createdAt":300,"updatedAt":400}]"""
+        val prefs = context.getSharedPreferences("setlists", 0)
+        prefs
+            .edit()
+            .putString("setlist_data", legacy)
+            .putString("setlist_data_backup", backup)
+            .commit()
+
+        assertEquals("Legacy", SetlistRepository(context).getAll().single().name)
+        assertNull(
+            "a migrated primary is not a loss, so nothing is quarantined",
+            prefs.getString("setlist_data_quarantine", null),
+        )
+    }
+
+    private companion object {
+        /** Stands in for a payload that neither parser can make sense of. */
+        const val CORRUPT = "}} not json {{"
+    }
+}

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -107,7 +107,7 @@
         <error line="39" column="38" source="standard:function-signature" />
         <error line="45" column="23" source="standard:multiline-expression-wrapping" />
         <error line="52" column="27" source="standard:chain-method-continuation" />
-        <error line="52" column="55" source="standard:chain-method-continuation" />
+        <error line="52" column="53" source="standard:chain-method-continuation" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt">
         <error line="27" column="44" source="standard:class-signature" />
@@ -115,7 +115,7 @@
         <error line="34" column="5" source="standard:blank-line-before-declaration" />
         <error line="47" column="23" source="standard:multiline-expression-wrapping" />
         <error line="54" column="27" source="standard:chain-method-continuation" />
-        <error line="54" column="57" source="standard:chain-method-continuation" />
+        <error line="54" column="53" source="standard:chain-method-continuation" />
         <error line="67" column="25" source="standard:multiline-expression-wrapping" />
         <error line="76" column="33" source="standard:multiline-expression-wrapping" />
         <error line="78" column="51" source="standard:string-template" />
@@ -132,7 +132,7 @@
         <error line="36" column="5" source="standard:blank-line-before-declaration" />
         <error line="49" column="23" source="standard:multiline-expression-wrapping" />
         <error line="56" column="27" source="standard:chain-method-continuation" />
-        <error line="56" column="61" source="standard:chain-method-continuation" />
+        <error line="56" column="53" source="standard:chain-method-continuation" />
         <error line="71" column="27" source="standard:multiline-expression-wrapping" />
         <error line="82" column="31" source="standard:multiline-expression-wrapping" />
     </file>
@@ -142,7 +142,7 @@
         <error line="34" column="5" source="standard:blank-line-before-declaration" />
         <error line="47" column="23" source="standard:multiline-expression-wrapping" />
         <error line="54" column="27" source="standard:chain-method-continuation" />
-        <error line="54" column="57" source="standard:chain-method-continuation" />
+        <error line="54" column="53" source="standard:chain-method-continuation" />
         <error line="67" column="25" source="standard:multiline-expression-wrapping" />
         <error line="76" column="28" source="standard:multiline-expression-wrapping" />
         <error line="77" column="33" source="standard:if-else-wrapping" />
@@ -191,7 +191,7 @@
         <error line="23" column="58" source="standard:statement-wrapping" />
         <error line="23" column="81" source="standard:statement-wrapping" />
         <error line="26" column="5" source="standard:blank-line-before-declaration" />
-        <error line="75" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="86" column="22" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/LearningProgressRepository.kt">
         <error line="20" column="34" source="standard:class-signature" />

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -104,52 +104,52 @@
         <error line="12" column="28" source="standard:class-signature" />
         <error line="12" column="44" source="standard:class-signature" />
         <error line="19" column="5" source="standard:blank-line-before-declaration" />
-        <error line="39" column="38" source="standard:function-signature" />
-        <error line="45" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="52" column="27" source="standard:chain-method-continuation" />
-        <error line="52" column="53" source="standard:chain-method-continuation" />
+        <error line="31" column="38" source="standard:function-signature" />
+        <error line="37" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="44" column="27" source="standard:chain-method-continuation" />
+        <error line="44" column="53" source="standard:chain-method-continuation" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/CustomFingerpickingPatternRepository.kt">
         <error line="27" column="44" source="standard:class-signature" />
         <error line="27" column="60" source="standard:class-signature" />
         <error line="34" column="5" source="standard:blank-line-before-declaration" />
-        <error line="47" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="54" column="27" source="standard:chain-method-continuation" />
-        <error line="54" column="53" source="standard:chain-method-continuation" />
-        <error line="67" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="76" column="33" source="standard:multiline-expression-wrapping" />
-        <error line="78" column="51" source="standard:string-template" />
-        <error line="79" column="15" source="standard:if-else-wrapping" />
-        <error line="79" column="20" source="standard:if-else-bracing" />
-        <error line="79" column="20" source="standard:if-else-wrapping" />
-        <error line="79" column="20" source="standard:multiline-if-else" />
-        <error line="80" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="86" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="39" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="46" column="27" source="standard:chain-method-continuation" />
+        <error line="46" column="53" source="standard:chain-method-continuation" />
+        <error line="59" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="68" column="33" source="standard:multiline-expression-wrapping" />
+        <error line="70" column="51" source="standard:string-template" />
+        <error line="71" column="15" source="standard:if-else-wrapping" />
+        <error line="71" column="20" source="standard:if-else-bracing" />
+        <error line="71" column="20" source="standard:if-else-wrapping" />
+        <error line="71" column="20" source="standard:multiline-if-else" />
+        <error line="72" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="78" column="27" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/CustomProgressionRepository.kt">
         <error line="29" column="35" source="standard:class-signature" />
         <error line="29" column="51" source="standard:class-signature" />
         <error line="36" column="5" source="standard:blank-line-before-declaration" />
-        <error line="49" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="56" column="27" source="standard:chain-method-continuation" />
-        <error line="56" column="53" source="standard:chain-method-continuation" />
-        <error line="71" column="27" source="standard:multiline-expression-wrapping" />
-        <error line="82" column="31" source="standard:multiline-expression-wrapping" />
+        <error line="41" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="48" column="27" source="standard:chain-method-continuation" />
+        <error line="48" column="53" source="standard:chain-method-continuation" />
+        <error line="63" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="74" column="31" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/CustomStrumPatternRepository.kt">
         <error line="27" column="36" source="standard:class-signature" />
         <error line="27" column="52" source="standard:class-signature" />
         <error line="34" column="5" source="standard:blank-line-before-declaration" />
-        <error line="47" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="54" column="27" source="standard:chain-method-continuation" />
-        <error line="54" column="53" source="standard:chain-method-continuation" />
-        <error line="67" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="76" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="77" column="33" source="standard:if-else-wrapping" />
-        <error line="77" column="33" source="standard:multiline-if-else" />
-        <error line="78" column="22" source="standard:if-else-wrapping" />
-        <error line="78" column="22" source="standard:multiline-if-else" />
-        <error line="82" column="27" source="standard:multiline-expression-wrapping" />
+        <error line="39" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="46" column="27" source="standard:chain-method-continuation" />
+        <error line="46" column="53" source="standard:chain-method-continuation" />
+        <error line="59" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="68" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="69" column="33" source="standard:if-else-wrapping" />
+        <error line="69" column="33" source="standard:multiline-if-else" />
+        <error line="70" column="22" source="standard:if-else-wrapping" />
+        <error line="70" column="22" source="standard:multiline-if-else" />
+        <error line="74" column="27" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt">
         <error line="16" column="27" source="standard:class-signature" />
@@ -158,40 +158,40 @@
         <error line="24" column="31" source="standard:statement-wrapping" />
         <error line="24" column="56" source="standard:statement-wrapping" />
         <error line="24" column="79" source="standard:statement-wrapping" />
-        <error line="68" column="54" source="standard:function-signature" />
-        <error line="74" column="18" source="standard:function-signature" />
-        <error line="74" column="39" source="standard:function-signature" />
-        <error line="74" column="60" source="standard:function-signature" />
-        <error line="74" column="76" source="standard:function-signature" />
-        <error line="82" column="20" source="standard:function-signature" />
-        <error line="82" column="46" source="standard:function-signature" />
-        <error line="82" column="69" source="standard:function-signature" />
-        <error line="103" column="1" source="standard:blank-line-between-when-conditions" />
-        <error line="133" column="22" source="standard:function-signature" />
-        <error line="133" column="40" source="standard:function-signature" />
-        <error line="133" column="55" source="standard:function-signature" />
-        <error line="144" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="153" column="33" source="standard:function-signature" />
-        <error line="153" column="51" source="standard:function-signature" />
-        <error line="153" column="76" source="standard:function-signature" />
-        <error line="168" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="181" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="194" column="14" source="standard:chain-method-continuation" />
-        <error line="203" column="20" source="standard:chain-method-continuation" />
-        <error line="230" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="246" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="267" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="293" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="309" column="36" source="standard:function-signature" />
-        <error line="309" column="60" source="standard:function-signature" />
-        <error line="309" column="92" source="standard:function-signature" />
+        <error line="67" column="54" source="standard:function-signature" />
+        <error line="73" column="18" source="standard:function-signature" />
+        <error line="73" column="39" source="standard:function-signature" />
+        <error line="73" column="60" source="standard:function-signature" />
+        <error line="73" column="76" source="standard:function-signature" />
+        <error line="81" column="20" source="standard:function-signature" />
+        <error line="81" column="46" source="standard:function-signature" />
+        <error line="81" column="69" source="standard:function-signature" />
+        <error line="102" column="1" source="standard:blank-line-between-when-conditions" />
+        <error line="131" column="22" source="standard:function-signature" />
+        <error line="131" column="40" source="standard:function-signature" />
+        <error line="131" column="55" source="standard:function-signature" />
+        <error line="142" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="151" column="33" source="standard:function-signature" />
+        <error line="151" column="51" source="standard:function-signature" />
+        <error line="151" column="76" source="standard:function-signature" />
+        <error line="166" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="179" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="192" column="14" source="standard:chain-method-continuation" />
+        <error line="201" column="20" source="standard:chain-method-continuation" />
+        <error line="258" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="274" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="295" column="29" source="standard:multiline-expression-wrapping" />
+        <error line="321" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="337" column="36" source="standard:function-signature" />
+        <error line="337" column="60" source="standard:function-signature" />
+        <error line="337" column="92" source="standard:function-signature" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt">
         <error line="23" column="33" source="standard:statement-wrapping" />
         <error line="23" column="58" source="standard:statement-wrapping" />
         <error line="23" column="81" source="standard:statement-wrapping" />
         <error line="26" column="5" source="standard:blank-line-before-declaration" />
-        <error line="86" column="22" source="standard:multiline-expression-wrapping" />
+        <error line="104" column="22" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/LearningProgressRepository.kt">
         <error line="20" column="34" source="standard:class-signature" />
@@ -266,13 +266,13 @@
         <error line="14" column="25" source="standard:class-signature" />
         <error line="14" column="41" source="standard:class-signature" />
         <error line="21" column="5" source="standard:blank-line-before-declaration" />
-        <error line="36" column="67" source="standard:function-expression-body" />
-        <error line="39" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="42" column="37" source="standard:if-else-wrapping" />
-        <error line="42" column="39" source="standard:statement-wrapping" />
-        <error line="42" column="54" source="standard:statement-wrapping" />
-        <error line="42" column="61" source="standard:statement-wrapping" />
-        <error line="42" column="68" source="standard:if-else-bracing" />
+        <error line="45" column="67" source="standard:function-expression-body" />
+        <error line="48" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="51" column="37" source="standard:if-else-wrapping" />
+        <error line="51" column="39" source="standard:statement-wrapping" />
+        <error line="51" column="54" source="standard:statement-wrapping" />
+        <error line="51" column="61" source="standard:statement-wrapping" />
+        <error line="51" column="68" source="standard:if-else-bracing" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/sync/BackupRestoreManager.kt">
         <error line="45" column="5" source="standard:blank-line-before-declaration" />


### PR DESCRIPTION
Fixes #564. Fixes #554.

## The bug

`JsonListRepository.getAll()` implements the recovery contract added for #316 — try the primary, fall back to the backup, and when neither parses, move the raw bytes to `${key}_quarantine` so they survive for a support request.

**Every subclass overrode it, and not one of them quarantined.** The contract lived entirely in a method nothing called, so #316 was closed as fixed while the stores it listed still behaved the way it described:

1. Both copies of `sheets_json` go bad.
2. `getAll()` falls through to the legacy-pipe scan, finds nothing, returns `emptyList()`. No log, no quarantine.
3. The user sees an empty songbook and adds one sheet.
4. `persist()` writes it over the primary and — since neither stored copy parses — re-seeds the backup with it.
5. The original bytes are gone, with nothing in logcat to explain it.

Affected: songbook, setlists, custom progressions, custom strum patterns, custom fingerpicking patterns, and favourites (both voicings and folders).

## The fix

The overrides existed only to add *"and if that fails, try the legacy on-disk format"*, which maps onto the three-way `BackupRead` from #562. The base class now takes that migration as a parameter instead of being replaced by it:

```kotlin
protected fun readOrElse(fallback: () -> List<T>): List<T>
```

Four of the five overrides collapse to one line each. Quarantining happens inside `readWithBackupFallback` before the fallback runs, so a store reaches its legacy format *and* keeps the bytes it could not read.

`SetlistRepository` is left asymmetric on purpose: it consults its org.json layout **before** the backup, because a primary kotlinx cannot read may still be readable org.json, and migrating it in place beats rolling back to an older copy. Only once that has failed does the shared rule take over — it re-reads and re-parses the primary, which is wasted work, but only on a store that is already broken.

`FavoritesRepository` is not a subclass and keeps its own storage, so it routes through `readWithBackupFallback` directly and gains `favorites_json_quarantine` / `folders_json_quarantine`.

## First commit: #554

The legacy migrations persist what they recovered and then sweep the preferences file, on the assumption that every key which is not the primary one is a leftover per-entry record. The backup `persist()` wrote two lines earlier is not, so it was swept away with it.

That had to be fixed first or this PR's quarantine would be deleted by the very migration it falls through to. Rather than adding `!= backupKey`, the set of keys a store owns is named once on the base class, which covers the quarantine slot before anything writes to it.

`ChordSheetRepository` has the same bug and is fixed here too — #554 lists only the three pattern stores.

## Testing

Behaviour changes per store, so there is a test per store rather than one for the shared helper. New `UnreadablePayloadQuarantineTest` (8 tests) covers all six stores, plus:

- `quarantinedBytesOutliveTheSaveThatFollowsTheLoss` — the point of the quarantine is surviving step 4 above.
- `setlistLegacyOrgJsonIsPreferredOverTheBackup` — pins the ordering deliberately kept asymmetric.

In `CustomProgressionRepositoryTest`, two tests that pinned today's behaviour are replaced by tests of the fixed behaviour, and `anUnrecoverableStoreStillFallsThroughToTheLegacyMigration` covers the interaction between the two commits.

Each new test was checked to discriminate by re-introducing the defect it guards. That caught one vacuous test: the first version of `setlistLegacyOrgJsonIsPreferredOverTheBackup` used quoted timestamps as its "org.json only" payload, and kotlinx accepts those, so the legacy branch never ran. It now uses unquoted keys and single-quoted strings, which org.json accepts and kotlinx does not.

Gates: `scripts/preflight.sh` all PASS, `:app:detekt` BUILD SUCCESSFUL. The ktlint baseline change is pure re-anchoring — the normalised violation multiset is byte-identical before and after across the whole repo, and the per-file entry counts are unchanged.

`RepositorySerializationTest` was already at detekt's `LargeClass` threshold, which is why the new tests are their own class rather than another section in it.

## Left for later

`FavoritesRepository.persistVoicings` / `persistFolders` still promote the outgoing primary into the backup without checking that it parses — the #553 bug, in the one store #553's fix did not reach. Filed separately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)