### PR TITLE
Fix: Put melodies on the shared backup-and-quarantine scheme

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt
@@ -11,21 +11,23 @@ import com.baijum.ukufretboard.domain.mergeNewerWins
  * melodies on the same backup-and-quarantine scheme as every other list store.
  * On first access, migrates from the legacy pipe-delimited per-entry format.
  */
-class MelodyRepository(context: Context) : JsonListRepository<Melody>(
-    context,
-    PREFS_NAME,
-    KEY_MELODIES,
-    Melody.serializer(),
-) {
+class MelodyRepository(
+    context: Context,
+) : JsonListRepository<Melody>(
+        context,
+        PREFS_NAME,
+        KEY_MELODIES,
+        Melody.serializer(),
+    ) {
     override fun entityId(item: Melody) = item.id
+
     override fun entityTimestamp(item: Melody) = item.createdAt
 
     /**
      * Newest first, the order this store has always answered in and the order
      * the saved-melody list is shown in.
      */
-    override fun getAll(): List<Melody> =
-        readOrElse(::migrateLegacyPipeEntries).sortedByDescending { it.createdAt }
+    override fun getAll(): List<Melody> = readOrElse(::migrateLegacyPipeEntries).sortedByDescending { it.createdAt }
 
     fun get(id: String): Melody? = getAll().firstOrNull { it.id == id }
 
@@ -82,20 +84,21 @@ class MelodyRepository(context: Context) : JsonListRepository<Melody>(
         val parts = value.split(LEGACY_SEPARATOR)
         if (parts.size < 5) return null
         return try {
-            val notes = if (parts[2].isBlank()) {
-                emptyList()
-            } else {
-                parts[2].split(LEGACY_NOTE_LIST_SEPARATOR).map { noteStr ->
-                    val fields = noteStr.split(LEGACY_NOTE_FIELD_SEPARATOR)
-                    MelodyNote(
-                        pitchClass = fields[0].takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
-                        octave = fields[1].toInt(),
-                        duration = NoteDuration.valueOf(fields[2]),
-                        stringIndex = fields.getOrNull(3)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
-                        fret = fields.getOrNull(4)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
-                    )
+            val notes =
+                if (parts[2].isBlank()) {
+                    emptyList()
+                } else {
+                    parts[2].split(LEGACY_NOTE_LIST_SEPARATOR).map { noteStr ->
+                        val fields = noteStr.split(LEGACY_NOTE_FIELD_SEPARATOR)
+                        MelodyNote(
+                            pitchClass = fields[0].takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
+                            octave = fields[1].toInt(),
+                            duration = NoteDuration.valueOf(fields[2]),
+                            stringIndex = fields.getOrNull(3)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
+                            fret = fields.getOrNull(4)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
+                        )
+                    }
                 }
-            }
             Melody(
                 id = parts[0],
                 name = parts[1].replace("\\|", "|"),

--- a/app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt
@@ -1,92 +1,98 @@
 package com.baijum.ukufretboard.data
 
 import android.content.Context
-import android.content.SharedPreferences
+import android.util.Log
 import com.baijum.ukufretboard.domain.mergeNewerWins
 
 /**
  * Repository for persisting melodies using SharedPreferences.
  *
- * Each melody is serialized as a pipe-delimited string with individual notes
- * encoded as colon-delimited fields.
+ * Stores the full list as a single JSON array under [KEY_MELODIES], which puts
+ * melodies on the same backup-and-quarantine scheme as every other list store.
+ * On first access, migrates from the legacy pipe-delimited per-entry format.
  */
-class MelodyRepository(context: Context) {
+class MelodyRepository(context: Context) : JsonListRepository<Melody>(
+    context,
+    PREFS_NAME,
+    KEY_MELODIES,
+    Melody.serializer(),
+) {
+    override fun entityId(item: Melody) = item.id
+    override fun entityTimestamp(item: Melody) = item.createdAt
 
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    /**
+     * Newest first, the order this store has always answered in and the order
+     * the saved-melody list is shown in.
+     */
+    override fun getAll(): List<Melody> =
+        readOrElse(::migrateLegacyPipeEntries).sortedByDescending { it.createdAt }
 
-    fun getAll(): List<Melody> {
-        return prefs.all.entries
-            .mapNotNull { (_, value) -> deserialize(value as? String) }
-            .sortedByDescending { it.createdAt }
-    }
-
-    fun get(id: String): Melody? {
-        val value = prefs.getString(id, null)
-        return deserialize(value)
-    }
-
-    fun save(melody: Melody) {
-        prefs.edit().putString(melody.id, serialize(melody)).apply()
-    }
-
-    fun delete(id: String) {
-        prefs.edit().remove(id).apply()
-    }
+    fun get(id: String): Melody? = getAll().firstOrNull { it.id == id }
 
     /**
      * Merges the given list of melodies into local storage using merge-by-ID.
      * Keeps the newer version (by createdAt) when a melody exists in both.
      */
-    fun importAll(melodies: List<Melody>) {
-        val merged = mergeNewerWins(
-            existing = getAll(),
-            incoming = melodies,
-            idOf = { it.id },
-            timestampOf = { it.createdAt },
-        )
+    override fun importAll(items: List<Melody>) {
+        persist(mergeNewerWins(getAll(), items, ::entityId, ::entityTimestamp))
+    }
+
+    /**
+     * Folds the legacy one-melody-per-key entries into the JSON list.
+     *
+     * Unlike the other pipe-format migrations this one sweeps only the keys it
+     * actually consumed. Under the per-key layout a melody whose string was
+     * damaged cost only itself: nothing rewrote the whole file, so its bytes
+     * sat under their own key indefinitely -- invisible, but recoverable
+     * (#565). Removing them here because they failed to parse would turn this
+     * fix into the loss it is meant to prevent, so they stay where they are and
+     * the log line says so.
+     */
+    private fun migrateLegacyPipeEntries(): List<Melody> {
+        val legacy = prefs.all.entries.filter { it.key !in ownKeys }
+        if (legacy.isEmpty()) return emptyList()
+
+        val migrated = mutableListOf<Melody>()
+        val consumed = mutableListOf<String>()
+        val unreadable = mutableListOf<String>()
+        for ((key, value) in legacy) {
+            val melody = deserializeLegacy(value as? String)
+            if (melody == null) {
+                unreadable += key
+            } else {
+                migrated += melody
+                consumed += key
+            }
+        }
+        if (unreadable.isNotEmpty()) {
+            Log.e(TAG, "unreadable melody entries left in place: ${unreadable.joinToString()}")
+        }
+
+        // Persisted even when nothing was readable: it is what marks the
+        // migration done, and without it every read would rescan and re-log.
+        persist(migrated)
         val editor = prefs.edit()
-        for (melody in merged) {
-            editor.putString(melody.id, serialize(melody))
-        }
+        consumed.forEach { editor.remove(it) }
         editor.apply()
+        return migrated
     }
 
-    private fun serialize(melody: Melody): String {
-        val notesPart = melody.notes.joinToString(NOTE_LIST_SEPARATOR) { note ->
-            listOf(
-                note.pitchClass?.toString() ?: NULL_MARKER,
-                note.octave.toString(),
-                note.duration.name,
-                note.stringIndex?.toString() ?: NULL_MARKER,
-                note.fret?.toString() ?: NULL_MARKER,
-            ).joinToString(NOTE_FIELD_SEPARATOR)
-        }
-        return listOf(
-            melody.id,
-            melody.name.replace("|", "\\|"),
-            notesPart,
-            melody.bpm.toString(),
-            melody.createdAt.toString(),
-        ).joinToString(SEPARATOR)
-    }
-
-    private fun deserialize(value: String?): Melody? {
+    private fun deserializeLegacy(value: String?): Melody? {
         if (value == null) return null
-        val parts = value.split(SEPARATOR)
+        val parts = value.split(LEGACY_SEPARATOR)
         if (parts.size < 5) return null
         return try {
             val notes = if (parts[2].isBlank()) {
                 emptyList()
             } else {
-                parts[2].split(NOTE_LIST_SEPARATOR).map { noteStr ->
-                    val fields = noteStr.split(NOTE_FIELD_SEPARATOR)
+                parts[2].split(LEGACY_NOTE_LIST_SEPARATOR).map { noteStr ->
+                    val fields = noteStr.split(LEGACY_NOTE_FIELD_SEPARATOR)
                     MelodyNote(
-                        pitchClass = fields[0].takeIf { it != NULL_MARKER }?.toInt(),
+                        pitchClass = fields[0].takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
                         octave = fields[1].toInt(),
                         duration = NoteDuration.valueOf(fields[2]),
-                        stringIndex = fields.getOrNull(3)?.takeIf { it != NULL_MARKER }?.toInt(),
-                        fret = fields.getOrNull(4)?.takeIf { it != NULL_MARKER }?.toInt(),
+                        stringIndex = fields.getOrNull(3)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
+                        fret = fields.getOrNull(4)?.takeIf { it != LEGACY_NULL_MARKER }?.toInt(),
                     )
                 }
             }
@@ -104,9 +110,11 @@ class MelodyRepository(context: Context) {
 
     companion object {
         private const val PREFS_NAME = "melodies"
-        private const val SEPARATOR = "|||"
-        private const val NOTE_LIST_SEPARATOR = ";;"
-        private const val NOTE_FIELD_SEPARATOR = ":"
-        private const val NULL_MARKER = "_"
+        private const val KEY_MELODIES = "melodies_json"
+        private const val LEGACY_SEPARATOR = "|||"
+        private const val LEGACY_NOTE_LIST_SEPARATOR = ";;"
+        private const val LEGACY_NOTE_FIELD_SEPARATOR = ":"
+        private const val LEGACY_NULL_MARKER = "_"
+        private const val TAG = "MelodyRepository"
     }
 }

--- a/app/src/test/java/com/baijum/ukufretboard/data/MelodyRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/MelodyRepositoryTest.kt
@@ -1,0 +1,221 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Tests for [MelodyRepository], the last list store to move onto the shared
+ * JSON-plus-backup scheme (#565).
+ *
+ * The move is what these tests are about. Round-tripping a melody is covered by
+ * `RepositorySerializationTest`; what is new here is the migration off the
+ * one-melody-per-key layout, and the promise that it does not destroy the
+ * entries it cannot read on the way past -- under the old layout a damaged
+ * melody was invisible but still on disk, and a migration that swept the file
+ * clean would have made this fix a loss.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MelodyRepositoryTest {
+    private lateinit var prefs: SharedPreferences
+    private lateinit var repo: MelodyRepository
+
+    @Before
+    fun setUp() {
+        val app: Application = ApplicationProvider.getApplicationContext()
+        prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        repo = MelodyRepository(app)
+    }
+
+    private fun melody(
+        id: String,
+        name: String = "Melody $id",
+        createdAt: Long = 1_000L,
+    ) = Melody(
+        id = id,
+        name = name,
+        notes = listOf(MelodyNote(pitchClass = 0, octave = 4, duration = NoteDuration.QUARTER)),
+        bpm = 120,
+        createdAt = createdAt,
+    )
+
+    /** The pre-JSON on-disk format: one preference key per melody. */
+    private fun legacyEntry(
+        id: String,
+        name: String,
+        notes: String = "0:4:QUARTER:2:3",
+        bpm: Int = 120,
+        createdAt: Long = 1_000L,
+    ) = listOf(id, name, notes, bpm.toString(), createdAt.toString()).joinToString("|||")
+
+    private fun writeRaw(
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    // ── Legacy migration ─────────────────────────────────────────────
+
+    @Test
+    fun migratesLegacyPipeEntriesNewestFirst() {
+        writeRaw("a", legacyEntry("a", "Oldest", createdAt = 1_000L))
+        writeRaw("b", legacyEntry("b", "Newest", createdAt = 3_000L))
+        writeRaw("c", legacyEntry("c", "Middle", createdAt = 2_000L))
+
+        assertEquals(listOf("b", "c", "a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun legacyMigrationPreservesEveryNoteField() {
+        writeRaw(
+            "a",
+            legacyEntry("a", "Tune \\| Two", notes = "0:4:QUARTER:2:3;;_:3:HALF:_:_", bpm = 96),
+        )
+
+        val migrated = repo.getAll().single()
+        assertEquals("Tune | Two", migrated.name)
+        assertEquals(96, migrated.bpm)
+        assertEquals(
+            listOf(
+                MelodyNote(pitchClass = 0, octave = 4, duration = NoteDuration.QUARTER, stringIndex = 2, fret = 3),
+                MelodyNote(pitchClass = null, octave = 3, duration = NoteDuration.HALF),
+            ),
+            migrated.notes,
+        )
+    }
+
+    @Test
+    fun migratedEntriesLeaveTheirLegacyKeysBehind() {
+        writeRaw("a", legacyEntry("a", "Migrated"))
+
+        repo.getAll()
+
+        assertNull("the consumed key should be swept", prefs.getString("a", null))
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun anUnreadableLegacyEntryIsLeftOnDiskWhileTheRestMigrate() {
+        // The whole point of #565: the damaged melody is still absent from the
+        // list, but its bytes are recoverable rather than swept away by the
+        // migration that moved its neighbours.
+        writeRaw("bad", "truncated|||entry")
+        writeRaw("good", legacyEntry("good", "Survivor"))
+
+        assertEquals(listOf("good"), repo.getAll().map { it.id })
+        assertEquals("truncated|||entry", prefs.getString("bad", null))
+    }
+
+    @Test
+    fun aStoreOfNothingButUnreadableEntriesStillFinishesMigrating() {
+        // Otherwise every read rescans the same broken entries and re-logs them.
+        writeRaw("bad", "truncated|||entry")
+
+        assertTrue(repo.getAll().isEmpty())
+        assertEquals("[]", prefs.getString(KEY_MELODIES, null))
+        assertEquals("truncated|||entry", prefs.getString("bad", null))
+    }
+
+    @Test
+    fun anEmptyStoreWritesNothing() {
+        assertTrue(repo.getAll().isEmpty())
+        assertNull("a fresh install has nothing to migrate", prefs.getString(KEY_MELODIES, null))
+    }
+
+    // ── Corrupt data ─────────────────────────────────────────────────
+
+    @Test
+    fun corruptPrimaryFallsBackToTheBackupCopy() {
+        repo.save(melody("a", name = "Recoverable"))
+        repo.save(melody("b", name = "Rotates a into the backup", createdAt = 2_000L))
+        writeRaw(KEY_MELODIES, "}} not json {{")
+
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun corruptPrimaryAndBackupQuarantineTheUnreadableBytes() {
+        writeRaw(KEY_MELODIES, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+
+        assertTrue("nothing is readable, so the store reads as empty", repo.getAll().isEmpty())
+        assertEquals(
+            "the primary's bytes should be preserved for a support request",
+            "}} not json {{",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    @Test
+    fun quarantinedBytesAreNotOverwrittenByTheNextSave() {
+        writeRaw(KEY_MELODIES, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+        repo.getAll()
+
+        repo.save(melody("a", name = "Added after the loss"))
+
+        assertEquals(listOf("a"), repo.getAll().map { it.id })
+        assertEquals("}} not json {{", prefs.getString(QUARANTINE_KEY, null))
+    }
+
+    @Test
+    fun anUnrecoverableStoreStillFallsThroughToTheLegacyMigration() {
+        // The migration's own cleanup must leave the bytes just quarantined
+        // alone -- they are not a leftover per-melody entry (#554).
+        writeRaw(KEY_MELODIES, "}} not json {{")
+        writeRaw(BACKUP_KEY, "also broken")
+        writeRaw("a", legacyEntry("a", "Recovered from the legacy format"))
+
+        assertEquals("Recovered from the legacy format", repo.getAll().single().name)
+        assertEquals(
+            "the migration cleanup should not sweep away the quarantine",
+            "}} not json {{",
+            prefs.getString(QUARANTINE_KEY, null),
+        )
+    }
+
+    // ── CRUD ─────────────────────────────────────────────────────────
+
+    @Test
+    fun getReturnsTheSavedMelody() {
+        repo.save(melody("a", name = "Findable"))
+        assertEquals("Findable", repo.get("a")?.name)
+        assertNull(repo.get("missing"))
+    }
+
+    @Test
+    fun deleteRemovesOnlyTheNamedMelody() {
+        repo.save(melody("a"))
+        repo.save(melody("b", createdAt = 2_000L))
+
+        repo.delete("a")
+
+        assertEquals(listOf("b"), repo.getAll().map { it.id })
+    }
+
+    @Test
+    fun importAllKeepsTheNewerCopyOfAnExistingId() {
+        repo.save(melody("a", name = "Old", createdAt = 100L))
+
+        repo.importAll(listOf(melody("a", name = "New", createdAt = 200L), melody("b", createdAt = 50L)))
+
+        assertEquals("New", repo.get("a")?.name)
+        assertEquals(listOf("a", "b"), repo.getAll().map { it.id })
+    }
+
+    private companion object {
+        const val PREFS_NAME = "melodies"
+        const val KEY_MELODIES = "melodies_json"
+        const val BACKUP_KEY = "melodies_json_backup"
+        const val QUARANTINE_KEY = "melodies_json_quarantine"
+    }
+}

--- a/app/src/test/java/com/baijum/ukufretboard/data/UnreadablePayloadQuarantineTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/UnreadablePayloadQuarantineTest.kt
@@ -94,6 +94,14 @@ class UnreadablePayloadQuarantineTest {
     }
 
     @Test
+    fun melodyUnreadableCopiesAreQuarantined() {
+        val prefs = corruptBothCopies("melodies", "melodies_json")
+
+        assertTrue(MelodyRepository(context).getAll().isEmpty())
+        assertEquals(CORRUPT, prefs.getString("melodies_json_quarantine", null))
+    }
+
+    @Test
     fun quarantinedBytesOutliveTheSaveThatFollowsTheLoss() {
         val prefs = corruptBothCopies("chord_sheets", "sheets_json")
         val repo = ChordSheetRepository(context)

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -238,13 +238,11 @@
         <error line="273" column="40" source="standard:function-signature" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt">
-        <error line="13" column="24" source="standard:class-signature" />
-        <error line="13" column="40" source="standard:class-signature" />
-        <error line="14" column="1" source="standard:no-empty-first-line-in-class-body" />
-        <error line="18" column="32" source="standard:function-expression-body" />
-        <error line="42" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="56" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="79" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="14" column="24" source="standard:class-signature" />
+        <error line="14" column="40" source="standard:class-signature" />
+        <error line="21" column="5" source="standard:blank-line-before-declaration" />
+        <error line="27" column="42" source="standard:function-signature" />
+        <error line="85" column="25" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt">
         <error line="19" column="31" source="standard:class-signature" />
@@ -4330,9 +4328,9 @@
         <error line="146" column="23" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/MelodyNote.kt">
-        <error line="9" column="25" source="standard:class-signature" />
-        <error line="9" column="44" source="standard:class-signature" />
-        <error line="9" column="60" source="standard:class-signature" />
+        <error line="10" column="25" source="standard:class-signature" />
+        <error line="10" column="44" source="standard:class-signature" />
+        <error line="10" column="60" source="standard:class-signature" />
     </file>
     <file name="shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/NavSection.kt">
         <error line="7" column="23" source="standard:class-signature" />

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -237,13 +237,6 @@
         <error line="261" column="1" source="standard:blank-line-between-when-conditions" />
         <error line="273" column="40" source="standard:function-signature" />
     </file>
-    <file name="app/src/main/java/com/baijum/ukufretboard/data/MelodyRepository.kt">
-        <error line="14" column="24" source="standard:class-signature" />
-        <error line="14" column="40" source="standard:class-signature" />
-        <error line="21" column="5" source="standard:blank-line-before-declaration" />
-        <error line="27" column="42" source="standard:function-signature" />
-        <error line="85" column="25" source="standard:multiline-expression-wrapping" />
-    </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt">
         <error line="19" column="31" source="standard:class-signature" />
         <error line="19" column="47" source="standard:class-signature" />

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/MelodyNote.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/data/MelodyNote.kt
@@ -2,6 +2,7 @@ package com.baijum.ukufretboard.data
 
 import com.baijum.ukufretboard.platform.currentTimeMillis
 import com.baijum.ukufretboard.platform.generateUuid
+import kotlinx.serialization.Serializable
 
 /**
  * Duration of a note relative to the beat.
@@ -23,6 +24,7 @@ enum class NoteDuration(val label: String, val beats: Float) {
  * @property stringIndex Which ukulele string this note is on (0–3). Null if unassigned.
  * @property fret Which fret this note is at. Null if unassigned.
  */
+@Serializable
 data class MelodyNote(
     val pitchClass: Int?,
     val octave: Int = 4,
@@ -40,6 +42,7 @@ data class MelodyNote(
  * @property bpm Tempo in beats per minute.
  * @property createdAt Timestamp.
  */
+@Serializable
 data class Melody(
     val id: String = generateUuid(),
     val name: String,


### PR DESCRIPTION
## Summary of changes

Fixes #565.

`MelodyRepository` was the last list store still using the one-melody-per-preference-key pipe format: no backup key, no quarantine key, no log. `getAll()` scanned `prefs.all` and `mapNotNull` dropped whatever `deserialize()` rejected, so a damaged melody just stopped appearing — indistinguishable, from the user's side, from one they deleted themselves. #316 covered melodies in principle, but the fix landed in `JsonListRepository`, which this class did not extend.

The issue asked for a deliberate choice between converting to a JSON list and inventing a per-entry quarantine. This takes the conversion, for the reasons the issue lists in its favour: it is the move #404 made for favourites and the chord sheets made before that, it inherits the backup/quarantine/log behaviour rather than growing a second copy of it, and iOS already stores melodies as a JSON array — so the two platforms' melody storage ends up the same shape again.

- `Melody` and `MelodyNote` become `@Serializable`; `MelodyRepository` becomes a `JsonListRepository<Melody>` keyed on `melodies_json`.
- `getAll()` keeps answering newest-first — the order the saved-melody list is shown in and the order the old per-key scan produced.
- `importAll` keeps merge-newer-wins; `get`/`save`/`delete` behave as before.

### The one place this migration differs from its siblings

The other pipe-format migrations persist what they recovered and then sweep every key that is not their own. Doing that here would have turned the fix into the loss it is meant to prevent: under the per-key layout a damaged melody cost only itself, and its bytes sat under their own key indefinitely — invisible, but recoverable, which the issue calls out explicitly.

So this migration removes only the keys it actually consumed, leaves unreadable entries where they are, and logs them by key so a bug report can name them. It persists even when nothing was readable, because that write is what marks the migration done — without it, every read would rescan and re-log the same broken entries.

### Out of scope

iOS `JSONStorageRepository` has no backup or quarantine of its own (`try?` decode, `else { return [] }`) — the same gap, on the other platform, across every iOS list store rather than melodies alone, and there without the per-key layout that keeps the bytes recoverable. Not touched here; filed as #569.

## Accessibility impact

- [x] No accessibility impact

Storage layer only; no UI or screen-reader surface changes.

## Commands run

- [x] `scripts/preflight.sh` (ktlint ratchet, shared KMP tests, Android unit tests, Android lint — all pass)
- [x] `./gradlew testDebugUnitTest`
- [x] `./gradlew detekt`
- [x] `./gradlew :shared:compileKotlinIosSimulatorArm64` (shared module still compiles for iOS)
- [ ] `xcodebuild ... build` — no iOS app sources changed

`ktlint-baseline.xml` is spliced, not regenerated: only the two touched files' entries move (line shifts plus the rewritten class, whose remaining violations are the same class-signature/blank-line shape every sibling repository is baselined with).

## Tests

New `MelodyRepositoryTest` covers the migration (ordering, every note field, key sweep), the corrupt-data branches now inherited (backup fallback, quarantine, quarantine surviving the next save, legacy migration still reachable after an unrecoverable read), and CRUD. Melodies join the per-store roster in `UnreadablePayloadQuarantineTest`.

Both new-behaviour tests were checked for discrimination by re-introducing the defect:
- sweeping every legacy key (sibling behaviour) → `anUnreadableLegacyEntryIsLeftOnDiskWhileTheRestMigrate` and `aStoreOfNothingButUnreadableEntriesStillFinishesMigrating` fail.
- skipping the persist when nothing was readable → `aStoreOfNothingButUnreadableEntriesStillFinishesMigrating` fails.

## Tuning modes tested

- [x] N/A — no chord/note logic changes

## Risk areas touched

- [x] Shared KMP module (affects both platforms) — `Melody`/`MelodyNote` gain `@Serializable`; no behaviour change, and iOS reads these types through its own Swift models.

Storage-format migration on Android: existing melodies are folded into the JSON list on first read. The backup file format (`BackupMelody`) is unchanged, so export/restore files stay compatible in both directions.

## Screenshots/recordings

N/A — no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Melody data is now stored and imported as a unified collection.
  - Existing melody data is automatically migrated when first accessed.
  - Newer melodies continue to appear first.
  - Invalid legacy entries are preserved for recovery while valid entries are migrated.

- **Bug Fixes**
  - Added safer handling for corrupted or unreadable melody data, including quarantine and fallback behavior.

- **Tests**
  - Expanded coverage for migration, ordering, imports, empty storage, corruption recovery, and data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
