### PR TITLE
Fix: Put every iOS UserDefaults store on backup-and-quarantine

### DIFF
--- a/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
+++ b/iosApp/UkuleleCompanion.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		A10309 /* PracticeTimerRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10309 /* PracticeTimerRepository.swift */; };
 		A10310 /* ScalePracticeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10310 /* ScalePracticeRepository.swift */; };
 		A10311 /* JSONStorageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10311 /* JSONStorageRepository.swift */; };
+		A10083 /* BackupRotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10083 /* BackupRotation.swift */; };
 		A10070 /* PatternPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10070 /* PatternPlayer.swift */; };
 		A10071 /* FullScreenFretboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10071 /* FullScreenFretboardView.swift */; };
 		A10072 /* PracticeTimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10072 /* PracticeTimerViewModelTests.swift */; };
@@ -119,6 +120,7 @@
 		A10100 /* PitchMonitorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10100 /* PitchMonitorViewModelTests.swift */; };
 		A10101 /* PlayAlongAndNeuralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10101 /* PlayAlongAndNeuralTests.swift */; };
 		A10102 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10102 /* AccessibilityTests.swift */; };
+		A10084 /* RepositoryBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10084 /* RepositoryBackupTests.swift */; };
 		A10000 /* ReviewPromptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000 /* ReviewPromptManagerTests.swift */; };
 		A10082 /* AchievementWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10082 /* AchievementWatcherTests.swift */; };
 		A20001 /* click_high.wav in Resources */ = {isa = PBXBuildFile; fileRef = B20001 /* click_high.wav */; };
@@ -270,6 +272,7 @@
 		B10309 /* PracticeTimerRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerRepository.swift; sourceTree = "<group>"; };
 		B10310 /* ScalePracticeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalePracticeRepository.swift; sourceTree = "<group>"; };
 		B10311 /* JSONStorageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONStorageRepository.swift; sourceTree = "<group>"; };
+		B10083 /* BackupRotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupRotation.swift; sourceTree = "<group>"; };
 		B10070 /* PatternPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatternPlayer.swift; sourceTree = "<group>"; };
 		B10071 /* FullScreenFretboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenFretboardView.swift; sourceTree = "<group>"; };
 		B10072 /* PracticeTimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeTimerViewModelTests.swift; sourceTree = "<group>"; };
@@ -289,6 +292,7 @@
 		B10100 /* PitchMonitorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PitchMonitorViewModelTests.swift; sourceTree = "<group>"; };
 		B10101 /* PlayAlongAndNeuralTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayAlongAndNeuralTests.swift; sourceTree = "<group>"; };
 		B10102 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
+		B10084 /* RepositoryBackupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryBackupTests.swift; sourceTree = "<group>"; };
 		B10000 /* ReviewPromptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPromptManagerTests.swift; sourceTree = "<group>"; };
 		B10082 /* AchievementWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementWatcherTests.swift; sourceTree = "<group>"; };
 		B20001 /* click_high.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = click_high.wav; sourceTree = "<group>"; };
@@ -544,6 +548,7 @@
 				B10309 /* PracticeTimerRepository.swift */,
 				B10310 /* ScalePracticeRepository.swift */,
 				B10311 /* JSONStorageRepository.swift */,
+				B10083 /* BackupRotation.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -580,6 +585,7 @@
 				B10100 /* PitchMonitorViewModelTests.swift */,
 				B10101 /* PlayAlongAndNeuralTests.swift */,
 				B10102 /* AccessibilityTests.swift */,
+				B10084 /* RepositoryBackupTests.swift */,
 				B10000 /* ReviewPromptManagerTests.swift */,
 				B10082 /* AchievementWatcherTests.swift */,
 			);
@@ -848,6 +854,7 @@
 				A10309 /* PracticeTimerRepository.swift in Sources */,
 				A10310 /* ScalePracticeRepository.swift in Sources */,
 				A10311 /* JSONStorageRepository.swift in Sources */,
+				A10083 /* BackupRotation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -872,6 +879,7 @@
 				A10100 /* PitchMonitorViewModelTests.swift in Sources */,
 				A10101 /* PlayAlongAndNeuralTests.swift in Sources */,
 				A10102 /* AccessibilityTests.swift in Sources */,
+				A10084 /* RepositoryBackupTests.swift in Sources */,
 				A10000 /* ReviewPromptManagerTests.swift in Sources */,
 				A10082 /* AchievementWatcherTests.swift in Sources */,
 			);

--- a/iosApp/UkuleleCompanion/Repositories/BackupRotation.swift
+++ b/iosApp/UkuleleCompanion/Repositories/BackupRotation.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// The outcome of reading a payload that is protected by a backup slot.
+///
+/// The three cases are kept apart because callers genuinely treat them
+/// differently: a store with nothing written yet is untouched, whereas one
+/// whose copies are both unreadable has already lost its data and can only
+/// start over. Today every iOS caller answers both with the same default, but
+/// the distinction is what a caller with a legacy layout to migrate would need,
+/// and it is the difference the quarantine slot and its log line record.
+enum BackupRead<T> {
+    /// A payload was read, from either the primary slot or the backup.
+    case loaded(T)
+
+    /// Nothing has ever been written to the primary slot.
+    case absent
+
+    /// Both copies were unreadable. The primary's raw bytes have been quarantined.
+    case unrecoverable
+}
+
+extension UserDefaults {
+    /// Where the backup copy of `key` lives.
+    ///
+    /// Derived rather than passed in, so the two halves of the scheme cannot be
+    /// pointed at different slots and no store has to remember its own naming.
+    static func backupKey(for key: String) -> String { "\(key)_backup" }
+
+    /// Where the unreadable bytes of `key` are set aside.
+    static func quarantineKey(for key: String) -> String { "\(key)_quarantine" }
+
+    /// Writes `raw` to `key` and rotates the outgoing payload into its backup slot.
+    ///
+    /// The backup only ever advances to a payload that `isReadable` accepts.
+    /// Promoting a copy that can no longer be read would destroy the last good
+    /// one, which is the single thing the backup exists to hold: once the
+    /// primary is corrupt, the backup is what the next read recovers from. When
+    /// neither stored copy is readable there is nothing worth preserving, so the
+    /// backup is re-seeded with `raw` and the next corruption again has
+    /// somewhere to fall back to.
+    ///
+    /// The backup is written before the primary is overwritten, so a process
+    /// killed mid-rotation leaves the last good copy behind rather than losing
+    /// it along with the write. `isReadable` is called at most twice and never
+    /// on the common path where the primary parses, so a store whose payload is
+    /// expensive to decode pays for the check only when something has already
+    /// gone wrong.
+    ///
+    /// This is the write half of the scheme whose read half is
+    /// ``readWithBackupFallback(key:tryParse:)``; the two are meant to be
+    /// changed together, which is why neither is written out per store. On
+    /// Android the same rule was written out twice and the two copies drifted
+    /// apart (#553, #560).
+    func writeWithBackupRotation(
+        key: String,
+        raw: Data,
+        isReadable: (Data) -> Bool
+    ) {
+        let backup = Self.backupKey(for: key)
+        if let lastGood = data(forKey: key).flatMap({ isReadable($0) ? $0 : nil }) {
+            set(lastGood, forKey: backup)
+        } else if data(forKey: backup).map(isReadable) != true {
+            // A missing backup is not readable, so an absent one is re-seeded
+            // the same way a corrupt one is.
+            set(raw, forKey: backup)
+        }
+        set(raw, forKey: key)
+    }
+
+    /// Reads `key`, falling back to its backup slot when the primary payload
+    /// cannot be decoded by `tryParse`.
+    ///
+    /// When neither copy is readable the primary's raw bytes are moved to the
+    /// quarantine slot rather than left to be overwritten by the next save, so
+    /// they survive for a support request instead of disappearing silently.
+    /// Quarantining is the only write this function performs.
+    ///
+    /// The silent-empty read this replaces was the whole bug: a store that
+    /// failed to decode was indistinguishable from one that had never been
+    /// written, and the first edit the user made wrote a one-element list over
+    /// everything they had (#569).
+    func readWithBackupFallback<T>(
+        key: String,
+        tryParse: (Data) -> T?
+    ) -> BackupRead<T> {
+        guard let raw = data(forKey: key) else { return .absent }
+
+        if let parsed = tryParse(raw) { return .loaded(parsed) }
+
+        if let recovered = data(forKey: Self.backupKey(for: key)).flatMap(tryParse) {
+            print("Storage: \(key) unreadable; recovered from backup")
+            return .loaded(recovered)
+        }
+
+        print("Storage: \(key) and its backup are both unreadable; quarantining")
+        set(raw, forKey: Self.quarantineKey(for: key))
+        return .unrecoverable
+    }
+}

--- a/iosApp/UkuleleCompanion/Repositories/FavoritesRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/FavoritesRepository.swift
@@ -1,31 +1,56 @@
 import Foundation
 
+/// Storage for favourited voicings and the folders they are filed under.
+///
+/// This class predates `JSONStorageRepository` and keeps two stores of its own,
+/// so it cannot inherit that class's `getAll`/`save`. Routing both of them
+/// through the same backup-and-quarantine helper is what stops the rule from
+/// being written out a second time and drifting — the drift between two
+/// hand-written copies is what Android's #553 and #560 were.
 final class FavoritesRepository {
     private let favoritesKey = "favorite_voicings"
     private let foldersKey = "favorite_folders"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
 
     func getAll() -> [FavoriteVoicingData] {
-        guard let data = UserDefaults.standard.data(forKey: favoritesKey),
-              let decoded = try? JSONDecoder().decode([FavoriteVoicingData].self, from: data)
-        else { return [] }
-        return decoded
+        load(favoritesKey)
     }
 
     func save(_ favorites: [FavoriteVoicingData]) {
-        guard let data = try? JSONEncoder().encode(favorites) else { return }
-        UserDefaults.standard.set(data, forKey: favoritesKey)
+        persist(favorites, to: favoritesKey)
     }
 
     func getAllFolders() -> [FavoriteFolderData] {
-        guard let data = UserDefaults.standard.data(forKey: foldersKey),
-              let decoded = try? JSONDecoder().decode([FavoriteFolderData].self, from: data)
-        else { return [] }
-        return decoded
+        load(foldersKey)
     }
 
     func saveFolders(_ folders: [FavoriteFolderData]) {
-        guard let data = try? JSONEncoder().encode(folders) else { return }
-        UserDefaults.standard.set(data, forKey: foldersKey)
+        persist(folders, to: foldersKey)
+    }
+
+    /// Reads one of the two stores, falling back to its backup copy when the
+    /// primary payload cannot be decoded. An empty list is the answer both to a
+    /// store that was never written and to one whose copies are both
+    /// unreadable; only the second leaves quarantined bytes behind.
+    private func load<Element: Decodable>(_ key: String) -> [Element] {
+        let parse: (Data) -> [Element]? = { try? JSONDecoder().decode([Element].self, from: $0) }
+        switch defaults.readWithBackupFallback(key: key, tryParse: parse) {
+        case let .loaded(items): return items
+        case .absent, .unrecoverable: return []
+        }
+    }
+
+    /// Writes one of the two stores, rotating the outgoing payload into its
+    /// backup slot.
+    private func persist<Element: Codable>(_ items: [Element], to key: String) {
+        guard let data = try? JSONEncoder().encode(items) else { return }
+        defaults.writeWithBackupRotation(key: key, raw: data) {
+            (try? JSONDecoder().decode([Element].self, from: $0)) != nil
+        }
     }
 
     func exportData(favorites: [FavoriteVoicingData], folders: [FavoriteFolderData]) -> (favorites: [[String: Any]], folders: [[String: Any]]) {

--- a/iosApp/UkuleleCompanion/Repositories/JSONStorageRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/JSONStorageRepository.swift
@@ -5,6 +5,13 @@ import Foundation
 /// Provides `getAll()`, `save(_:)`, and `exportData(_:)` with a single
 /// implementation. Subclasses only need to implement merge logic in
 /// `importData(_:into:)`.
+///
+/// The whole list is one blob per key, so a payload that fails to decode is
+/// all-or-nothing: one bad byte in `chord_sheets` loses every song rather than
+/// one. That is why reads and writes go through the backup-and-quarantine rule
+/// in ``UserDefaults/readWithBackupFallback(key:tryParse:)`` and
+/// ``UserDefaults/writeWithBackupRotation(key:raw:isReadable:)`` rather than
+/// decoding with `try?` and answering with an empty array (#569).
 class JSONStorageRepository<T: Codable> {
     let userDefaultsKey: String
     private let defaults: UserDefaults
@@ -14,16 +21,30 @@ class JSONStorageRepository<T: Codable> {
         self.defaults = defaults
     }
 
+    /// Reads the list, falling back to the backup copy when the primary payload
+    /// cannot be decoded.
+    ///
+    /// An empty list is the answer both to a store that was never written and to
+    /// one whose copies are both unreadable: with no legacy layout to migrate,
+    /// the two cases lead to the same place. They differ on disk — the second
+    /// has left the unreadable bytes in the quarantine slot.
     func getAll() -> [T] {
-        guard let data = defaults.data(forKey: userDefaultsKey),
-              let decoded = try? JSONDecoder().decode([T].self, from: data)
-        else { return [] }
-        return decoded
+        switch defaults.readWithBackupFallback(key: userDefaultsKey, tryParse: Self.tryParse) {
+        case let .loaded(items): return items
+        case .absent, .unrecoverable: return []
+        }
     }
 
+    /// Writes the list, rotating the outgoing payload into the backup slot.
     func save(_ items: [T]) {
         guard let data = try? JSONEncoder().encode(items) else { return }
-        defaults.set(data, forKey: userDefaultsKey)
+        defaults.writeWithBackupRotation(key: userDefaultsKey, raw: data) {
+            Self.tryParse($0) != nil
+        }
+    }
+
+    private static func tryParse(_ data: Data) -> [T]? {
+        try? JSONDecoder().decode([T].self, from: data)
     }
 
     func exportData(_ items: [T]) -> [[String: Any]] {

--- a/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
@@ -1,18 +1,39 @@
 import Foundation
 
+/// Storage for the practice totals.
+///
+/// One object rather than a list, but with the same thing to lose: a payload
+/// that fails to decode used to reset the totals to zero, and the next session
+/// wrote that zero back over the only copy. It goes through the same
+/// backup-and-quarantine helper as the list stores (#569).
 final class PracticeTimerRepository {
     private let storageKey = "practice_timer"
+    private let defaults: UserDefaults
 
-    func load() -> PracticeTimerData {
-        guard let stored = UserDefaults.standard.data(forKey: storageKey),
-              let decoded = try? JSONDecoder().decode(PracticeTimerData.self, from: stored)
-        else { return PracticeTimerData() }
-        return decoded
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
     }
 
+    /// Reads the totals, falling back to the backup copy when the primary
+    /// payload cannot be decoded. Fresh totals are the answer both to a store
+    /// that was never written and to one whose copies are both unreadable; only
+    /// the second leaves quarantined bytes behind.
+    func load() -> PracticeTimerData {
+        let parse: (Data) -> PracticeTimerData? = {
+            try? JSONDecoder().decode(PracticeTimerData.self, from: $0)
+        }
+        switch defaults.readWithBackupFallback(key: storageKey, tryParse: parse) {
+        case let .loaded(stored): return stored
+        case .absent, .unrecoverable: return PracticeTimerData()
+        }
+    }
+
+    /// Writes the totals, rotating the outgoing payload into the backup slot.
     func save(_ data: PracticeTimerData) {
         guard let encoded = try? JSONEncoder().encode(data) else { return }
-        UserDefaults.standard.set(encoded, forKey: storageKey)
+        defaults.writeWithBackupRotation(key: storageKey, raw: encoded) {
+            (try? JSONDecoder().decode(PracticeTimerData.self, from: $0)) != nil
+        }
     }
 
     func exportData(_ data: PracticeTimerData) -> [String: Any] {

--- a/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
+++ b/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+@testable import UkuleleCompanion
+
+/// What each UserDefaults-backed store does when its stored payload cannot be
+/// decoded.
+///
+/// Every one of these stores used to answer that question the same way: `try?`
+/// turned the failure into `nil`, the store reported empty, and the first edit
+/// the user made wrote a one-element list over everything they had (#569). The
+/// list stores keep the whole list in one blob per key, so that was all-or-
+/// nothing — one bad byte in `chord_sheets` lost every song.
+///
+/// One test per store, because routing them onto the shared rule changes what
+/// each of them does on disk, and because the Android side of this work found
+/// that a recovery contract can exist while nothing actually reaches it (#564).
+final class RepositoryBackupTests: XCTestCase {
+    /// Every primary key that now carries a backup and a quarantine slot.
+    private static let storeKeys = [
+        "chord_sheets",
+        "setlists",
+        "melodies",
+        "custom_progressions",
+        "custom_strum_patterns",
+        "custom_fingerpicking_patterns",
+        "favorite_voicings",
+        "favorite_folders",
+        "practice_timer",
+    ]
+
+    private let defaults = UserDefaults.standard
+
+    override func setUp() {
+        super.setUp()
+        clearStores()
+    }
+
+    override func tearDown() {
+        clearStores()
+        super.tearDown()
+    }
+
+    private func clearStores() {
+        for key in Self.storeKeys {
+            for slot in [key, UserDefaults.backupKey(for: key), UserDefaults.quarantineKey(for: key)] {
+                defaults.removeObject(forKey: slot)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let corrupt = Data("NOT JSON".utf8)
+    private static let alsoCorrupt = Data("ALSO NOT JSON".utf8)
+
+    /// Leaves both stored copies of `key` unreadable.
+    private func corruptBothCopies(_ key: String) {
+        defaults.set(Self.corrupt, forKey: key)
+        defaults.set(Self.alsoCorrupt, forKey: UserDefaults.backupKey(for: key))
+    }
+
+    /// Asserts that `key` holds the bytes the read was supposed to set aside.
+    private func assertQuarantined(_ key: String, line: UInt = #line) {
+        XCTAssertEqual(
+            defaults.data(forKey: UserDefaults.quarantineKey(for: key)), Self.corrupt,
+            "\(key) should have left its unreadable bytes in quarantine",
+            line: line
+        )
+    }
+
+    private func makeSong(id: String, title: String) -> StoredSong {
+        StoredSong(
+            id: id, title: title, artist: "", content: "[C]Hello",
+            key: "C", capo: 0, strumPatternName: "", labels: [],
+            createdAt: 1000, updatedAt: 1000,
+            viewCount: 0, lastViewedAt: 0, totalViewTimeMs: 0
+        )
+    }
+
+    // MARK: - Both copies unreadable
+
+    func testSongbookQuarantinesUnreadableCopies() {
+        corruptBothCopies("chord_sheets")
+
+        XCTAssertTrue(SongbookRepository().getAll().isEmpty)
+        assertQuarantined("chord_sheets")
+    }
+
+    func testSetlistQuarantinesUnreadableCopies() {
+        corruptBothCopies("setlists")
+
+        XCTAssertTrue(SetlistRepository().getAll().isEmpty)
+        assertQuarantined("setlists")
+    }
+
+    func testMelodyQuarantinesUnreadableCopies() {
+        corruptBothCopies("melodies")
+
+        XCTAssertTrue(MelodyRepository().getAll().isEmpty)
+        assertQuarantined("melodies")
+    }
+
+    func testProgressionsQuarantinesUnreadableCopies() {
+        corruptBothCopies("custom_progressions")
+
+        XCTAssertTrue(ProgressionsRepository().getAll().isEmpty)
+        assertQuarantined("custom_progressions")
+    }
+
+    func testStrumPatternsQuarantineUnreadableCopies() {
+        corruptBothCopies("custom_strum_patterns")
+
+        XCTAssertTrue(CustomPatternsRepository().getAllStrum().isEmpty)
+        assertQuarantined("custom_strum_patterns")
+    }
+
+    func testFingerpickingPatternsQuarantineUnreadableCopies() {
+        corruptBothCopies("custom_fingerpicking_patterns")
+
+        XCTAssertTrue(CustomPatternsRepository().getAllFingerpicking().isEmpty)
+        assertQuarantined("custom_fingerpicking_patterns")
+    }
+
+    func testFavoriteVoicingsQuarantineUnreadableCopies() {
+        corruptBothCopies("favorite_voicings")
+
+        XCTAssertTrue(FavoritesRepository().getAll().isEmpty)
+        assertQuarantined("favorite_voicings")
+    }
+
+    func testFavoriteFoldersQuarantineUnreadableCopies() {
+        corruptBothCopies("favorite_folders")
+
+        XCTAssertTrue(FavoritesRepository().getAllFolders().isEmpty)
+        assertQuarantined("favorite_folders")
+    }
+
+    /// One object rather than a list, and the loss is the practice totals
+    /// rather than a song list, but the shape is the same.
+    func testPracticeTimerQuarantinesUnreadableCopies() {
+        corruptBothCopies("practice_timer")
+
+        XCTAssertEqual(PracticeTimerRepository().load().totalMinutes, 0)
+        assertQuarantined("practice_timer")
+    }
+
+    /// A store nobody has written to is not a store that lost anything.
+    func testUntouchedStoreQuarantinesNothing() {
+        XCTAssertTrue(SongbookRepository().getAll().isEmpty)
+        XCTAssertNil(defaults.data(forKey: UserDefaults.quarantineKey(for: "chord_sheets")))
+    }
+
+    // MARK: - Recovery from the backup copy
+
+    func testCorruptPrimaryRecoversFromBackup() {
+        let repository = SongbookRepository()
+        repository.save([makeSong(id: "song-1", title: "Amazing Grace")])
+
+        defaults.set(Self.corrupt, forKey: "chord_sheets")
+
+        let recovered = repository.getAll()
+        XCTAssertEqual(recovered.map(\.title), ["Amazing Grace"])
+        XCTAssertNil(
+            defaults.data(forKey: UserDefaults.quarantineKey(for: "chord_sheets")),
+            "a payload the backup could answer for has not been lost"
+        )
+    }
+
+    /// The sequence from #569: the list reads as empty, the user adds a song,
+    /// and the save takes the rest with it. The backup is what stops step three.
+    func testAddingASongAfterCorruptionDoesNotDestroyTheOthers() {
+        let repository = SongbookRepository()
+        repository.save([
+            makeSong(id: "song-1", title: "Amazing Grace"),
+            makeSong(id: "song-2", title: "Blackbird"),
+        ])
+
+        defaults.set(Self.corrupt, forKey: "chord_sheets")
+
+        var songs = repository.getAll()
+        songs.append(makeSong(id: "song-3", title: "Hallelujah"))
+        repository.save(songs)
+
+        XCTAssertEqual(
+            SongbookRepository().getAll().map(\.title).sorted(),
+            ["Amazing Grace", "Blackbird", "Hallelujah"]
+        )
+    }
+
+    func testPracticeTimerRecoversTotalsFromBackup() {
+        let repository = PracticeTimerRepository()
+        var data = PracticeTimerData()
+        data.totalMinutes = 120
+        repository.save(data)
+
+        defaults.set(Self.corrupt, forKey: "practice_timer")
+
+        XCTAssertEqual(repository.load().totalMinutes, 120)
+    }
+
+    func testFavoritesRecoverFromBackup() {
+        let repository = FavoritesRepository()
+        repository.save([
+            FavoriteVoicingData(rootPitchClass: 0, chordSymbol: "maj",
+                                frets: [0, 0, 0, 3], addedAt: 1000, folderIds: []),
+        ])
+
+        defaults.set(Self.corrupt, forKey: "favorite_voicings")
+
+        XCTAssertEqual(repository.getAll().map(\.chordSymbol), ["maj"])
+    }
+
+    // MARK: - What the backup is allowed to advance to
+
+    /// The backup only ever advances to a payload that still decodes. Promoting
+    /// a corrupt primary would destroy the last good copy — the single thing the
+    /// backup exists to hold (#553, #560).
+    func testSaveDoesNotPromoteACorruptPrimaryIntoTheBackup() {
+        let repository = SongbookRepository()
+        repository.save([makeSong(id: "song-1", title: "Amazing Grace")])
+        let lastGood = defaults.data(forKey: UserDefaults.backupKey(for: "chord_sheets"))
+        XCTAssertNotNil(lastGood, "the first save should have seeded the backup")
+
+        defaults.set(Self.corrupt, forKey: "chord_sheets")
+        repository.save([makeSong(id: "song-2", title: "Blackbird")])
+
+        XCTAssertEqual(defaults.data(forKey: UserDefaults.backupKey(for: "chord_sheets")), lastGood)
+    }
+
+    /// With neither stored copy readable there is nothing worth preserving, so
+    /// the backup is re-seeded and the next corruption again has somewhere to
+    /// fall back to.
+    func testSaveReseedsAnUnreadableBackup() {
+        let repository = SongbookRepository()
+        corruptBothCopies("chord_sheets")
+
+        repository.save([makeSong(id: "song-1", title: "Amazing Grace")])
+
+        defaults.set(Self.corrupt, forKey: "chord_sheets")
+        XCTAssertEqual(repository.getAll().map(\.title), ["Amazing Grace"])
+    }
+
+    /// An ordinary save rotates the previous payload into the backup rather than
+    /// leaving the backup pinned to whatever seeded it.
+    func testSaveRotatesThePreviousPayloadIntoTheBackup() {
+        let repository = SongbookRepository()
+        repository.save([makeSong(id: "song-1", title: "Amazing Grace")])
+        repository.save([makeSong(id: "song-2", title: "Blackbird")])
+
+        defaults.set(Self.corrupt, forKey: "chord_sheets")
+
+        XCTAssertEqual(repository.getAll().map(\.title), ["Amazing Grace"])
+    }
+}


### PR DESCRIPTION
Fixes #569.

## The bug

Every iOS list store read through one `try?` in `JSONStorageRepository.getAll()`, so a payload that failed to decode was answered with an empty array — indistinguishable from a store that had never been written. The whole list is one blob per key, so this was all-or-nothing: one bad byte in `chord_sheets` lost every song, not one.

The ViewModels load once into a published array and write the whole array back on every edit, so the sequence was: the blob goes bad → the user opens the Songbook and sees nothing → they add a song → `save(songs)` puts a one-element array over the key → the original bytes are gone. This is #316 on the other platform, and unlike the melody case in #565 there was no per-key layout leaving the bytes recoverable on disk.

## The fix

Port the rule Android settled on across #316, #553, #560, #564 and #565, in the one place iOS already funnels these reads through — a new `BackupRotation.swift` holding both halves:

- **Write** rotates the outgoing payload into `<key>_backup`, and the backup only ever advances to a payload that still decodes. Promoting a corrupt primary would destroy the last good copy, which is the single thing the backup exists to hold (#553, #560). The backup is written before the primary is overwritten, so a process killed mid-rotation leaves the last good copy behind.
- **Read** falls back to the backup, and when neither copy decodes it moves the primary's raw bytes to `<key>_quarantine` before anything can overwrite them, with a log line naming the key.

Routed through it:

| Store | Keys |
|---|---|
| `JSONStorageRepository` and its subclasses | `chord_sheets`, `setlists`, `melodies`, `custom_progressions`, `custom_strum_patterns`, `custom_fingerpicking_patterns` |
| `FavoritesRepository` | `favorite_voicings`, `favorite_folders` |
| `PracticeTimerRepository` | `practice_timer` |

`FavoritesRepository` and `PracticeTimerRepository` keep their own storage and cannot inherit `JSONStorageRepository`, so they call the same helper rather than growing a second copy of the rule — the drift between two hand-written copies is what #553 and #560 were. Both gained an injectable `UserDefaults` for testing, defaulting to `.standard`.

`SettingsRepository` and `LearnRepository` are untouched: they store per-key primitives, so there is no single blob to lose.

## Tests

`RepositoryBackupTests` — 17 tests, one per store for the both-copies-unreadable case, plus recovery-from-backup, the #569 sequence end to end (a corrupt primary followed by adding a song keeps the other songs), the no-promoting-a-corrupt-primary rule, backup re-seeding, and rotation. The Android side of this work found a recovery contract that existed while nothing actually reached it (#564), which is why there is a test per store.

Verified they discriminate: re-introducing the old `try?` reads fails 15 of the 17. The two that still pass are the guard against over-quarantining an untouched store, and the no-promote rule, which the old code passed only because it had no backup key at all.

## Checks

- `xcodebuild test` — 241 tests, 0 failures, no malformed-project warnings from the two hand-added `pbxproj` entries.
- No Kotlin touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)