### PR TITLE
Fix: Keep a corrupt favourites payload out of the backup slot

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/FavoritesRepository.kt
@@ -186,22 +186,32 @@ class FavoritesRepository(context: Context) {
 
     // ── JSON persistence ────────────────────────────────────────────
 
+    /**
+     * Writes the voicings, rotating the outgoing payload into the backup slot.
+     *
+     * See [writeWithBackupRotation] for the rule the backup follows.
+     */
     private fun persistVoicings(items: List<FavoriteVoicing>) {
-        val raw = json.encodeToString(ListSerializer(FavoriteVoicing.serializer()), items)
-        val previousGood = prefs.getString(KEY_FAVORITES, null)
-        prefs.edit()
-            .putString(BACKUP_KEY_FAVORITES, previousGood ?: raw)
-            .putString(KEY_FAVORITES, raw)
-            .apply()
+        prefs.writeWithBackupRotation(
+            key = KEY_FAVORITES,
+            backupKey = BACKUP_KEY_FAVORITES,
+            raw = json.encodeToString(ListSerializer(FavoriteVoicing.serializer()), items),
+            isReadable = { tryParseVoicings(it) != null },
+        )
     }
 
+    /**
+     * Writes the folders, rotating the outgoing payload into the backup slot.
+     *
+     * See [writeWithBackupRotation] for the rule the backup follows.
+     */
     private fun persistFolders(items: List<FavoriteFolder>) {
-        val raw = json.encodeToString(ListSerializer(FavoriteFolder.serializer()), items)
-        val previousGood = folderPrefs.getString(KEY_FOLDERS, null)
-        folderPrefs.edit()
-            .putString(BACKUP_KEY_FOLDERS, previousGood ?: raw)
-            .putString(KEY_FOLDERS, raw)
-            .apply()
+        folderPrefs.writeWithBackupRotation(
+            key = KEY_FOLDERS,
+            backupKey = BACKUP_KEY_FOLDERS,
+            raw = json.encodeToString(ListSerializer(FavoriteFolder.serializer()), items),
+            isReadable = { tryParseFolders(it) != null },
+        )
     }
 
     /**

--- a/app/src/test/java/com/baijum/ukufretboard/data/FavoritesRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/FavoritesRepositoryTest.kt
@@ -1,0 +1,181 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * What [FavoritesRepository] writes to disk when one of its two stores has a
+ * corrupt primary copy.
+ *
+ * This class predates [JsonListRepository] and keeps its own storage, so the
+ * write side was never carried along when the rotation rule was fixed there
+ * (#553) and extracted into [writeWithBackupRotation] (#561). It rotated the
+ * outgoing payload into the backup unconditionally, which promoted corrupt
+ * bytes over the last readable copy — on nothing more dangerous than starring a
+ * chord (#567). Both of its stores are covered, because they are two separate
+ * preference files with two separate write paths.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FavoritesRepositoryTest {
+    private lateinit var context: Application
+    private lateinit var prefs: SharedPreferences
+    private lateinit var folderPrefs: SharedPreferences
+    private lateinit var repo: FavoritesRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        prefs = context.getSharedPreferences(PREFS_NAME, 0)
+        folderPrefs = context.getSharedPreferences(FOLDER_PREFS_NAME, 0)
+        repo = FavoritesRepository(context)
+    }
+
+    private fun voicing(
+        root: Int,
+        symbol: String = "maj",
+        frets: List<Int> = listOf(0, 0, 0, 3),
+    ) = FavoriteVoicing(rootPitchClass = root, chordSymbol = symbol, frets = frets, addedAt = 1L)
+
+    private fun writeRaw(
+        prefs: SharedPreferences,
+        key: String,
+        value: String,
+    ) {
+        prefs.edit().putString(key, value).commit()
+    }
+
+    // ── Voicings ─────────────────────────────────────────────────────
+
+    @Test
+    fun starringAChordOverACorruptPrimaryLeavesTheLastGoodBackupInPlace() {
+        repo.add(voicing(0))
+        val lastGood = prefs.getString(BACKUP_KEY_FAVORITES, null)
+        writeRaw(prefs, KEY_FAVORITES, CORRUPT)
+
+        repo.add(voicing(5))
+
+        assertEquals(
+            "the corrupt primary must not be promoted over the last readable copy",
+            lastGood,
+            prefs.getString(BACKUP_KEY_FAVORITES, null),
+        )
+    }
+
+    @Test
+    fun aStarredChordOverACorruptPrimaryLeavesFavoritesRecoverableAfterTheNextCorruption() {
+        repo.add(voicing(0))
+        writeRaw(prefs, KEY_FAVORITES, CORRUPT)
+        repo.add(voicing(5))
+
+        // Second corruption: the surviving backup is what keeps the data alive.
+        writeRaw(prefs, KEY_FAVORITES, "corrupt again")
+
+        assertEquals(
+            "the backup should still serve the last good copy",
+            listOf(voicing(0).key),
+            repo.getAll().map { it.key },
+        )
+        assertNull(
+            "a recoverable read must not quarantine",
+            prefs.getString(QUARANTINE_KEY_FAVORITES, null),
+        )
+    }
+
+    @Test
+    fun voicingBackupLagsExactlyOnePersistBehindThePrimary() {
+        repo.add(voicing(0))
+        val afterFirst = prefs.getString(KEY_FAVORITES, null)
+        repo.add(voicing(5))
+
+        assertEquals(
+            "the backup should hold the previous primary",
+            afterFirst,
+            prefs.getString(BACKUP_KEY_FAVORITES, null),
+        )
+    }
+
+    @Test
+    fun persistReseedsTheVoicingBackupWhenNeitherStoredCopyIsReadable() {
+        writeRaw(prefs, KEY_FAVORITES, CORRUPT)
+        writeRaw(prefs, BACKUP_KEY_FAVORITES, "also corrupt")
+
+        repo.add(voicing(0))
+
+        assertEquals(
+            "with nothing worth keeping, the backup is re-seeded with the new payload",
+            prefs.getString(KEY_FAVORITES, null),
+            prefs.getString(BACKUP_KEY_FAVORITES, null),
+        )
+    }
+
+    // ── Folders ──────────────────────────────────────────────────────
+
+    @Test
+    fun savingAFolderOverACorruptPrimaryLeavesTheLastGoodBackupInPlace() {
+        repo.saveFolder(FavoriteFolder(id = "f1", name = "Jazz", createdAt = 1L))
+        val lastGood = folderPrefs.getString(BACKUP_KEY_FOLDERS, null)
+        writeRaw(folderPrefs, KEY_FOLDERS, CORRUPT)
+
+        repo.saveFolder(FavoriteFolder(id = "f2", name = "Blues", createdAt = 2L))
+
+        assertEquals(
+            "the corrupt primary must not be promoted over the last readable copy",
+            lastGood,
+            folderPrefs.getString(BACKUP_KEY_FOLDERS, null),
+        )
+    }
+
+    @Test
+    fun aSavedFolderOverACorruptPrimaryLeavesFoldersRecoverableAfterTheNextCorruption() {
+        repo.saveFolder(FavoriteFolder(id = "f1", name = "Jazz", createdAt = 1L))
+        writeRaw(folderPrefs, KEY_FOLDERS, CORRUPT)
+        repo.saveFolder(FavoriteFolder(id = "f2", name = "Blues", createdAt = 2L))
+
+        writeRaw(folderPrefs, KEY_FOLDERS, "corrupt again")
+
+        assertEquals(
+            "the backup should still serve the last good copy",
+            listOf("f1"),
+            repo.getAllFolders().map { it.id },
+        )
+        assertNull(
+            "a recoverable read must not quarantine",
+            folderPrefs.getString(QUARANTINE_KEY_FOLDERS, null),
+        )
+    }
+
+    @Test
+    fun persistReseedsTheFolderBackupWhenNeitherStoredCopyIsReadable() {
+        writeRaw(folderPrefs, KEY_FOLDERS, CORRUPT)
+        writeRaw(folderPrefs, BACKUP_KEY_FOLDERS, "also corrupt")
+
+        repo.saveFolder(FavoriteFolder(id = "f1", name = "Jazz", createdAt = 1L))
+
+        assertEquals(
+            "with nothing worth keeping, the backup is re-seeded with the new payload",
+            folderPrefs.getString(KEY_FOLDERS, null),
+            folderPrefs.getString(BACKUP_KEY_FOLDERS, null),
+        )
+    }
+
+    private companion object {
+        const val PREFS_NAME = "chord_favorites"
+        const val KEY_FAVORITES = "favorites_json"
+        const val BACKUP_KEY_FAVORITES = "favorites_json_backup"
+        const val QUARANTINE_KEY_FAVORITES = "favorites_json_quarantine"
+        const val FOLDER_PREFS_NAME = "favorite_folders"
+        const val KEY_FOLDERS = "folders_json"
+        const val BACKUP_KEY_FOLDERS = "folders_json_backup"
+        const val QUARANTINE_KEY_FOLDERS = "folders_json_quarantine"
+
+        /** Stands in for a payload the parser cannot make sense of. */
+        const val CORRUPT = "}} not json {{"
+    }
+}

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -176,15 +176,13 @@
         <error line="151" column="76" source="standard:function-signature" />
         <error line="166" column="22" source="standard:multiline-expression-wrapping" />
         <error line="179" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="192" column="14" source="standard:chain-method-continuation" />
-        <error line="201" column="20" source="standard:chain-method-continuation" />
-        <error line="258" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="274" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="295" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="321" column="25" source="standard:multiline-expression-wrapping" />
-        <error line="337" column="36" source="standard:function-signature" />
-        <error line="337" column="60" source="standard:function-signature" />
-        <error line="337" column="92" source="standard:function-signature" />
+        <error line="268" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="284" column="23" source="standard:multiline-expression-wrapping" />
+        <error line="305" column="29" source="standard:multiline-expression-wrapping" />
+        <error line="331" column="25" source="standard:multiline-expression-wrapping" />
+        <error line="347" column="36" source="standard:function-signature" />
+        <error line="347" column="60" source="standard:function-signature" />
+        <error line="347" column="92" source="standard:function-signature" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/JsonListRepository.kt">
         <error line="23" column="33" source="standard:statement-wrapping" />


### PR DESCRIPTION
`FavoritesRepository` was the one store #553's fix did not reach. Its two write paths rotated the outgoing payload into the backup slot without checking that it could still be read, so a corrupt primary was promoted over the last readable copy.

## Why it matters

A corrupt primary is invisible to the user: `getAll()` already recovers from the backup and shows their favourites as usual. Starring one chord then writes the corruption into the backup, and the read after that has nothing to fall back to — both copies quarantine and the list comes back empty. A fully recoverable state becomes unrecoverable on an action nobody would think twice about.

## The change

Both `persistVoicings` and `persistFolders` now go through `writeWithBackupRotation` (`app/src/main/java/com/baijum/ukufretboard/data/BackupRotation.kt`), the same call `JsonListRepository.persist()` and `SettingsRepository.save()` make. This class is not a `JsonListRepository` subclass and keeps its own two preference files, which is why it was missed here and in #566 (the matching read side).

Routing through the helper also brings the re-seed rule unified in #560 to this store: a save over two unreadable copies re-seeds the backup with the new payload instead of leaving it corrupt forever.

## Tests

New `FavoritesRepositoryTest` covers both stores — they are two separate write paths — and pins the issue's sequence end to end: corrupt the primary, save, corrupt it again, and check the store still reads back the last good copy. Six of the seven tests fail against the previous implementation.

`scripts/preflight.sh` passes (ktlint ratchet, shared tests, Android unit tests, lint). The ktlint baseline entry for `FavoritesRepository.kt` is spliced, not regenerated: two `chain-method-continuation` entries are dropped with the hand-rolled edit chain they described, and five shift by the ten lines the change adds.

No UI or accessibility surface is touched.

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of saved favorites when primary data becomes corrupted.
  * Preserved the latest readable backup for both voicings and folders.
  * Automatically restores backup availability when both stored copies are unreadable.

* **Tests**
  * Added coverage for persistence, backup rotation, corruption recovery, and reseeding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->