### PR TITLE
Fix: song editor no longer discards unsaved edits on recreation

### DIFF
--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
@@ -1,0 +1,154 @@
+package com.baijum.ukufretboard
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.platform.app.InstrumentationRegistry
+import com.baijum.ukufretboard.data.ChordSheet
+import com.baijum.ukufretboard.ui.songbook.SheetEditor
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * UI tests for unsaved-edit survival across recreation (issue #573).
+ *
+ * The defect was that every editor field used plain [androidx.compose.runtime.remember],
+ * so an activity recreation (rotation, system font/display size change, split-screen)
+ * silently restored the last *saved* values and discarded everything typed.
+ *
+ * The test simulates recreation the same way Compose does it: the whole composition
+ * under a [androidx.compose.runtime.saveable.SaveableStateHolder.SaveableStateProvider]
+ * is disposed and re-provided with the same key, so only `rememberSaveable` state
+ * survives — exactly what happens across a configuration change.
+ *
+ * Run with: ./gradlew connectedAndroidTest
+ *   -Pandroid.testInstrumentationRunnerArguments.class=com.baijum.ukufretboard.SheetEditorStateRestorationTest
+ */
+class SheetEditorStateRestorationTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private data class SaveArgs(
+        val title: String,
+        val artist: String,
+        val content: String,
+        val key: String,
+        val capo: Int,
+        val strumPatternName: String,
+        val labels: List<String>,
+    )
+
+    private var saved: SaveArgs? = null
+
+    /** Toggling this disposes and re-creates the editor under the same saveable key. */
+    private lateinit var editorVisible: androidx.compose.runtime.MutableState<Boolean>
+
+    private fun str(id: Int): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.getString(id)
+    }
+
+    private fun renderEditor(sheet: ChordSheet?) {
+        saved = null
+        editorVisible = mutableStateOf(true)
+        composeTestRule.setContent {
+            MaterialTheme {
+                val holder = rememberSaveableStateHolder()
+                if (editorVisible.value) {
+                    holder.SaveableStateProvider("sheet-editor") {
+                        SheetEditor(
+                            sheet = sheet,
+                            allLabels = emptySet(),
+                            onSave = { title, artist, content, key, capo, strumPatternName, labels ->
+                                saved = SaveArgs(title, artist, content, key, capo, strumPatternName, labels)
+                            },
+                            onCancel = {},
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun simulateRecreation() {
+        composeTestRule.runOnUiThread { editorVisible.value = false }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnUiThread { editorVisible.value = true }
+        composeTestRule.waitForIdle()
+    }
+
+    private fun tapSave() {
+        composeTestRule.onNodeWithText(str(R.string.dialog_save)).performClick()
+    }
+
+    @Test
+    fun typedTitleAndLyricsSurviveRecreation() {
+        renderEditor(null)
+
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_field_title))
+            .performTextInput("Rotation Test")
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_field_lyrics))
+            .performTextInput("[C]First verse\nSecond line")
+
+        simulateRecreation()
+
+        composeTestRule.onNodeWithText("Rotation Test").assertExists()
+
+        tapSave()
+        assertEquals("Rotation Test", saved?.title)
+        assertEquals("[C]First verse\nSecond line", saved?.content)
+    }
+
+    @Test
+    fun editedLabelsSurviveRecreation() {
+        renderEditor(null)
+
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_field_title))
+            .performTextInput("Label Test")
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_label_hint))
+            .performTextInput("folk")
+        composeTestRule.onNodeWithContentDescription(str(R.string.cd_add_label)).performClick()
+
+        simulateRecreation()
+
+        // The added label chip must still be there after recreation.
+        composeTestRule.onNodeWithText("folk").assertExists()
+
+        tapSave()
+        assertEquals(listOf("folk"), saved?.labels)
+    }
+
+    @Test
+    fun editsOnAnExistingSongSurviveRecreation() {
+        // The exact #573 repro shape: edit a saved song without saving.
+        renderEditor(
+            ChordSheet(
+                title = "Heart of Gold",
+                artist = "Neil Young",
+                content = "[Em]I want to live",
+                key = "G",
+                capo = 2,
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_field_lyrics))
+            .performTextInput("\n[Am]More lyrics")
+
+        simulateRecreation()
+
+        tapSave()
+        assertEquals("Heart of Gold", saved?.title)
+        assertEquals("[Em]I want to live\n[Am]More lyrics", saved?.content)
+    }
+}

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.platform.app.InstrumentationRegistry
 import com.baijum.ukufretboard.data.ChordSheet
@@ -141,9 +142,14 @@ class SheetEditorStateRestorationTest {
             ),
         )
 
+        // Replace the content deterministically: typing into a pre-filled field
+        // places the cursor at position 0, so clear first, then type the edit.
         composeTestRule
             .onNodeWithText(str(R.string.songbook_field_lyrics))
-            .performTextInput("\n[Am]More lyrics")
+            .performTextClearance()
+        composeTestRule
+            .onNodeWithText(str(R.string.songbook_field_lyrics))
+            .performTextInput("[Em]I want to live\n[Am]More lyrics")
 
         simulateRecreation()
 

--- a/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
+++ b/app/src/androidTest/java/com/baijum/ukufretboard/SheetEditorStateRestorationTest.kt
@@ -156,5 +156,10 @@ class SheetEditorStateRestorationTest {
         tapSave()
         assertEquals("Heart of Gold", saved?.title)
         assertEquals("[Em]I want to live\n[Am]More lyrics", saved?.content)
+        // Pin the remaining editable fields too: they must survive recreation
+        // untouched, not silently reset to defaults.
+        assertEquals("Neil Young", saved?.artist)
+        assertEquals("G", saved?.key)
+        assertEquals(2, saved?.capo)
     }
 }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/StateSavers.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/StateSavers.kt
@@ -9,143 +9,180 @@ import com.baijum.ukufretboard.domain.ChordEarTrainer
 import com.baijum.ukufretboard.domain.IntervalTrainer
 import com.baijum.ukufretboard.domain.QuizGenerator
 
+/** Reusable [Saver] for [List]<[String]> (e.g. sheet labels) so it survives activity recreation. */
+val StringListSaver: Saver<List<String>, Any> =
+    listSaver(
+        save = { ArrayList(it) },
+        restore = { it.toList() },
+    )
+
 /** Reusable [Saver] for any non-nullable enum backed by its [Enum.name]. */
-inline fun <reified E : Enum<E>> enumSaver(): Saver<E, String> = Saver(
-    save = { it.name },
-    restore = { enumValueOf<E>(it) },
-)
+inline fun <reified E : Enum<E>> enumSaver(): Saver<E, String> =
+    Saver(
+        save = { it.name },
+        restore = { enumValueOf<E>(it) },
+    )
 
 /** Reusable [Saver] for a nullable enum backed by its [Enum.name] (empty string for null). */
-inline fun <reified E : Enum<E>> nullableEnumSaver(): Saver<E?, String> = Saver(
-    save = { it?.name ?: "" },
-    restore = { name -> if (name.isEmpty()) null else enumValueOf<E>(name) },
-)
+inline fun <reified E : Enum<E>> nullableEnumSaver(): Saver<E?, String> =
+    Saver(
+        save = { it?.name ?: "" },
+        restore = { name -> if (name.isEmpty()) null else enumValueOf<E>(name) },
+    )
 
 /** Saver for a nullable [IntervalTrainer.IntervalQuestion]. */
-val IntervalQuestionSaver: Saver<IntervalTrainer.IntervalQuestion?, Any> = listSaver(
-    save = { q ->
-        if (q == null) emptyList()
-        else listOf(
-            q.note1PitchClass,
-            q.note2PitchClass,
-            q.note1Name,
-            q.note2Name,
-            q.intervalSemitones,
-            q.correctAnswer,
-            ArrayList(q.options),
-            q.correctIndex,
-            q.note1Fret,
-            q.note2Fret,
-            q.note1Octave,
-            q.note2Octave,
-            q.direction.name,
-        )
-    },
-    restore = { list ->
-        if (list.isEmpty()) null
-        else IntervalTrainer.IntervalQuestion(
-            note1PitchClass = list[0] as Int,
-            note2PitchClass = list[1] as Int,
-            note1Name = list[2] as String,
-            note2Name = list[3] as String,
-            intervalSemitones = list[4] as Int,
-            correctAnswer = list[5] as String,
-            options = @Suppress("UNCHECKED_CAST") (list[6] as List<String>),
-            correctIndex = list[7] as Int,
-            note1Fret = list[8] as Int,
-            note2Fret = list[9] as Int,
-            note1Octave = list[10] as Int,
-            note2Octave = list[11] as Int,
-            direction = IntervalTrainer.IntervalDirection.valueOf(list[12] as String),
-        )
-    },
-)
+val IntervalQuestionSaver: Saver<IntervalTrainer.IntervalQuestion?, Any> =
+    listSaver(
+        save = { q ->
+            if (q == null) {
+                emptyList()
+            } else {
+                listOf(
+                    q.note1PitchClass,
+                    q.note2PitchClass,
+                    q.note1Name,
+                    q.note2Name,
+                    q.intervalSemitones,
+                    q.correctAnswer,
+                    ArrayList(q.options),
+                    q.correctIndex,
+                    q.note1Fret,
+                    q.note2Fret,
+                    q.note1Octave,
+                    q.note2Octave,
+                    q.direction.name,
+                )
+            }
+        },
+        restore = { list ->
+            if (list.isEmpty()) {
+                null
+            } else {
+                IntervalTrainer.IntervalQuestion(
+                    note1PitchClass = list[0] as Int,
+                    note2PitchClass = list[1] as Int,
+                    note1Name = list[2] as String,
+                    note2Name = list[3] as String,
+                    intervalSemitones = list[4] as Int,
+                    correctAnswer = list[5] as String,
+                    options = @Suppress("UNCHECKED_CAST") (list[6] as List<String>),
+                    correctIndex = list[7] as Int,
+                    note1Fret = list[8] as Int,
+                    note2Fret = list[9] as Int,
+                    note1Octave = list[10] as Int,
+                    note2Octave = list[11] as Int,
+                    direction = IntervalTrainer.IntervalDirection.valueOf(list[12] as String),
+                )
+            }
+        },
+    )
 
 /** Saver for a nullable [QuizGenerator.QuizQuestion]. */
-val QuizQuestionSaver: Saver<QuizGenerator.QuizQuestion?, Any> = listSaver(
-    save = { q ->
-        if (q == null) emptyList()
-        else listOf(
-            q.category.name,
-            q.question,
-            ArrayList(q.options),
-            q.correctIndex,
-            q.explanation,
-        )
-    },
-    restore = { list ->
-        if (list.isEmpty()) null
-        else QuizGenerator.QuizQuestion(
-            category = QuizGenerator.QuizCategory.valueOf(list[0] as String),
-            question = list[1] as String,
-            options = @Suppress("UNCHECKED_CAST") (list[2] as List<String>),
-            correctIndex = list[3] as Int,
-            explanation = list[4] as String,
-        )
-    },
-)
+val QuizQuestionSaver: Saver<QuizGenerator.QuizQuestion?, Any> =
+    listSaver(
+        save = { q ->
+            if (q == null) {
+                emptyList()
+            } else {
+                listOf(
+                    q.category.name,
+                    q.question,
+                    ArrayList(q.options),
+                    q.correctIndex,
+                    q.explanation,
+                )
+            }
+        },
+        restore = { list ->
+            if (list.isEmpty()) {
+                null
+            } else {
+                QuizGenerator.QuizQuestion(
+                    category = QuizGenerator.QuizCategory.valueOf(list[0] as String),
+                    question = list[1] as String,
+                    options = @Suppress("UNCHECKED_CAST") (list[2] as List<String>),
+                    correctIndex = list[3] as Int,
+                    explanation = list[4] as String,
+                )
+            }
+        },
+    )
 
 /** Saver for a nullable [ChordEarTrainer.ChordEarQuestion]. */
-val ChordEarQuestionSaver: Saver<ChordEarTrainer.ChordEarQuestion?, Any> = listSaver(
-    save = { q ->
-        if (q == null) emptyList()
-        else listOf(
-            q.rootPitchClass,
-            q.rootName,
-            q.quality,
-            q.symbol,
-            q.notes.joinToString("|") { "${it.first},${it.second}" },
-            q.correctAnswer,
-            ArrayList(q.options),
-            q.correctIndex,
-        )
-    },
-    restore = { list ->
-        if (list.isEmpty()) null
-        else ChordEarTrainer.ChordEarQuestion(
-            rootPitchClass = list[0] as Int,
-            rootName = list[1] as String,
-            quality = list[2] as String,
-            symbol = list[3] as String,
-            notes = (list[4] as String).split("|").map { s ->
-                val parts = s.split(",")
-                parts[0].toInt() to parts[1].toInt()
-            },
-            correctAnswer = list[5] as String,
-            options = @Suppress("UNCHECKED_CAST") (list[6] as List<String>),
-            correctIndex = list[7] as Int,
-        )
-    },
-)
+val ChordEarQuestionSaver: Saver<ChordEarTrainer.ChordEarQuestion?, Any> =
+    listSaver(
+        save = { q ->
+            if (q == null) {
+                emptyList()
+            } else {
+                listOf(
+                    q.rootPitchClass,
+                    q.rootName,
+                    q.quality,
+                    q.symbol,
+                    q.notes.joinToString("|") { "${it.first},${it.second}" },
+                    q.correctAnswer,
+                    ArrayList(q.options),
+                    q.correctIndex,
+                )
+            }
+        },
+        restore = { list ->
+            if (list.isEmpty()) {
+                null
+            } else {
+                ChordEarTrainer.ChordEarQuestion(
+                    rootPitchClass = list[0] as Int,
+                    rootName = list[1] as String,
+                    quality = list[2] as String,
+                    symbol = list[3] as String,
+                    notes =
+                        (list[4] as String).split("|").map { s ->
+                            val parts = s.split(",")
+                            parts[0].toInt() to parts[1].toInt()
+                        },
+                    correctAnswer = list[5] as String,
+                    options = @Suppress("UNCHECKED_CAST") (list[6] as List<String>),
+                    correctIndex = list[7] as Int,
+                )
+            }
+        },
+    )
 
 /** Saver for a nullable [Progression] using string-serialized degrees. */
-val ProgressionSaver: Saver<Progression?, Any> = listSaver(
-    save = { p ->
-        if (p == null) emptyList()
-        else listOf(
-            p.name,
-            p.description,
-            p.scaleType.name,
-            p.degrees.joinToString("|") { "${it.interval};${it.quality};${it.numeral}" },
-        )
-    },
-    restore = { list ->
-        if (list.isEmpty()) null
-        else {
-            val degreesStr = list[3]
-            Progression(
-                name = list[0],
-                description = list[1],
-                scaleType = ScaleType.valueOf(list[2]),
-                degrees = degreesStr.split("|").map { s ->
-                    val parts = s.split(";", limit = 3)
-                    ChordDegree(
-                        interval = parts[0].toInt(),
-                        quality = parts[1],
-                        numeral = parts[2],
-                    )
-                },
-            )
-        }
-    },
-)
+val ProgressionSaver: Saver<Progression?, Any> =
+    listSaver(
+        save = { p ->
+            if (p == null) {
+                emptyList()
+            } else {
+                listOf(
+                    p.name,
+                    p.description,
+                    p.scaleType.name,
+                    p.degrees.joinToString("|") { "${it.interval};${it.quality};${it.numeral}" },
+                )
+            }
+        },
+        restore = { list ->
+            if (list.isEmpty()) {
+                null
+            } else {
+                val degreesStr = list[3]
+                Progression(
+                    name = list[0],
+                    description = list[1],
+                    scaleType = ScaleType.valueOf(list[2]),
+                    degrees =
+                        degreesStr.split("|").map { s ->
+                            val parts = s.split(";", limit = 3)
+                            ChordDegree(
+                                interval = parts[0].toInt(),
+                                quality = parts[1],
+                                numeral = parts[2],
+                            )
+                        },
+                )
+            }
+        },
+    )

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt
@@ -53,6 +53,7 @@ import com.baijum.ukufretboard.R
 import com.baijum.ukufretboard.data.ChordParser
 import com.baijum.ukufretboard.data.ChordSheet
 import com.baijum.ukufretboard.ui.CapoStepper
+import com.baijum.ukufretboard.ui.StringListSaver
 
 /** Highest capo position offered by the editor stepper; matches the iOS 0...12 range. */
 private const val MAX_CAPO_FRET = 12
@@ -75,23 +76,28 @@ internal fun SheetEditor(
     ) -> Unit,
     onCancel: () -> Unit,
 ) {
-    var title by remember(sheet?.id) { mutableStateOf(sheet?.title ?: "") }
-    var artist by remember(sheet?.id) { mutableStateOf(sheet?.artist ?: "") }
-    var content by remember(sheet?.id) { mutableStateOf(sheet?.content ?: "") }
-    var key by remember(sheet?.id) { mutableStateOf(sheet?.key ?: "") }
-    var capo by remember(sheet?.id) { mutableIntStateOf(sheet?.capo ?: 0) }
-    var strumPatternName by remember(sheet?.id) { mutableStateOf(sheet?.strumPatternName ?: "") }
-    var labels by remember(sheet?.id) { mutableStateOf(sheet?.labels ?: emptyList()) }
+    var title by rememberSaveable(sheet?.id) { mutableStateOf(sheet?.title ?: "") }
+    var artist by rememberSaveable(sheet?.id) { mutableStateOf(sheet?.artist ?: "") }
+    var content by rememberSaveable(sheet?.id) { mutableStateOf(sheet?.content ?: "") }
+    var key by rememberSaveable(sheet?.id) { mutableStateOf(sheet?.key ?: "") }
+    var capo by rememberSaveable(sheet?.id) { mutableIntStateOf(sheet?.capo ?: 0) }
+    var strumPatternName by rememberSaveable(sheet?.id) { mutableStateOf(sheet?.strumPatternName ?: "") }
+    // List<String> is not auto-saveable; use the reusable StringListSaver so unsaved
+    // label edits survive activity recreation (rotation, font-size change, #573).
+    var labels by rememberSaveable(sheet?.id, stateSaver = StringListSaver) {
+        mutableStateOf(sheet?.labels ?: emptyList())
+    }
     var showPreview by rememberSaveable { mutableStateOf(false) }
     var showDiscardDialog by remember { mutableStateOf(false) }
 
-    val hasChanges = title != (sheet?.title ?: "") ||
-        artist != (sheet?.artist ?: "") ||
-        content != (sheet?.content ?: "") ||
-        key != (sheet?.key ?: "") ||
-        capo != (sheet?.capo ?: 0) ||
-        strumPatternName != (sheet?.strumPatternName ?: "") ||
-        labels != (sheet?.labels ?: emptyList<String>())
+    val hasChanges =
+        title != (sheet?.title ?: "") ||
+            artist != (sheet?.artist ?: "") ||
+            content != (sheet?.content ?: "") ||
+            key != (sheet?.key ?: "") ||
+            capo != (sheet?.capo ?: 0) ||
+            strumPatternName != (sheet?.strumPatternName ?: "") ||
+            labels != (sheet?.labels ?: emptyList<String>())
 
     val handleCancel = {
         if (hasChanges) {
@@ -112,9 +118,10 @@ internal fun SheetEditor(
     }
 
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
     ) {
         OutlinedTextField(
             value = title,
@@ -188,9 +195,10 @@ internal fun SheetEditor(
 
         // Chord insertion helper row
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState()),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             val commonChords = listOf("C", "G", "Am", "F", "Em", "Dm", "D", "A", "E", "Bm")
@@ -201,9 +209,10 @@ internal fun SheetEditor(
                     selected = false,
                     onClick = { content += "[$chord]" },
                     label = { Text(chord) },
-                    modifier = Modifier.clearAndSetSemantics {
-                        contentDescription = insertChordDesc
-                    },
+                    modifier =
+                        Modifier.clearAndSetSemantics {
+                            contentDescription = insertChordDesc
+                        },
                 )
             }
         }
@@ -233,10 +242,11 @@ internal fun SheetEditor(
         if (showPreview) {
             // Live preview of chords above lyrics
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState()),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState()),
             ) {
                 content.lines().forEach { line ->
                     val segments = ChordParser.parseLine(line)
@@ -257,6 +267,7 @@ internal fun SheetEditor(
                                 is ChordParser.TextSegment.PlainText -> {
                                     lyricLine.append(segment.text)
                                 }
+
                                 is ChordParser.TextSegment.Chord -> {
                                     hasChords = true
                                     chordPositions.add(lyricLine.length to segment.name)
@@ -265,39 +276,42 @@ internal fun SheetEditor(
                         }
 
                         if (hasChords) {
-                            val chordAnnotated = buildAnnotatedString {
-                                var cursor = 0
-                                chordPositions.forEach { (pos, name) ->
-                                    if (pos > cursor) {
-                                        append(" ".repeat(pos - cursor))
-                                        cursor = pos
+                            val chordAnnotated =
+                                buildAnnotatedString {
+                                    var cursor = 0
+                                    chordPositions.forEach { (pos, name) ->
+                                        if (pos > cursor) {
+                                            append(" ".repeat(pos - cursor))
+                                            cursor = pos
+                                        }
+                                        withStyle(
+                                            SpanStyle(
+                                                color = chordColor,
+                                                fontWeight = FontWeight.Bold,
+                                            ),
+                                        ) {
+                                            append(name)
+                                        }
+                                        cursor += name.length
                                     }
-                                    withStyle(
-                                        SpanStyle(
-                                            color = chordColor,
-                                            fontWeight = FontWeight.Bold,
-                                        )
-                                    ) {
-                                        append(name)
-                                    }
-                                    cursor += name.length
                                 }
-                            }
 
                             Text(
                                 text = chordAnnotated,
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    fontFamily = FontFamily.Monospace,
-                                ),
+                                style =
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        fontFamily = FontFamily.Monospace,
+                                    ),
                             )
                         }
 
                         Text(
                             text = lyricLine.toString(),
-                            style = MaterialTheme.typography.bodyMedium.copy(
-                                fontFamily = FontFamily.Monospace,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            ),
+                            style =
+                                MaterialTheme.typography.bodyMedium.copy(
+                                    fontFamily = FontFamily.Monospace,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                ),
                         )
                     }
                 }
@@ -307,9 +321,10 @@ internal fun SheetEditor(
                 value = content,
                 onValueChange = { content = it },
                 label = { Text(stringResource(R.string.songbook_field_lyrics)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
                 textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
             )
         }
@@ -391,21 +406,23 @@ private fun LabelEditorSection(
     var labelInput by remember { mutableStateOf("") }
     var showSuggestions by remember { mutableStateOf(false) }
 
-    val suggestions = remember(labelInput, allLabels, labels) {
-        if (labelInput.isBlank()) {
-            emptyList()
-        } else {
-            val query = labelInput.trim().lowercase()
-            (allLabels - labels.toSet())
-                .filter { it.lowercase().contains(query) }
-                .take(5)
+    val suggestions =
+        remember(labelInput, allLabels, labels) {
+            if (labelInput.isBlank()) {
+                emptyList()
+            } else {
+                val query = labelInput.trim().lowercase()
+                (allLabels - labels.toSet())
+                    .filter { it.lowercase().contains(query) }
+                    .take(5)
+            }
         }
-    }
 
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
     ) {
         Text(
             text = stringResource(R.string.songbook_labels),
@@ -436,10 +453,11 @@ private fun LabelEditorSection(
                             )
                         },
                         modifier = Modifier.height(28.dp),
-                        colors = InputChipDefaults.inputChipColors(
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                            labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                        ),
+                        colors =
+                            InputChipDefaults.inputChipColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                labelColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
                     )
                 }
             }

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1731,49 +1731,6 @@
         <error line="78" column="18" source="standard:if-else-wrapping" />
         <error line="78" column="18" source="standard:multiline-if-else" />
     </file>
-    <file name="app/src/main/java/com/baijum/ukufretboard/ui/StateSavers.kt">
-        <error line="13" column="66" source="standard:multiline-expression-wrapping" />
-        <error line="13" column="66" source="standard:function-signature" />
-        <error line="19" column="75" source="standard:multiline-expression-wrapping" />
-        <error line="19" column="75" source="standard:function-signature" />
-        <error line="25" column="76" source="standard:multiline-expression-wrapping" />
-        <error line="27" column="24" source="standard:if-else-wrapping" />
-        <error line="27" column="24" source="standard:multiline-if-else" />
-        <error line="28" column="14" source="standard:if-else-wrapping" />
-        <error line="28" column="14" source="standard:multiline-if-else" />
-        <error line="45" column="29" source="standard:if-else-wrapping" />
-        <error line="45" column="29" source="standard:multiline-if-else" />
-        <error line="46" column="14" source="standard:if-else-wrapping" />
-        <error line="46" column="14" source="standard:multiline-if-else" />
-        <error line="65" column="66" source="standard:multiline-expression-wrapping" />
-        <error line="67" column="24" source="standard:if-else-wrapping" />
-        <error line="67" column="24" source="standard:multiline-if-else" />
-        <error line="68" column="14" source="standard:if-else-wrapping" />
-        <error line="68" column="14" source="standard:multiline-if-else" />
-        <error line="77" column="29" source="standard:if-else-wrapping" />
-        <error line="77" column="29" source="standard:multiline-if-else" />
-        <error line="78" column="14" source="standard:if-else-wrapping" />
-        <error line="78" column="14" source="standard:multiline-if-else" />
-        <error line="89" column="76" source="standard:multiline-expression-wrapping" />
-        <error line="91" column="24" source="standard:if-else-wrapping" />
-        <error line="91" column="24" source="standard:multiline-if-else" />
-        <error line="92" column="14" source="standard:if-else-wrapping" />
-        <error line="92" column="14" source="standard:multiline-if-else" />
-        <error line="104" column="29" source="standard:if-else-wrapping" />
-        <error line="104" column="29" source="standard:multiline-if-else" />
-        <error line="105" column="14" source="standard:if-else-wrapping" />
-        <error line="105" column="14" source="standard:multiline-if-else" />
-        <error line="110" column="21" source="standard:multiline-expression-wrapping" />
-        <error line="122" column="50" source="standard:multiline-expression-wrapping" />
-        <error line="124" column="24" source="standard:if-else-wrapping" />
-        <error line="124" column="24" source="standard:multiline-if-else" />
-        <error line="125" column="14" source="standard:if-else-wrapping" />
-        <error line="125" column="14" source="standard:multiline-if-else" />
-        <error line="133" column="29" source="standard:if-else-bracing" />
-        <error line="133" column="29" source="standard:if-else-wrapping" />
-        <error line="133" column="29" source="standard:multiline-if-else" />
-        <error line="140" column="27" source="standard:multiline-expression-wrapping" />
-    </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/TapTempoButton.kt">
         <error line="66" column="27" source="standard:multiline-expression-wrapping" />
     </file>
@@ -2533,22 +2490,6 @@
         <error line="146" column="121" source="standard:argument-list-wrapping" />
         <error line="146" column="121" source="standard:max-line-length" />
         <error line="146" column="122" source="standard:argument-list-wrapping" />
-    </file>
-    <file name="app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetEditor.kt">
-        <error line="88" column="22" source="standard:multiline-expression-wrapping" />
-        <error line="115" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="191" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="204" column="32" source="standard:multiline-expression-wrapping" />
-        <error line="236" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="260" column="1" source="standard:blank-line-between-when-conditions" />
-        <error line="268" column="50" source="standard:multiline-expression-wrapping" />
-        <error line="279" column="42" source="standard:trailing-comma-on-call-site" />
-        <error line="289" column="41" source="standard:multiline-expression-wrapping" />
-        <error line="297" column="37" source="standard:multiline-expression-wrapping" />
-        <error line="310" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="394" column="23" source="standard:multiline-expression-wrapping" />
-        <error line="406" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="439" column="34" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt">
         <error line="3" column="1" source="standard:import-ordering" />


### PR DESCRIPTION
## Problem

Every field in `SheetEditor` was held in a plain `remember`, so an activity
recreation (rotation, system font/display size change, split-screen) restored
the last **saved** values and silently threw away the in-progress edit.
`hasChanges` then recomputed as `false`, so not even the discard-confirmation
dialog fired — there was no indication anything was lost.

Worst on the accessibility path this app cares about: changing the system
Display/Font size is a configuration change, so a low-vision user adjusting
text size mid-edit lost the whole song.

Fixes #573

## Changes

### Android (`ui/songbook/SheetEditor.kt`)
- All seven editor fields now use `rememberSaveable(sheet?.id)`; keying on
  `sheet?.id` still works since `rememberSaveable` accepts inputs the same way.
- `labels: List<String>` is not auto-saveable, so it uses a new reusable
  `StringListSaver` added to `ui/StateSavers.kt` (alongside the existing savers).

### Regression tests (`SheetEditorStateRestorationTest`)
- Simulates recreation the same way Compose does: the editor is disposed and
  re-provided under the same `SaveableStateHolder` key, so only
  `rememberSaveable` state survives — exactly what happens across a config change.
- Covers: typed title + lyrics surviving recreation, edited labels surviving,
  and editing a saved song without saving (the exact repro shape).

### ktlint baseline
The insertions shifted pre-existing baselined violations in both touched files,
which would have failed the ratchet by line mismatch. Per the 62bd0c8 precedent
("Format MelodyRepository instead of baselining it"), both files were formatted
with ktlint and their stale baseline blocks removed.

iOS is unaffected: SwiftUI `@State` survives rotation natively.

## Verification
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` ✅
- `./gradlew testDebugUnitTest` ✅
- `scripts/ktlint.sh --baseline=ktlint-baseline.xml` ✅
- Instrumented tests require a device/emulator:
  `./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.baijum.ukufretboard.SheetEditorStateRestorationTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor content—including titles, lyrics, labels, and song changes—is now preserved when the activity is recreated.
  * Added support for restoring newly added and edited labels.

* **Bug Fixes**
  * Prevented loss of in-progress sheet edits during configuration changes or activity recreation.

* **Style**
  * Improved formatting and code consistency in the sheet editor and state-saving components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->