### PR TITLE
Fix: iOS setlist delete/reorder targets the rendered row

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/SetlistViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/SetlistViewModel.swift
@@ -18,9 +18,20 @@ final class SetlistViewModel: ObservableObject {
     // touched from init and deinit, which never overlap.
     private nonisolated(unsafe) var songsDeletedObserver: NSObjectProtocol?
 
-    init(repository: SetlistRepository = SetlistRepository()) {
+    init(
+        repository: SetlistRepository = SetlistRepository(),
+        songbookRepository: SongbookRepository = SongbookRepository()
+    ) {
         self.repository = repository
         setlists = repository.getAll()
+        // One-time reconciliation at launch: strip any songIds entry that no
+        // longer resolves in the song library. A dead ID (a song deleted in an
+        // earlier version, or one a restored backup's import skipped) would
+        // otherwise persist forever and offset every future delete/reorder,
+        // since the rendered list — built with compactMap — is shorter than the
+        // raw songIds array (issue #602). Nothing else reconciles at launch: the
+        // #594 observer only fires on live deletions.
+        reconcileWithLibrary(validSongIds: Set(songbookRepository.getAll().map { $0.id }))
         // When a song is deleted from the Songbook, drop it from every setlist
         // right away so dead IDs cannot resurface in a later save (issue #594).
         songsDeletedObserver = NotificationCenter.default.addObserver(
@@ -81,14 +92,39 @@ final class SetlistViewModel: ObservableObject {
         repository.save(setlists)
     }
 
-    func moveSong(setlistId: String, from: Int, to: Int) {
+    /// Moves `songId` by `offset` positions within the persisted song order
+    /// (`offset` of -1 moves it up one, +1 down one).
+    ///
+    /// Keyed by song ID rather than by display index so it cannot be desynced
+    /// from the stored `songIds` array — e.g. when an unresolvable ID makes the
+    /// rendered list (built with `compactMap`) shorter than the raw array and
+    /// the visible offsets no longer match the persisted ones (issue #602).
+    func moveSong(setlistId: String, songId: String, offset: Int) {
+        guard offset != 0 else { return }
         guard let idx = setlists.firstIndex(where: { $0.id == setlistId }) else { return }
-        guard from >= 0, from < setlists[idx].songIds.count,
-              to >= 0, to < setlists[idx].songIds.count else { return }
-        let item = setlists[idx].songIds.remove(at: from)
-        setlists[idx].songIds.insert(item, at: to)
+        guard let currentIndex = setlists[idx].songIds.firstIndex(of: songId) else { return }
+        let targetIndex = currentIndex + offset
+        guard targetIndex >= 0, targetIndex < setlists[idx].songIds.count else { return }
+        let item = setlists[idx].songIds.remove(at: currentIndex)
+        setlists[idx].songIds.insert(item, at: targetIndex)
         setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
         repository.save(setlists)
+    }
+
+    /// Drops every `songIds` entry not present in `validSongIds`. Persisted and
+    /// in-memory setlists are updated in place; only setlists that actually held
+    /// a dead ID are rewritten, so clean setlists keep their `updatedAt`.
+    private func reconcileWithLibrary(validSongIds: Set<String>) {
+        var changed = false
+        for idx in setlists.indices
+        where setlists[idx].songIds.contains(where: { !validSongIds.contains($0) }) {
+            setlists[idx].songIds.removeAll { !validSongIds.contains($0) }
+            setlists[idx].updatedAt = Date().timeIntervalSince1970 * 1000
+            changed = true
+        }
+        if changed {
+            repository.save(setlists)
+        }
     }
 
     /// Strips deleted library songs out of every setlist — persisted and in

--- a/iosApp/UkuleleCompanion/Views/SetlistView.swift
+++ b/iosApp/UkuleleCompanion/Views/SetlistView.swift
@@ -114,13 +114,25 @@ struct SetlistDetailView: View {
                     .accessibilityLabel("\(index + 1). \(song.title.isEmpty ? "Untitled" : song.title)")
                 }
                 .onMove { source, destination in
-                    guard let from = source.first else { return }
+                    guard let from = source.first, from < setlistSongs.count else { return }
                     let to = destination > from ? destination - 1 : destination
-                    viewModel.moveSong(setlistId: currentSetlist.id, from: from, to: to)
+                    // Resolve the song ID from the RENDERED row and move by
+                    // offset; the ViewModel re-keys to the persisted array so a
+                    // shorter rendered list (compactMap drops unresolved IDs)
+                    // can't offset the wrong song (issue #602).
+                    let songId = setlistSongs[from].id
+                    viewModel.moveSong(
+                        setlistId: currentSetlist.id,
+                        songId: songId,
+                        offset: to - from
+                    )
                 }
                 .onDelete { offsets in
-                    for index in offsets {
-                        let songId = currentSetlist.songIds[index]
+                    // Resolve from the RENDERED row, not currentSetlist.songIds[index]:
+                    // an unresolvable ID makes songIds longer than the rendered
+                    // list, so a raw-array index would delete the wrong song (#602).
+                    for index in offsets where index < setlistSongs.count {
+                        let songId = setlistSongs[index].id
                         viewModel.removeSong(setlistId: currentSetlist.id, songId: songId)
                     }
                 }

--- a/iosApp/UkuleleCompanionTests/SetlistViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/SetlistViewModelTests.swift
@@ -5,7 +5,37 @@ final class SetlistViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.removeObject(forKey: "setlists")
+        clearStores()
+    }
+
+    override func tearDown() {
+        clearStores()
+        super.tearDown()
+    }
+
+    private func clearStores() {
+        for key in ["setlists", "chord_sheets"] {
+            UserDefaults.standard.removeObject(forKey: key)
+            UserDefaults.standard.removeObject(forKey: "\(key)_backup")
+            UserDefaults.standard.removeObject(forKey: "\(key)_quarantine")
+        }
+    }
+
+    private func seedLibrary(ids: [String]) {
+        let songs = ids.map { id in
+            StoredSong(
+                id: id, title: id, artist: "", content: "", key: "C",
+                capo: 0, strumPatternName: "", labels: [], createdAt: 0, updatedAt: 0
+            )
+        }
+        SongbookRepository().save(songs)
+    }
+
+    private func seedSetlist(id: String, name: String, songIds: [String]) {
+        let setlist = StoredSetlist(
+            id: id, name: name, songIds: songIds, createdAt: 0, updatedAt: 0
+        )
+        SetlistRepository().save([setlist])
     }
 
     @MainActor
@@ -88,8 +118,79 @@ final class SetlistViewModelTests: XCTestCase {
         vm.addSong(setlistId: id, songId: "b")
         vm.addSong(setlistId: id, songId: "c")
 
-        vm.moveSong(setlistId: id, from: 2, to: 0)
+        // Keyed by song ID + offset, not a raw index: move "c" up two places.
+        vm.moveSong(setlistId: id, songId: "c", offset: -2)
         XCTAssertEqual(vm.setlists.first?.songIds, ["c", "a", "b"])
+    }
+
+    @MainActor
+    func testMoveSongWithUnknownIdIsNoOp() {
+        let vm = SetlistViewModel()
+        vm.create(name: "My Set")
+        guard let id = vm.setlists.first?.id else { return XCTFail("no setlist") }
+        vm.addSong(setlistId: id, songId: "a")
+        vm.addSong(setlistId: id, songId: "b")
+
+        vm.moveSong(setlistId: id, songId: "missing", offset: 1)
+        vm.moveSong(setlistId: id, songId: "a", offset: 0)
+        XCTAssertEqual(vm.setlists.first?.songIds, ["a", "b"])
+    }
+
+    // MARK: - Launch reconciliation (issue #602)
+
+    @MainActor
+    func testInitDropsSongIdsAbsentFromLibrary() {
+        // A setlist persisted with a leading ID (S1) that no longer resolves in
+        // the library — a legacy dead ID, or one a restored backup's import
+        // skipped. It should render two rows (S2, S3), so reconciliation must
+        // strip S1 rather than let it offset every edit.
+        seedLibrary(ids: ["S2", "S3"])
+        seedSetlist(id: "set-1", name: "Legacy", songIds: ["S1", "S2", "S3"])
+
+        let vm = SetlistViewModel()
+
+        XCTAssertEqual(vm.setlists.first?.songIds, ["S2", "S3"])
+    }
+
+    @MainActor
+    func testInitReconciliationPersistsAcrossReload() {
+        seedLibrary(ids: ["S2", "S3"])
+        seedSetlist(id: "set-1", name: "Legacy", songIds: ["S1", "S2", "S3"])
+
+        _ = SetlistViewModel() // reconciles and saves
+        let reloaded = SetlistViewModel()
+
+        XCTAssertEqual(reloaded.setlists.first?.songIds, ["S2", "S3"])
+    }
+
+    @MainActor
+    func testInitLeavesResolvableSetlistUntouched() {
+        seedLibrary(ids: ["S1", "S2", "S3"])
+        seedSetlist(id: "set-1", name: "Clean", songIds: ["S1", "S2", "S3"])
+
+        let vm = SetlistViewModel()
+
+        XCTAssertEqual(vm.setlists.first?.songIds, ["S1", "S2", "S3"])
+        // A setlist without dead IDs must not be rewritten (updatedAt preserved).
+        XCTAssertEqual(vm.setlists.first?.updatedAt, 0)
+    }
+
+    @MainActor
+    func testDeleteAfterReconciliationTargetsCorrectRenderedRow() {
+        // Pre-fix: songIds[0] = S1 (dead), so deleting rendered row 0 (S2) read
+        // S1 and left S2 in place. After reconciliation songIds == rendered
+        // order, so removing the rendered row's ID hits the right song.
+        seedLibrary(ids: ["S2", "S3"])
+        seedSetlist(id: "set-1", name: "Legacy", songIds: ["S1", "S2", "S3"])
+
+        let vm = SetlistViewModel()
+        guard let renderedFirst = vm.setlists.first?.songIds.first else {
+            return XCTFail("expected reconciled rows")
+        }
+        XCTAssertEqual(renderedFirst, "S2")
+
+        vm.removeSong(setlistId: "set-1", songId: renderedFirst)
+        XCTAssertEqual(vm.setlists.first?.songIds, ["S3"])
     }
 
     @MainActor

--- a/iosApp/UkuleleCompanionTests/SetlistViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/SetlistViewModelTests.swift
@@ -234,6 +234,10 @@ final class SetlistViewModelTests: XCTestCase {
 
     @MainActor
     func testPurgeDeletedSongsPersistsTheCleanup() {
+        // Seed the library so the launch-time reconciliation (#602) keeps "b":
+        // setlist song IDs must resolve in the songbook, otherwise init strips
+        // them as dead IDs.
+        seedLibrary(ids: ["a", "b"])
         let vm = SetlistViewModel()
         vm.create(name: "Gig")
         let id = vm.setlists.first!.id


### PR DESCRIPTION
## Problem

The iOS setlist detail view fed display-row offsets into operations that indexed the **persisted** `songIds` array. `setlistSongs` is built with `compactMap { songMap[$0] }`, so any ID that no longer resolves in the library makes the rendered list **shorter** than `songIds`. Every offset then pointed at the wrong song:

- Swipe-delete row 0 read `songIds[0]` (a dead leading ID) and removed the wrong song — the control appeared to do nothing.
- Drag-reorder moved a different (or dead) song and saved that order.
- The `.onDelete` VoiceOver custom action hit the same wrong target, with no visual cue for a blind user.

The Android half of this was fixed in #572/#594 (ad96bd5); that commit explicitly ruled iOS out because its library is unfiltered — which covers the **filter** cause but not the **unresolvable-ID** cause. `purgeDeletedSongs` (#594) only runs from the live-deletion observer, so dead IDs accumulated before that release (or introduced by a restored backup whose song import skipped songs) persisted forever.

## Fix (mirrors the Android approach)

- `moveSong` is now `moveSong(setlistId:songId:offset:)`, resolving `songIds.firstIndex(of:)` internally instead of taking a raw index.
- `.onMove`/`.onDelete` resolve the song ID from the **rendered** row (`setlistSongs[index].id`), not `currentSetlist.songIds[index]`.
- `SetlistViewModel.init` runs a one-time reconciliation that drops any `songIds` entry absent from the song library, clearing legacy dead IDs instead of letting them offset every future edit. Clean setlists are not rewritten (`updatedAt` preserved).

VoiceOver Delete/Move custom actions are preserved.

## Tests

Added `SetlistViewModelTests` cases: init drops unresolvable IDs and persists across reload, a clean setlist is left untouched, delete after reconciliation targets the correct rendered row, and `moveSong` is keyed by ID/offset (unknown ID is a no-op). Updated the existing `testMoveSong` for the new signature.

## Verification

Fully offline. Code self-reviewed against the Android reference the issue quotes; a full `xcodebuild` (which rebuilds the KMP framework) was not run in this environment — **simulator/build verification pending**.

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)