### PR TITLE
Fix: iOS restore writes to the shared ViewModels

### DIFF
--- a/iosApp/UkuleleCompanion/ContentView.swift
+++ b/iosApp/UkuleleCompanion/ContentView.swift
@@ -25,6 +25,13 @@ struct ContentView: View {
     @StateObject private var customPatternsVM = CustomPatternsViewModel()
     @StateObject private var setlistVM = SetlistViewModel()
     @StateObject private var metronomeVM = MetronomeViewModel()
+    @StateObject private var melodyVM = MelodyViewModel()
+    @StateObject private var progressionsVM = ProgressionsViewModel()
+    // Owned by UkuleleCompanionApp and injected at the app root; forwarded here
+    // so it also reaches the Settings sheet, the same way the shared instances
+    // above do. Declared as @EnvironmentObject (not @StateObject) to avoid
+    // creating a second, divergent copy.
+    @EnvironmentObject private var practiceTimerVM: PracticeTimerViewModel
 
     init() {
         let completed = UserDefaults(suiteName: "app_settings")?.bool(forKey: "onboarding_completed") ?? false
@@ -119,6 +126,9 @@ struct ContentView: View {
         .environmentObject(customPatternsVM)
         .environmentObject(setlistVM)
         .environmentObject(metronomeVM)
+        .environmentObject(melodyVM)
+        .environmentObject(progressionsVM)
+        .environmentObject(practiceTimerVM)
         .tint(isHighContrast ? .yellow : nil)
         .sheet(isPresented: $showSettings) { SettingsView() }
         .onChange(of: showSettings) { isShowing in
@@ -145,6 +155,9 @@ struct ContentView: View {
         .environmentObject(customPatternsVM)
         .environmentObject(setlistVM)
         .environmentObject(metronomeVM)
+        .environmentObject(melodyVM)
+        .environmentObject(progressionsVM)
+        .environmentObject(practiceTimerVM)
         .tint(isHighContrast ? .yellow : nil)
         .sheet(isPresented: $showSettings) { SettingsView() }
         .onChange(of: showSettings) { isShowing in
@@ -283,5 +296,8 @@ struct ContentView: View {
 }
 
 struct ContentView_Previews: PreviewProvider {
-    static var previews: some View { ContentView() }
+    static var previews: some View {
+        ContentView()
+            .environmentObject(PracticeTimerViewModel())
+    }
 }

--- a/iosApp/UkuleleCompanion/Views/SettingsView.swift
+++ b/iosApp/UkuleleCompanion/Views/SettingsView.swift
@@ -6,12 +6,12 @@ struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
     @EnvironmentObject private var favoritesVM: FavoritesViewModel
     @EnvironmentObject var songbookVM: SongbookViewModel
-    @StateObject private var melodyVM = MelodyViewModel()
-    @StateObject private var progressionsVM = ProgressionsViewModel()
-    @StateObject private var learnVM = LearnViewModel()
-    @StateObject private var practiceTimerVM = PracticeTimerViewModel()
+    @EnvironmentObject var melodyVM: MelodyViewModel
+    @EnvironmentObject var progressionsVM: ProgressionsViewModel
+    @EnvironmentObject var learnVM: LearnViewModel
+    @EnvironmentObject var practiceTimerVM: PracticeTimerViewModel
     @EnvironmentObject var customPatternsVM: CustomPatternsViewModel
-    @StateObject private var setlistVM = SetlistViewModel()
+    @EnvironmentObject var setlistVM: SetlistViewModel
     @State private var backupManager: BackupRestoreManager?
     @State private var backupDocument: BackupDocument?
     @State private var showExporter = false


### PR DESCRIPTION
## Summary

`SettingsView` built its own private `@StateObject` copies of five list ViewModels (melody, progressions, learn, practiceTimer, setlist) while three others correctly came from `@EnvironmentObject`. The restore path (`BackupRestoreManager`) merged and saved into those private copies, but the real, long-lived instances the app actually displays stayed stale. Because every mutator writes the **whole** in-memory array back over the stored blob, the next edit on the real instance overwrote the restored records — permanent P0 data loss (restored setlists/melodies silently destroyed).

## Fix

- **SettingsView**: the five VMs are now `@EnvironmentObject`, exactly as `favoritesVM` / `songbookVM` / `customPatternsVM` already were. The `BackupRestoreManager` wiring is unchanged — it now receives the shared instances.
- **ContentView**: added `melodyVM` and `progressionsVM` as owned `@StateObject`s (they previously had no shared owner) and injected them into both the tab and sidebar layouts. `practiceTimerVM` is owned by `UkuleleCompanionApp` (app root); ContentView now takes it via `@EnvironmentObject` and re-forwards it into both layouts so it reliably reaches the Settings sheet — without creating a second, divergent copy. `learnVM` and `setlistVM` were already injected.
- Fixed the `ContentView_Previews` to inject a `PracticeTimerViewModel` (now required in the environment).

All eight environment objects SettingsView reads are injected on an ancestor in both the tab and sidebar chains. No new `@EnvironmentObject` is left without a matching `.environmentObject(...)`.

## Scope note

Followed the "belt-and-braces `reload()`" suggestion only as far as it stays within these two files. Adding `reload()` would require editing five ViewModel files plus `BackupRestoreManager` — files other agents may be touching — so it was skipped per the task's scope guard. The environment fix alone stops the data loss; for setlist/learn the on-screen view (bound to the shared instance) also refreshes live after restore.

## Verification

- Self-reviewed: no `@StateObject private var … = SomeViewModel()` remains for the five in SettingsView; every introduced `@EnvironmentObject` has a matching injection.
- Full `xcodebuild` not run (heavy with multiple agents active) — **simulator verification pending**.

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)