### PR TITLE
Fix: Android practice clock measures foreground time

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/data/PracticeTimerRepository.kt
@@ -27,7 +27,12 @@ class PracticeTimerRepository(context: Context) {
      * @param durationMs Duration in milliseconds.
      */
     fun recordSession(durationMs: Long) {
-        val minutes = (durationMs / 60_000).toInt().coerceAtLeast(1)
+        // Sanity ceiling: even with the lifecycle-bounded clock (#601), never
+        // let a single span exceed a plausible practice session. This stops an
+        // already-corrupt duration from permanently pinning longest_session (and
+        // inflating the cumulative totals), since those figures cannot be
+        // lowered afterwards through max-merge backup import.
+        val minutes = (durationMs / 60_000).toInt().coerceIn(1, MAX_SESSION_MINUTES)
         val today = todayKey()
 
         prefs.edit().apply {
@@ -149,6 +154,15 @@ class PracticeTimerRepository(context: Context) {
         private const val KEY_LAST_SESSION = "last_session"
         private const val KEY_DAILY_GOAL = "daily_goal"
         private const val DEFAULT_DAILY_GOAL = 15
+
+        /**
+         * Upper bound (minutes) for a single recorded session. A genuine
+         * foreground practice stretch never approaches this; it exists only to
+         * cap an already-corrupt span (e.g. a stale clock) before it lands in
+         * the cumulative totals or longest_session, which cannot be lowered
+         * later. 12 hours is well beyond any real session.
+         */
+        private const val MAX_SESSION_MINUTES = 12 * 60
     }
 }
 

--- a/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/navigation/FretboardScreen.kt
@@ -198,15 +198,40 @@ fun FretboardScreen(
     }
 
     val practiceTimerRepository = remember { PracticeTimerRepository(context) }
-    val sessionStartMs = remember { System.currentTimeMillis() }
     var practiceStats by remember { mutableStateOf(practiceTimerRepository.stats()) }
 
-    androidx.compose.runtime.DisposableEffect(Unit) {
-        onDispose {
-            val durationMs = System.currentTimeMillis() - sessionStartMs
-            if (durationMs >= 60_000L) {
-                practiceTimerRepository.recordSession(durationMs)
+    // Drive the practice-session clock from the process lifecycle, not from the
+    // composition. A composition created by `setContent` is disposed only on
+    // Activity *destroy* — which any configuration change (a mere screen
+    // rotation) triggers — not on stop/pause, so timing the composition banks
+    // every backgrounded minute, even a full day, as practice time (#601).
+    // Instead start the clock when the app enters the foreground (ON_START) and
+    // record the elapsed span when it leaves (ON_STOP), mirroring the iOS
+    // scenePhase handling: a span only counts if it lasted at least 60s.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        var sessionStartMs = System.currentTimeMillis()
+        val observer =
+            androidx.lifecycle.LifecycleEventObserver { _, event ->
+                when (event) {
+                    androidx.lifecycle.Lifecycle.Event.ON_START -> {
+                        sessionStartMs = System.currentTimeMillis()
+                    }
+
+                    androidx.lifecycle.Lifecycle.Event.ON_STOP -> {
+                        val durationMs = System.currentTimeMillis() - sessionStartMs
+                        if (durationMs >= 60_000L) {
+                            practiceTimerRepository.recordSession(durationMs)
+                            practiceStats = practiceTimerRepository.stats()
+                        }
+                    }
+
+                    else -> {}
+                }
             }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/app/src/test/java/com/baijum/ukufretboard/data/PracticeTimerRepositoryTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/data/PracticeTimerRepositoryTest.kt
@@ -1,0 +1,61 @@
+package com.baijum.ukufretboard.data
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PracticeTimerRepositoryTest {
+    private lateinit var repo: PracticeTimerRepository
+
+    @Before
+    fun setUp() {
+        val context: Application = ApplicationProvider.getApplicationContext()
+        repo = PracticeTimerRepository(context)
+    }
+
+    @Test
+    fun recordSessionConvertsMillisToMinutes() {
+        repo.recordSession(25 * 60_000L)
+        assertEquals(25, repo.totalMinutes())
+        assertEquals(25, repo.todayMinutes())
+        assertEquals(25, repo.longestSession())
+        assertEquals(1, repo.totalSessions())
+    }
+
+    @Test
+    fun recordSessionFloorsToAtLeastOneMinute() {
+        // A span between 60s and 120s rounds down to 1 minute of integer
+        // division; it must still count as a minute, never zero.
+        repo.recordSession(90_000L)
+        assertEquals(1, repo.totalMinutes())
+        assertEquals(1, repo.longestSession())
+    }
+
+    @Test
+    fun recordSessionCapsAnAbsurdSpanAtTheCeiling() {
+        // The pre-fix defect banked ~24h (a rotation/background span). The
+        // sanity ceiling must clamp it so it cannot pin longest_session (#601).
+        val twentyFourHoursMs = 24 * 60 * 60_000L
+        repo.recordSession(twentyFourHoursMs)
+        val ceilingMinutes = 12 * 60
+        assertEquals(ceilingMinutes, repo.totalMinutes())
+        assertEquals(ceilingMinutes, repo.todayMinutes())
+        assertEquals(ceilingMinutes, repo.longestSession())
+    }
+
+    @Test
+    fun recordSessionAccumulatesAcrossSessions() {
+        repo.recordSession(10 * 60_000L)
+        repo.recordSession(5 * 60_000L)
+        assertEquals(15, repo.totalMinutes())
+        assertEquals(15, repo.todayMinutes())
+        assertEquals(2, repo.totalSessions())
+        // Longest tracks the single largest session, not the sum.
+        assertEquals(10, repo.longestSession())
+    }
+}

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -239,8 +239,8 @@
         <error line="19" column="31" source="standard:class-signature" />
         <error line="19" column="47" source="standard:class-signature" />
         <error line="20" column="1" source="standard:no-empty-first-line-in-class-body" />
-        <error line="86" column="34" source="standard:multiline-expression-wrapping" />
-        <error line="86" column="34" source="standard:function-signature" />
+        <error line="91" column="34" source="standard:multiline-expression-wrapping" />
+        <error line="91" column="34" source="standard:function-signature" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/data/ReviewPromptRepository.kt">
         <error line="18" column="30" source="standard:class-signature" />


### PR DESCRIPTION
## Problem

The Android practice-session clock was tied to the Compose composition. A composition created by `setContent` is disposed only on Activity **destroy** — which any configuration change (a mere screen rotation) triggers — not on stop/pause. The old `DisposableEffect(Unit) { onDispose { recordSession } }` therefore banked every backgrounded minute, up to a full day (~1440m), as practice time. Because the cumulative totals and `longest_session` are max-merged and have no reachable reset, the inflated figure was permanent, and Android/iOS reported materially different totals for identical use.

## Fix

- **Lifecycle-driven clock** (`FretboardScreen.kt`): a `LifecycleEventObserver` starts the clock on `ON_START` and records the elapsed foreground span on `ON_STOP` (only if >= 60s), mirroring the iOS `scenePhase` handling. Stats are refreshed after banking so Learning Progress reflects the new session. Uses the same fully-qualified lifecycle pattern already used in `PitchMonitorTab`/`TunerTab`.
- **Sanity ceiling** (`PracticeTimerRepository.recordSession`): caps any single span at 12h (`MAX_SESSION_MINUTES`) so an already-corrupt duration cannot permanently pin `longest_session` or inflate the max-merged totals.

## Tests

Adds `PracticeTimerRepositoryTest` (Robolectric) covering ms→minutes conversion, the >=60s floor, cumulative accumulation, and the 24h→12h ceiling clamp.

## Verified

- `./gradlew :app:compileDebugKotlin` — success
- `./gradlew testDebugUnitTest --tests PracticeTimerRepositoryTest` — pass
- `scripts/ktlint.sh` — no new violations (baseline line-shift for the pre-existing `stats()` entry updated)

Not run (per lightweight scope): `assembleDebug`, instrumented tests. The lifecycle wiring itself is not unit-testable and was verified by review against the established pattern.

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)