### PR TITLE
Fix: Fretboard Note Map grid scroll sync and TalkBack labels

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/FretboardNoteMapView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/FretboardNoteMapView.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -62,20 +65,22 @@ fun FretboardNoteMapView(
 ) {
     val canToggleHighLow = tuning == UkuleleTuning.HIGH_G || tuning == UkuleleTuning.LOW_G
     var isLowG by remember(tuning) { mutableStateOf(tuning == UkuleleTuning.LOW_G) }
-    val effectiveTuning = if (canToggleHighLow) {
-        if (isLowG) UkuleleTuning.LOW_G else UkuleleTuning.HIGH_G
-    } else {
-        tuning
-    }
+    val effectiveTuning =
+        if (canToggleHighLow) {
+            if (isLowG) UkuleleTuning.LOW_G else UkuleleTuning.HIGH_G
+        } else {
+            tuning
+        }
     var highlightNote by remember { mutableIntStateOf(-1) } // -1 = none
     val scope = rememberCoroutineScope()
     val maxFret = lastFret
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Text(
             text = stringResource(R.string.note_map_title),
@@ -99,19 +104,21 @@ fun FretboardNoteMapView(
                     selected = !isLowG,
                     onClick = { isLowG = false },
                     label = { Text(stringResource(R.string.note_map_high_g)) },
-                    colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = MaterialTheme.colorScheme.primary,
-                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+                    colors =
+                        FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
                 )
                 FilterChip(
                     selected = isLowG,
                     onClick = { isLowG = true },
                     label = { Text(stringResource(R.string.note_map_low_g)) },
-                    colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = MaterialTheme.colorScheme.primary,
-                        selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
-                    ),
+                    colors =
+                        FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
@@ -132,30 +139,33 @@ fun FretboardNoteMapView(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(vertical = 4.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(vertical = 4.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             FilterChip(
                 selected = highlightNote == -1,
                 onClick = { highlightNote = -1 },
                 label = { Text(stringResource(R.string.label_all), style = MaterialTheme.typography.labelSmall) },
-                colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = MaterialTheme.colorScheme.secondary,
-                    selectedLabelColor = MaterialTheme.colorScheme.onSecondary,
-                ),
+                colors =
+                    FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.secondary,
+                        selectedLabelColor = MaterialTheme.colorScheme.onSecondary,
+                    ),
             )
             (0..11).forEach { pc ->
                 FilterChip(
                     selected = highlightNote == pc,
                     onClick = { highlightNote = pc },
                     label = { Text(Notes.pitchClassToName(pc), style = MaterialTheme.typography.labelSmall) },
-                    colors = FilterChipDefaults.filterChipColors(
-                        selectedContainerColor = MaterialTheme.colorScheme.secondary,
-                        selectedLabelColor = MaterialTheme.colorScheme.onSecondary,
-                    ),
+                    colors =
+                        FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.secondary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onSecondary,
+                        ),
                 )
             }
         }
@@ -173,11 +183,16 @@ fun FretboardNoteMapView(
                 val octaves = effectiveTuning.octaves
                 val stringNames = effectiveTuning.stringNames
 
+                // Single shared scroll state so the header and all string rows
+                // move together and stay column-aligned (#584).
+                val gridScroll = rememberScrollState()
+
                 // Header row: fret numbers
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(gridScroll),
                 ) {
                     // String label column
                     Box(modifier = Modifier.size(36.dp))
@@ -201,9 +216,10 @@ fun FretboardNoteMapView(
                     val openPc = tuningPitchClasses[stringIndex]
                     val baseOctave = octaves[stringIndex]
                     Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .horizontalScroll(rememberScrollState()),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(gridScroll),
                     ) {
                         // String name
                         Box(
@@ -224,32 +240,57 @@ fun FretboardNoteMapView(
                             val noteName = Notes.pitchClassToName(pitchClass)
                             val isHighlighted = highlightNote == -1 || highlightNote == pitchClass
                             val isOpen = fret == 0
-                            val bgColor = when {
-                                !isHighlighted -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                                isOpen -> MaterialTheme.colorScheme.primaryContainer
-                                else -> MaterialTheme.colorScheme.surface
-                            }
-                            val textColor = when {
-                                !isHighlighted -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-                                isOpen -> MaterialTheme.colorScheme.onPrimaryContainer
-                                else -> MaterialTheme.colorScheme.onSurface
-                            }
+                            val bgColor =
+                                when {
+                                    !isHighlighted -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+                                    isOpen -> MaterialTheme.colorScheme.primaryContainer
+                                    else -> MaterialTheme.colorScheme.surface
+                                }
+                            val textColor =
+                                when {
+                                    !isHighlighted -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+                                    isOpen -> MaterialTheme.colorScheme.onPrimaryContainer
+                                    else -> MaterialTheme.colorScheme.onSurface
+                                }
+                            // Full cell semantics for TalkBack: note + string + fret,
+                            // plus highlighted/dimmed state (#585). The description on the
+                            // clickable container intentionally replaces the child Text.
+                            val cellDescription =
+                                stringResource(
+                                    R.string.note_map_cell_description,
+                                    noteName,
+                                    stringNames[stringIndex],
+                                    fret,
+                                )
+                            val cellState =
+                                if (isHighlighted) {
+                                    stringResource(R.string.note_map_cell_highlighted)
+                                } else {
+                                    stringResource(R.string.note_map_cell_dimmed)
+                                }
+                            val playLabel = stringResource(R.string.cd_play_sound)
 
                             Box(
-                                modifier = Modifier
-                                    .size(36.dp)
-                                    .clip(RoundedCornerShape(4.dp))
-                                    .background(bgColor)
-                                    .border(
-                                        width = if (isOpen) 1.5.dp else 0.5.dp,
-                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                        shape = RoundedCornerShape(4.dp),
-                                    )
-                                    .clickable(enabled = isHighlighted) {
-                                        scope.launch {
-                                            ToneGenerator.playNote(pitchClass, octave)
-                                        }
-                                    },
+                                modifier =
+                                    Modifier
+                                        .size(36.dp)
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(bgColor)
+                                        .border(
+                                            width = if (isOpen) 1.5.dp else 0.5.dp,
+                                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                            shape = RoundedCornerShape(4.dp),
+                                        ).clickable(
+                                            enabled = isHighlighted,
+                                            onClickLabel = playLabel,
+                                        ) {
+                                            scope.launch {
+                                                ToneGenerator.playNote(pitchClass, octave)
+                                            }
+                                        }.semantics {
+                                            contentDescription = cellDescription
+                                            stateDescription = cellState
+                                        },
                                 contentAlignment = Alignment.Center,
                             ) {
                                 Text(
@@ -283,10 +324,11 @@ fun FretboardNoteMapView(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "\u2022 ${stringResource(R.string.note_map_tip_1)}\n" +
-                        "\u2022 ${stringResource(R.string.note_map_tip_2)}\n" +
-                        "\u2022 ${stringResource(R.string.note_map_tip_3)}\n" +
-                        "\u2022 ${stringResource(R.string.note_map_tip_4)}",
+                    text =
+                        "\u2022 ${stringResource(R.string.note_map_tip_1)}\n" +
+                            "\u2022 ${stringResource(R.string.note_map_tip_2)}\n" +
+                            "\u2022 ${stringResource(R.string.note_map_tip_3)}\n" +
+                            "\u2022 ${stringResource(R.string.note_map_tip_4)}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                 )

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1207,4 +1207,7 @@
     <string name="cd_setlist_move_up">تحريك لأعلى</string>
     <string name="cd_setlist_move_down">تحريك لأسفل</string>
     <string name="cd_setlist_remove_song">إزالة من القائمة</string>
+    <string name="note_map_cell_description">%1$s، الوتر %2$s، الدستان %3$d</string>
+    <string name="note_map_cell_highlighted">مُميَّز</string>
+    <string name="note_map_cell_dimmed">خافت</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -1197,4 +1197,7 @@
     <string name="cd_setlist_move_up">上移</string>
     <string name="cd_setlist_move_down">下移</string>
     <string name="cd_setlist_remove_song">从歌单中移除</string>
+    <string name="note_map_cell_description">%1$s，第 %2$s 弦，第 %3$d 品</string>
+    <string name="note_map_cell_highlighted">已高亮</string>
+    <string name="note_map_cell_dimmed">已变暗</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1201,4 +1201,7 @@
     <string name="cd_setlist_move_up">Nach oben verschieben</string>
     <string name="cd_setlist_move_down">Nach unten verschieben</string>
     <string name="cd_setlist_remove_song">Aus Setlist entfernen</string>
+    <string name="note_map_cell_description">%1$s, Saite %2$s, Bund %3$d</string>
+    <string name="note_map_cell_highlighted">hervorgehoben</string>
+    <string name="note_map_cell_dimmed">abgeblendet</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1214,4 +1214,7 @@
     <string name="cd_setlist_move_up">Mover arriba</string>
     <string name="cd_setlist_move_down">Mover abajo</string>
     <string name="cd_setlist_remove_song">Eliminar de la lista</string>
+    <string name="note_map_cell_description">%1$s, cuerda %2$s, traste %3$d</string>
+    <string name="note_map_cell_highlighted">resaltado</string>
+    <string name="note_map_cell_dimmed">atenuado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1198,4 +1198,7 @@
     <string name="cd_setlist_move_up">Déplacer vers le haut</string>
     <string name="cd_setlist_move_down">Déplacer vers le bas</string>
     <string name="cd_setlist_remove_song">Retirer de la setlist</string>
+    <string name="note_map_cell_description">%1$s, corde %2$s, frette %3$d</string>
+    <string name="note_map_cell_highlighted">en surbrillance</string>
+    <string name="note_map_cell_dimmed">estompé</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1203,4 +1203,7 @@
     <string name="cd_setlist_move_up">ऊपर ले जाएं</string>
     <string name="cd_setlist_move_down">नीचे ले जाएं</string>
     <string name="cd_setlist_remove_song">सेटलिस्ट से हटाएं</string>
+    <string name="note_map_cell_description">%1$s, तार %2$s, फ्रेट %3$d</string>
+    <string name="note_map_cell_highlighted">हाइलाइट किया गया</string>
+    <string name="note_map_cell_dimmed">मंद</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1200,4 +1200,7 @@
     <string name="cd_setlist_move_up">Pindah ke atas</string>
     <string name="cd_setlist_move_down">Pindah ke bawah</string>
     <string name="cd_setlist_remove_song">Hapus dari daftar</string>
+    <string name="note_map_cell_description">%1$s, senar %2$s, fret %3$d</string>
+    <string name="note_map_cell_highlighted">disorot</string>
+    <string name="note_map_cell_dimmed">redup</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1202,4 +1202,7 @@
     <string name="cd_setlist_move_up">Sposta su</string>
     <string name="cd_setlist_move_down">Sposta giù</string>
     <string name="cd_setlist_remove_song">Rimuovi dalla scaletta</string>
+    <string name="note_map_cell_description">%1$s, corda %2$s, tasto %3$d</string>
+    <string name="note_map_cell_highlighted">evidenziato</string>
+    <string name="note_map_cell_dimmed">attenuato</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1202,4 +1202,7 @@
     <string name="cd_setlist_move_up">上に移動</string>
     <string name="cd_setlist_move_down">下に移動</string>
     <string name="cd_setlist_remove_song">セットリストから削除</string>
+    <string name="note_map_cell_description">%1$s、%2$s弦、%3$dフレット</string>
+    <string name="note_map_cell_highlighted">ハイライト</string>
+    <string name="note_map_cell_dimmed">淡色表示</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1202,4 +1202,7 @@
     <string name="cd_setlist_move_up">위로 이동</string>
     <string name="cd_setlist_move_down">아래로 이동</string>
     <string name="cd_setlist_remove_song">세트리스트에서 제거</string>
+    <string name="note_map_cell_description">%1$s, %2$s 줄, %3$d 프렛</string>
+    <string name="note_map_cell_highlighted">강조됨</string>
+    <string name="note_map_cell_dimmed">흐리게 표시됨</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1201,4 +1201,7 @@
     <string name="cd_setlist_move_up">Omhoog verplaatsen</string>
     <string name="cd_setlist_move_down">Omlaag verplaatsen</string>
     <string name="cd_setlist_remove_song">Verwijderen uit setlist</string>
+    <string name="note_map_cell_description">%1$s, snaar %2$s, fret %3$d</string>
+    <string name="note_map_cell_highlighted">gemarkeerd</string>
+    <string name="note_map_cell_dimmed">gedimd</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1203,4 +1203,7 @@
     <string name="cd_setlist_move_up">Przenieś w górę</string>
     <string name="cd_setlist_move_down">Przenieś w dół</string>
     <string name="cd_setlist_remove_song">Usuń z listy</string>
+    <string name="note_map_cell_description">%1$s, struna %2$s, próg %3$d</string>
+    <string name="note_map_cell_highlighted">wyróżnione</string>
+    <string name="note_map_cell_dimmed">przyciemnione</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1200,4 +1200,7 @@
     <string name="cd_setlist_move_up">Mover para cima</string>
     <string name="cd_setlist_move_down">Mover para baixo</string>
     <string name="cd_setlist_remove_song">Remover da lista</string>
+    <string name="note_map_cell_description">%1$s, corda %2$s, traste %3$d</string>
+    <string name="note_map_cell_highlighted">destacado</string>
+    <string name="note_map_cell_dimmed">esmaecido</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1205,4 +1205,7 @@
     <string name="cd_setlist_move_up">Переместить вверх</string>
     <string name="cd_setlist_move_down">Переместить вниз</string>
     <string name="cd_setlist_remove_song">Убрать из сет-листа</string>
+    <string name="note_map_cell_description">%1$s, струна %2$s, лад %3$d</string>
+    <string name="note_map_cell_highlighted">выделено</string>
+    <string name="note_map_cell_dimmed">затемнено</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1201,4 +1201,7 @@
     <string name="cd_setlist_move_up">Yukarı taşı</string>
     <string name="cd_setlist_move_down">Aşağı taşı</string>
     <string name="cd_setlist_remove_song">Set listesinden kaldır</string>
+    <string name="note_map_cell_description">%1$s, tel %2$s, perde %3$d</string>
+    <string name="note_map_cell_highlighted">vurgulanmış</string>
+    <string name="note_map_cell_dimmed">soluk</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -850,6 +850,10 @@
     <string name="note_map_tip_3">Fret 12 is the same notes as fret 0 (one octave higher)</string>
     <string name="note_map_tip_4">Switch to Low-G to see how the G string changes</string>
     <string name="note_map_string">String %d</string>
+    <!-- Note map cell accessibility: %1$s note name, %2$s string name, %3$d fret number -->
+    <string name="note_map_cell_description">%1$s, string %2$s, fret %3$d</string>
+    <string name="note_map_cell_highlighted">highlighted</string>
+    <string name="note_map_cell_dimmed">dimmed</string>
 
     <!-- ── Fretboard View ───────────────────────────────────────────── -->
     <string name="fretboard_string">string, </string>

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -61082,6 +61082,306 @@
         }
       }
     },
+    "note_map_cell_description": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, string %2$@, fret %3$lld"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, corde %2$@, frette %3$lld"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, Saite %2$@, Bund %3$lld"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, cuerda %2$@, traste %3$lld"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, corda %2$@, tasto %3$lld"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, corda %2$@, traste %3$lld"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, snaar %2$@, fret %3$lld"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, струна %2$@, лад %3$lld"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, tel %2$@, perde %3$lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, struna %2$@, próg %3$lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@、%2$@弦、%3$lldフレット"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, %2$@ 줄, %3$lld 프렛"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, तार %2$@, फ्रेट %3$lld"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@, senar %2$@, fret %3$lld"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@، الوتر %2$@، الدستان %3$lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@，第 %2$@ 弦，第 %3$lld 品"
+          }
+        }
+      }
+    },
+    "note_map_cell_dimmed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dimmed"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "estompé"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "abgeblendet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "atenuado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "attenuato"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "esmaecido"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gedimd"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "затемнено"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "soluk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "przyciemnione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "淡色表示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "흐리게 표시됨"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "मंद"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "redup"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خافت"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已变暗"
+          }
+        }
+      }
+    },
+    "note_map_cell_highlighted": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "highlighted"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "en surbrillance"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hervorgehoben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "resaltado"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "evidenziato"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "destacado"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gemarkeerd"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "выделено"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vurgulanmış"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "wyróżnione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハイライト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강조됨"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "हाइलाइट किया गया"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "disorot"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مُميَّز"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已高亮"
+          }
+        }
+      }
+    },
     "note_map_high_g": {
       "localizations": {
         "en": {


### PR DESCRIPTION
## Summary

Two fixes to the Fretboard Note Map (`FretboardNoteMapView.kt`), which both live in the same file.

### #584 — rows scrolled independently, desynchronising notes from the fret header
Each string row and the fret-number header created its own `rememberScrollState()`, so scrolling one row left the others (and the header) in place — every note read off the map got attributed to the wrong fret. Now a single `gridScroll = rememberScrollState()` is hoisted above the header and shared by the header row and all four string rows, so the whole table moves as one. The note-filter row keeps its own separate scroll state (it is a genuinely independent control).

### #585 — cells unusable with TalkBack (P0, accessibility)
Each cell was a clickable `Box` whose only semantics were the bare note name, so a screen-reader user heard 52 context-free note names with no string/fret anchor, no click label, and no highlight state. The cell now carries, mirroring the iOS labelling:
- `contentDescription` = "<note>, string <name>, fret <n>"
- `stateDescription` = highlighted / dimmed
- `onClickLabel` on `.clickable(...)` (reuses the existing `cd_play_sound`)

As intended by the project rule, the container `contentDescription` replaces the child `Text` semantics — the description already includes the note name.

## Strings / localisation
Three new strings (`note_map_cell_description`, `note_map_cell_highlighted`, `note_map_cell_dimmed`) added to **all 16 Android locales**; `Localizable.xcstrings` regenerated via `scripts/convert_strings.py` (format specifiers converted, e.g. `%3$d` → `%3$lld`). `onClickLabel` reuses the existing `cd_play_sound` to avoid a new string.

## Note on diff size
The file was reformatted to satisfy ktlint. CI's ktlint ratchet matches its baseline by line number, so inserting lines shifted every pre-existing wrapping violation and would have failed the ratchet; running the formatter cleared the file's pre-existing debt. The functional change is small — review with `git diff -w`.

## Verification
- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew lintDebug` — BUILD SUCCESSFUL, no MissingTranslation/ExtraTranslation
- `scripts/ktlint.sh --baseline=ktlint-baseline.xml <file>` — clean (exit 0)
- Not run: `assembleDebug`, instrumented tests, on-device/emulator TalkBack pass.

Closes #584
Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)