### PR TITLE
Fix: applying a chord-library voicing honours the capo

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt
@@ -293,22 +293,28 @@ class FretboardViewModel : ViewModel() {
             }.toMap()
 
             val detection = if (rootPitchClass != null && formula != null) {
-                // Run detection to discover alternate chord names
+                // Run detection to discover alternate chord names. This goes
+                // through the capo-aware path, so its notes already reflect the
+                // sounding strings.
                 val detected = detectChord(newSelections)
-                val alternates = buildAlternates(detected, rootPitchClass, formula)
+
+                // Transpose the intended root by the capo so the named chord
+                // matches the strings that actually sound. Every other pitch
+                // site in this file adds the capo; without it, applying a
+                // library "C" at capo 2 would label the board "C" while the
+                // strings sound D.
+                val capo = current.capoFret
+                val soundingRoot = (rootPitchClass + capo).mod(Notes.PITCH_CLASS_COUNT)
+                val alternates = buildAlternates(detected, soundingRoot, formula)
 
                 val rootNote = Note(
-                    pitchClass = rootPitchClass,
-                    name = Notes.pitchClassToName(rootPitchClass),
+                    pitchClass = soundingRoot,
+                    name = Notes.pitchClassToName(soundingRoot),
                 )
-                val chordNotes = newSelections.entries
-                    .sortedBy { it.key }
-                    .mapNotNull { (i, fret) ->
-                        fret?.let {
-                            val pc = ((tuning[i].openPitchClass + it) % Notes.PITCH_CLASS_COUNT + Notes.PITCH_CLASS_COUNT) % Notes.PITCH_CLASS_COUNT
-                            Note(pitchClass = pc, name = Notes.pitchClassToName(pc))
-                        }
-                    }
+                // Use the capo-aware note list from detection so the notes
+                // shown match the sounding strings (identical to tapping the
+                // same frets by hand).
+                val chordNotes = detectedNotes(detected)
 
                 ChordDetector.DetectionResult.ChordFound(
                     ChordResult(
@@ -330,6 +336,22 @@ class FretboardViewModel : ViewModel() {
             )
         }
     }
+
+    /**
+     * Extracts the note list carried by a [ChordDetector.DetectionResult].
+     *
+     * Used by [applyVoicing] so the notes shown for a library voicing come from
+     * the capo-aware detection pass and match what tapping the same frets by
+     * hand produces.
+     */
+    private fun detectedNotes(detected: ChordDetector.DetectionResult): List<Note> =
+        when (detected) {
+            is ChordDetector.DetectionResult.ChordFound -> detected.result.notes
+            is ChordDetector.DetectionResult.NoMatch -> detected.notes
+            is ChordDetector.DetectionResult.Interval -> detected.notes
+            is ChordDetector.DetectionResult.SingleNote -> listOf(detected.note)
+            ChordDetector.DetectionResult.NoSelection -> emptyList()
+        }
 
     /**
      * Builds the list of alternate chord interpretations, excluding the

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/FretboardViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/FretboardViewModelTest.kt
@@ -1,11 +1,13 @@
 package com.baijum.ukufretboard.viewmodel
 
+import com.baijum.ukufretboard.data.ChordFormulas
 import com.baijum.ukufretboard.data.Notes
 import com.baijum.ukufretboard.data.Scale
 import com.baijum.ukufretboard.data.Scales
 import com.baijum.ukufretboard.data.TuningSettings
 import com.baijum.ukufretboard.data.UkuleleTuning
 import com.baijum.ukufretboard.domain.ChordDetector
+import com.baijum.ukufretboard.domain.ChordVoicing
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -226,5 +228,99 @@ class FretboardViewModelTest {
         val state = vm.uiState.value
         assertEquals(4, state.tuning.size)
         assertEquals(UkuleleTuning.LOW_G.octaves[0], state.tuning[0].octave)
+    }
+
+    // ── applyVoicing honours the capo (#574) ─────────────────────────
+
+    /** The open C-major shape (G-C-E-A tuning): G0, C0, E0, C on A-string. */
+    private fun cMajorVoicing(): ChordVoicing =
+        ChordVoicing(
+            frets = listOf(0, 0, 0, 3),
+            notes = listOf(null, null, null, null),
+            minFret = 0,
+            maxFret = 3,
+        )
+
+    private val majorFormula = ChordFormulas.ALL.first { it.quality == "Major" }
+
+    @Test
+    fun applyVoicingWithoutCapoUsesLibraryName() {
+        vm.applyVoicing(cMajorVoicing(), rootPitchClass = 0, formula = majorFormula)
+        val result = vm.uiState.value.detectionResult
+        assertTrue(result is ChordDetector.DetectionResult.ChordFound)
+        val chord = (result as ChordDetector.DetectionResult.ChordFound).result
+        assertEquals("No capo: library C shape stays C", "C", chord.name)
+        assertEquals(0, chord.root.pitchClass)
+        assertEquals(
+            "Notes are C-E-G",
+            setOf(0, 4, 7),
+            chord.notes.map { it.pitchClass }.toSet(),
+        )
+    }
+
+    @Test
+    fun applyVoicingShiftsNameAndNotesByCapo() {
+        vm.setCapoFret(2)
+        vm.applyVoicing(cMajorVoicing(), rootPitchClass = 0, formula = majorFormula)
+
+        val result = vm.uiState.value.detectionResult
+        assertTrue(result is ChordDetector.DetectionResult.ChordFound)
+        val chord = (result as ChordDetector.DetectionResult.ChordFound).result
+
+        // Capo 2 raises the C shape by two semitones: it sounds D major.
+        assertEquals("Capo 2 + library C shape sounds D", "D", chord.name)
+        assertEquals(2, chord.root.pitchClass)
+        assertEquals(
+            "Notes are the sounding D-F#-A, not C-E-G",
+            setOf(2, 6, 9),
+            chord.notes.map { it.pitchClass }.toSet(),
+        )
+    }
+
+    @Test
+    fun applyVoicingWithCapoMatchesManualTap() {
+        // Library path: apply the C shape with a capo at fret 2.
+        vm.setCapoFret(2)
+        vm.applyVoicing(cMajorVoicing(), rootPitchClass = 0, formula = majorFormula)
+        val applied = vm.uiState.value.detectionResult
+        assertTrue(applied is ChordDetector.DetectionResult.ChordFound)
+        val appliedChord = (applied as ChordDetector.DetectionResult.ChordFound).result
+
+        // Manual path: tap the identical frets with the same capo.
+        // clearAll() resets the capo, so re-apply it before tapping.
+        vm.clearAll()
+        vm.setCapoFret(2)
+        vm.toggleFret(0, 0)
+        vm.toggleFret(1, 0)
+        vm.toggleFret(2, 0)
+        vm.toggleFret(3, 3)
+        val tapped = vm.uiState.value.detectionResult
+        assertTrue(tapped is ChordDetector.DetectionResult.ChordFound)
+        val tappedChord = (tapped as ChordDetector.DetectionResult.ChordFound).result
+
+        assertEquals("Applied name matches manual-tap name", tappedChord.name, appliedChord.name)
+        assertEquals(
+            "Applied notes match manual-tap notes",
+            tappedChord.notes.map { it.pitchClass }.toSet(),
+            appliedChord.notes.map { it.pitchClass }.toSet(),
+        )
+    }
+
+    @Test
+    fun applyVoicingHonoursCapoInLowGTuning() {
+        vm.setTuningSettings(TuningSettings(tuning = UkuleleTuning.LOW_G))
+        vm.setCapoFret(2)
+        vm.applyVoicing(cMajorVoicing(), rootPitchClass = 0, formula = majorFormula)
+
+        val result = vm.uiState.value.detectionResult
+        assertTrue(result is ChordDetector.DetectionResult.ChordFound)
+        val chord = (result as ChordDetector.DetectionResult.ChordFound).result
+
+        // Pitch classes are tuning-independent, so Low-G sounds D major too.
+        assertEquals("Low-G capo 2 + C shape sounds D", "D", chord.name)
+        assertEquals(
+            setOf(2, 6, 9),
+            chord.notes.map { it.pitchClass }.toSet(),
+        )
     }
 }

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -2733,7 +2733,10 @@
         <error line="179" column="41" source="standard:wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/viewmodel/FretboardViewModel.kt">
-        <error line="3" column="1" source="standard:import-ordering" />
+                <error line="291" column="33" source="standard:multiline-expression-wrapping" />
+        <error line="291" column="46" source="standard:chain-method-continuation" />
+        <error line="295" column="29" source="standard:multiline-expression-wrapping" />
+<error line="3" column="1" source="standard:import-ordering" />
         <error line="70" column="35" source="standard:multiline-expression-wrapping" />
         <error line="83" column="1" source="standard:no-empty-first-line-in-class-body" />
         <error line="109" column="52" source="standard:multiline-expression-wrapping" />
@@ -2745,63 +2748,55 @@
         <error line="194" column="33" source="standard:multiline-expression-wrapping" />
         <error line="232" column="27" source="standard:multiline-expression-wrapping" />
         <error line="253" column="27" source="standard:multiline-expression-wrapping" />
-        <error line="291" column="33" source="standard:multiline-expression-wrapping" />
-        <error line="291" column="46" source="standard:chain-method-continuation" />
-        <error line="295" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="300" column="32" source="standard:multiline-expression-wrapping" />
-        <error line="304" column="34" source="standard:multiline-expression-wrapping" />
-        <error line="308" column="38" source="standard:binary-expression-wrapping" />
-        <error line="308" column="98" source="standard:binary-expression-wrapping" />
-        <error line="308" column="121" source="standard:max-line-length" />
-        <error line="308" column="125" source="standard:binary-expression-wrapping" />
-        <error line="321" column="22" source="standard:trailing-comma-on-call-site" />
-        <error line="357" column="18" source="standard:trailing-comma-on-call-site" />
-        <error line="365" column="14" source="standard:trailing-comma-on-call-site" />
-        <error line="408" column="32" source="standard:multiline-expression-wrapping" />
-        <error line="413" column="18" source="standard:trailing-comma-on-call-site" />
-        <error line="436" column="19" source="standard:function-signature" />
-        <error line="436" column="37" source="standard:function-signature" />
-        <error line="436" column="46" source="standard:function-signature" />
-        <error line="439" column="26" source="standard:binary-expression-wrapping" />
-        <error line="439" column="112" source="standard:binary-expression-wrapping" />
-        <error line="439" column="121" source="standard:max-line-length" />
-        <error line="441" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="465" column="21" source="standard:multiline-expression-wrapping" />
-        <error line="467" column="46" source="standard:if-else-wrapping" />
-        <error line="467" column="46" source="standard:multiline-if-else" />
-        <error line="468" column="22" source="standard:if-else-wrapping" />
-        <error line="468" column="22" source="standard:multiline-if-else" />
-        <error line="470" column="13" source="standard:chain-method-continuation" />
-        <error line="473" column="34" source="standard:binary-expression-wrapping" />
-        <error line="473" column="102" source="standard:binary-expression-wrapping" />
-        <error line="473" column="121" source="standard:max-line-length" />
-        <error line="473" column="129" source="standard:binary-expression-wrapping" />
-        <error line="502" column="21" source="standard:multiline-expression-wrapping" />
-        <error line="505" column="30" source="standard:binary-expression-wrapping" />
-        <error line="505" column="121" source="standard:max-line-length" />
-        <error line="505" column="123" source="standard:binary-expression-wrapping" />
-        <error line="554" column="29" source="standard:multiline-expression-wrapping" />
-        <error line="557" column="38" source="standard:binary-expression-wrapping" />
-        <error line="557" column="104" source="standard:binary-expression-wrapping" />
-        <error line="557" column="121" source="standard:max-line-length" />
-        <error line="557" column="131" source="standard:binary-expression-wrapping" />
-        <error line="580" column="28" source="standard:function-signature" />
-        <error line="580" column="46" source="standard:function-signature" />
-        <error line="580" column="55" source="standard:function-signature" />
-        <error line="583" column="26" source="standard:binary-expression-wrapping" />
-        <error line="583" column="119" source="standard:binary-expression-wrapping" />
-        <error line="583" column="121" source="standard:max-line-length" />
-        <error line="603" column="24" source="standard:function-signature" />
-        <error line="603" column="41" source="standard:function-signature" />
-        <error line="603" column="56" source="standard:function-signature" />
-        <error line="627" column="31" source="standard:function-signature" />
-        <error line="627" column="52" source="standard:function-signature" />
-        <error line="627" column="69" source="standard:function-signature" />
-        <error line="627" column="78" source="standard:function-signature" />
-        <error line="627" column="85" source="standard:function-expression-body" />
-        <error line="641" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="645" column="105" source="standard:binary-expression-wrapping" />
-        <error line="645" column="121" source="standard:max-line-length" />
+        <error line="310" column="32" source="standard:multiline-expression-wrapping" />
+        <error line="327" column="22" source="standard:trailing-comma-on-call-site" />
+        <error line="379" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="387" column="14" source="standard:trailing-comma-on-call-site" />
+        <error line="430" column="32" source="standard:multiline-expression-wrapping" />
+        <error line="435" column="18" source="standard:trailing-comma-on-call-site" />
+        <error line="458" column="19" source="standard:function-signature" />
+        <error line="458" column="37" source="standard:function-signature" />
+        <error line="458" column="46" source="standard:function-signature" />
+        <error line="461" column="26" source="standard:binary-expression-wrapping" />
+        <error line="461" column="112" source="standard:binary-expression-wrapping" />
+        <error line="461" column="121" source="standard:max-line-length" />
+        <error line="463" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="487" column="21" source="standard:multiline-expression-wrapping" />
+        <error line="489" column="46" source="standard:if-else-wrapping" />
+        <error line="489" column="46" source="standard:multiline-if-else" />
+        <error line="490" column="22" source="standard:if-else-wrapping" />
+        <error line="490" column="22" source="standard:multiline-if-else" />
+        <error line="492" column="13" source="standard:chain-method-continuation" />
+        <error line="495" column="34" source="standard:binary-expression-wrapping" />
+        <error line="495" column="102" source="standard:binary-expression-wrapping" />
+        <error line="495" column="121" source="standard:max-line-length" />
+        <error line="495" column="129" source="standard:binary-expression-wrapping" />
+        <error line="524" column="21" source="standard:multiline-expression-wrapping" />
+        <error line="527" column="30" source="standard:binary-expression-wrapping" />
+        <error line="527" column="121" source="standard:max-line-length" />
+        <error line="527" column="123" source="standard:binary-expression-wrapping" />
+        <error line="576" column="29" source="standard:multiline-expression-wrapping" />
+        <error line="579" column="38" source="standard:binary-expression-wrapping" />
+        <error line="579" column="104" source="standard:binary-expression-wrapping" />
+        <error line="579" column="121" source="standard:max-line-length" />
+        <error line="579" column="131" source="standard:binary-expression-wrapping" />
+        <error line="602" column="28" source="standard:function-signature" />
+        <error line="602" column="46" source="standard:function-signature" />
+        <error line="602" column="55" source="standard:function-signature" />
+        <error line="605" column="26" source="standard:binary-expression-wrapping" />
+        <error line="605" column="119" source="standard:binary-expression-wrapping" />
+        <error line="605" column="121" source="standard:max-line-length" />
+        <error line="625" column="24" source="standard:function-signature" />
+        <error line="625" column="41" source="standard:function-signature" />
+        <error line="625" column="56" source="standard:function-signature" />
+        <error line="649" column="31" source="standard:function-signature" />
+        <error line="649" column="52" source="standard:function-signature" />
+        <error line="649" column="69" source="standard:function-signature" />
+        <error line="649" column="78" source="standard:function-signature" />
+        <error line="649" column="85" source="standard:function-expression-body" />
+        <error line="663" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="667" column="105" source="standard:binary-expression-wrapping" />
+        <error line="667" column="121" source="standard:max-line-length" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/viewmodel/LearningProgressViewModel.kt">
         <error line="19" column="33" source="standard:class-signature" />
@@ -3350,7 +3345,7 @@
         <error line="113" column="45" source="standard:chain-method-continuation" />
     </file>
     <file name="app/src/test/java/com/baijum/ukufretboard/viewmodel/FretboardViewModelTest.kt">
-        <error line="18" column="1" source="standard:no-empty-first-line-in-class-body" />
+        <error line="20" column="1" source="standard:no-empty-first-line-in-class-body" />
     </file>
     <file name="app/src/test/java/com/baijum/ukufretboard/viewmodel/MetronomeViewModelTest.kt">
         <error line="16" column="1" source="standard:no-empty-first-line-in-class-body" />


### PR DESCRIPTION
## Summary

`FretboardViewModel.applyVoicing` was the one pitch computation in the file that omitted the `+ capo` shift. Applying a chord-library voicing with a capo set showed the un-capoed chord name and a note list a capo-height too low — e.g. capo 2 + library "C" labelled the board "C" and listed C–E–G, while the strings actually sound D (D–F#–A). Tapping the same frets by hand went through the capo-aware `detectChord` path and was already correct, so the same fretboard gave two different answers.

## Fix

In the `rootPitchClass != null && formula != null` branch of `applyVoicing`:
- Transpose the intended root by the current capo (`soundingRoot = (rootPitchClass + capo).mod(12)`) before building the chord name/root and the alternates.
- Take the note list from the capo-aware detection pass (new `detectedNotes` helper) instead of rebuilding it from the raw selections, so the notes shown match the sounding strings and are identical to a manual tap.

The logic is purely on pitch classes, so High-G and Low-G tunings both stay correct.

## Tests

Added four `FretboardViewModelTest` cases:
- no-capo library "C" shape still names "C" / C–E–G (baseline preserved),
- capo 2 + library "C" now names "D" and lists D–F#–A,
- applied voicing matches what tapping the identical frets produces (name + notes),
- Low-G tuning with capo 2 also sounds D.

All 22 tests in the class pass. Verified `:app:compileDebugKotlin` and confirmed the ktlint ratchet introduces no new violations (counts for the changed files are ≤ baseline).

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)