### PR TITLE
Fix: AchievementWatcher clamps Int32 conversions to avoid a launch crash

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/AchievementWatcher.swift
+++ b/iosApp/UkuleleCompanion/Helpers/AchievementWatcher.swift
@@ -27,21 +27,28 @@ enum AchievementWatcher {
         let scaleStats = learnVM.scalePracticeStats()
         let totalLessons = TheoryLessons.shared.ALL.asArray(of: TheoryLesson.self).count
 
+        // Counts are clamped rather than converted: these values originate from
+        // `UserDefaults` (64-bit `Int`), and a value outside `Int32` — from a
+        // corrupt store or a restored backup — would trap on the way into the
+        // shared rules. This runs from `ContentView`'s `.task` on every launch,
+        // so a trap here is a startup crash loop. Clamping to `Int32.max` also
+        // stays on the safe side of every achievement threshold. Matches
+        // `ReviewPromptManager.snapshot()`.
         return AchievementContext(
-            currentStreak: Int32(learnVM.currentDayStreak()),
-            bestStreak: Int32(learnVM.bestDayStreak()),
-            completedLessons: Int32(learnVM.completedLessonCount()),
-            totalLessons: Int32(totalLessons),
-            quizCorrect: Int32(quizStats.correct),
-            quizTotal: Int32(quizStats.total),
-            quizBestStreak: Int32(quizStats.bestStreak),
-            intervalTotal: Int32(intervalStats.total),
-            intervalCorrect: Int32(intervalStats.correct),
-            chordEarTotal: Int32(chordEarStats.total),
-            chordEarCorrect: Int32(chordEarStats.correct),
-            scalePracticeTotal: Int32(scaleStats.total),
-            songsCount: Int32(songsCount),
-            favoritesCount: Int32(favoritesCount)
+            currentStreak: Int32(clamping: learnVM.currentDayStreak()),
+            bestStreak: Int32(clamping: learnVM.bestDayStreak()),
+            completedLessons: Int32(clamping: learnVM.completedLessonCount()),
+            totalLessons: Int32(clamping: totalLessons),
+            quizCorrect: Int32(clamping: quizStats.correct),
+            quizTotal: Int32(clamping: quizStats.total),
+            quizBestStreak: Int32(clamping: quizStats.bestStreak),
+            intervalTotal: Int32(clamping: intervalStats.total),
+            intervalCorrect: Int32(clamping: intervalStats.correct),
+            chordEarTotal: Int32(clamping: chordEarStats.total),
+            chordEarCorrect: Int32(clamping: chordEarStats.correct),
+            scalePracticeTotal: Int32(clamping: scaleStats.total),
+            songsCount: Int32(clamping: songsCount),
+            favoritesCount: Int32(clamping: favoritesCount)
         )
     }
 


### PR DESCRIPTION
`AchievementWatcher.context` narrowed fourteen 64-bit, UserDefaults-backed values with trapping `Int32(_:)` conversions. Since commit 702bd4f moved this builder from `AchievementsView` to the composition root (`ContentView`'s `.task`), it runs on **every launch**.

A restored or corrupt backup can carry a learn-progress counter above `Int32.max` — `LearnRepository.importProgress` stores any `value as? Int` with no upper bound. On the next launch `Int32(quizStats.total)` would trap, crashing the app during startup with no screen to avoid and no in-app way to clear the value: a launch crash loop that only a delete-and-reinstall recovers from.

This switches all fourteen conversions in `context` to `Int32(clamping:)`, matching the sibling `ReviewPromptManager.snapshot()` (hardened in 8d0c52a for exactly this reason). Clamping to `Int32.max` also stays on the safe side of every achievement threshold.

Scope: `AchievementWatcher.swift` only. `LearnRepository.importProgress` bounding (the other end of the door) is intentionally left out — a separate change is in flight there.

Verification: self-reviewed that no plain `Int32(` narrowing remains in `context`. Full xcodebuild not run (heavy) — pending. Fully offline.

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved app startup stability when stored achievement metrics exceed supported numeric limits.
  - Prevented potential crashes caused by unusually large achievement values.
  - Ensured achievement tracking continues safely without affecting threshold-based progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->