### PR TITLE
Fix: iOS restore no longer overwrites the daily practice goal

### DIFF
--- a/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/PracticeTimerRepository.swift
@@ -8,6 +8,9 @@ import Foundation
 /// backup-and-quarantine helper as the list stores (#569).
 final class PracticeTimerRepository {
     private let storageKey = "practice_timer"
+    /// Default daily practice goal in minutes; matches `PracticeTimerData`'s
+    /// default and Android's `DEFAULT_DAILY_GOAL`.
+    private static let defaultDailyGoal = 15
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -62,7 +65,16 @@ final class PracticeTimerRepository {
             data.lastSessionTime = max(data.lastSessionTime, normalized)
         }
         if let goal = dict["dailyGoal"] as? Int {
-            data.dailyGoal = goal
+            // Mirror Android (PracticeTimerRepository.importAll): clamp the
+            // incoming goal to the valid 5...120 range and apply it only when it
+            // differs from the 15-minute default. The backup dictionary always
+            // carries this key — an absent or default practice-timer section
+            // decodes to a goal of 15 — so assigning it unconditionally would
+            // silently overwrite a goal the user chose (#608).
+            let incomingGoal = min(max(goal, 5), 120)
+            if incomingGoal != Self.defaultDailyGoal {
+                data.dailyGoal = incomingGoal
+            }
         }
         if let daily = dict["dailyMinutes"] as? [String: Int] {
             for (key, value) in daily {

--- a/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
+++ b/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
@@ -197,6 +197,49 @@ final class RepositoryBackupTests: XCTestCase {
         XCTAssertEqual(repository.load().totalMinutes, 120)
     }
 
+    // MARK: - Importing the daily practice goal
+
+    /// A backup with no practice-timer data (or one made on a device still at the
+    /// default) carries the 15-minute default goal. Importing it must not clobber
+    /// a goal the user chose (#608). Mirrors Android's guard in
+    /// `PracticeTimerRepository.importAll`.
+    func testImportDefaultGoalLeavesUserGoalUntouched() {
+        let repository = PracticeTimerRepository()
+        var data = PracticeTimerData()
+        data.dailyGoal = 60
+
+        repository.importData(["dailyGoal": 15], into: &data)
+
+        XCTAssertEqual(data.dailyGoal, 60)
+        XCTAssertEqual(repository.load().dailyGoal, 60)
+    }
+
+    /// A non-default goal from a backup still overrides the current goal.
+    func testImportNonDefaultGoalOverridesCurrent() {
+        let repository = PracticeTimerRepository()
+        var data = PracticeTimerData()
+        data.dailyGoal = 60
+
+        repository.importData(["dailyGoal": 30], into: &data)
+
+        XCTAssertEqual(data.dailyGoal, 30)
+        XCTAssertEqual(repository.load().dailyGoal, 30)
+    }
+
+    /// A hand-edited or corrupt backup cannot push the goal outside the 5...120
+    /// range the app's own setter enforces.
+    func testImportClampsOutOfRangeGoal() {
+        let repository = PracticeTimerRepository()
+        var data = PracticeTimerData()
+        data.dailyGoal = 60
+
+        repository.importData(["dailyGoal": 500], into: &data)
+        XCTAssertEqual(data.dailyGoal, 120)
+
+        repository.importData(["dailyGoal": 1], into: &data)
+        XCTAssertEqual(data.dailyGoal, 5)
+    }
+
     func testFavoritesRecoverFromBackup() {
         let repository = FavoritesRepository()
         repository.save([


### PR DESCRIPTION
`PracticeTimerRepository.importData` assigned `dailyGoal` unconditionally. The backup dictionary always carries the key, and a backup with no practice-timer section decodes to the 15-minute default, so restoring any such backup silently dropped a user's chosen goal (e.g. 60) to 15 — the Learning Progress ring and "15m goal" label changed with no mention in the restore result. The `5...120` clamp the setter enforces was also skipped, so a hand-edited or corrupt backup could set an out-of-range goal.

## Fix
Mirror Android (`PracticeTimerRepository.importAll`): clamp the incoming goal to `5...120` and apply it only when it differs from the 15-minute default. Change is confined to `importData`; `BackupRestoreManager` untouched.

## Tests
Adds `RepositoryBackupTests` cases: a default-goal (15) import leaves a user's 60 untouched, a non-default import overrides, and out-of-range values clamp to 5/120.

## Verification
Self-reviewed; fully offline. Simulator/xcodebuild verification pending (skipped locally to avoid a heavy build with agents running).

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)