### PR TITLE
Fix: iOS Reset All Progress keeps unlocked achievements

### DIFF
--- a/iosApp/UkuleleCompanion/Repositories/LearnRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/LearnRepository.swift
@@ -56,9 +56,17 @@ final class LearnRepository {
     }
 
     func clearAll() {
+        // Preserve unlocked achievements: they live in this same suite but are
+        // not "learning progress". Android keeps trophies across Reset All
+        // Progress (achievements live in a separate store there), so read the
+        // list, clear the suite, then write it back to match. See issue #607.
+        let preservedAchievements = defaults.stringArray(forKey: "unlocked_achievements")
         let allKeys = defaults.dictionaryRepresentation().keys
         for key in allKeys {
             defaults.removeObject(forKey: key)
+        }
+        if let preservedAchievements, !preservedAchievements.isEmpty {
+            defaults.set(preservedAchievements, forKey: "unlocked_achievements")
         }
     }
 

--- a/iosApp/UkuleleCompanionTests/LearnViewModelTests.swift
+++ b/iosApp/UkuleleCompanionTests/LearnViewModelTests.swift
@@ -133,13 +133,31 @@ final class LearnViewModelTests: XCTestCase {
         let vm = LearnViewModel()
         vm.markLessonCompleted("lesson_1")
         vm.recordQuizAnswer(category: .intervals, correct: true)
+
+        vm.clearAllProgress()
+
+        XCTAssertFalse(vm.isLessonCompleted("lesson_1"))
+        XCTAssertEqual(vm.quizStats().total, 0)
+    }
+
+    // Reset All Progress must clear learning progress but keep unlocked
+    // achievements, matching Android (where trophies live in a separate
+    // store). See issue #607.
+    @MainActor
+    func testClearAllProgressKeepsUnlockedAchievements() {
+        let vm = LearnViewModel()
+        vm.markLessonCompleted("lesson_1")
+        vm.recordQuizAnswer(category: .intervals, correct: true)
+        vm.unlockAchievement("first_chord")
         vm.unlockAchievement("test")
 
         vm.clearAllProgress()
 
         XCTAssertFalse(vm.isLessonCompleted("lesson_1"))
         XCTAssertEqual(vm.quizStats().total, 0)
-        XCTAssertTrue(vm.unlockedAchievementIds.isEmpty)
+        XCTAssertTrue(vm.unlockedAchievementIds.contains("first_chord"))
+        XCTAssertTrue(vm.unlockedAchievementIds.contains("test"))
+        XCTAssertEqual(vm.unlockedAchievementIds.count, 2)
     }
 
     @MainActor


### PR DESCRIPTION
iOS "Reset All Progress" wiped the user's entire achievement history, while Android keeps trophies across the same action.

`LearnRepository.clearAll()` swept every key in the `learn_progress` suite — including `unlocked_achievements` — so the reset took the trophy list along with the learning counters. Android's equivalent path clears only its learning store; achievements live in a separate store there and survive. Neither platform's confirmation dialog mentions achievements, so the iOS loss was silent and irreversible (no undo, no backup).

## Change
Applied the issue's primary suggested fix, scoped to `LearnRepository.clearAll()`:
- Read `unlocked_achievements` before clearing the suite.
- Clear the suite as before.
- Write the preserved list back.

Now iOS matches Android: Reset All Progress clears progress, streaks, and quiz stats but keeps unlocked achievements. Did not take the alternative "wipe on both platforms" route, which would require a product decision and confirmation-copy changes.

## Tests
- Updated `testClearAllProgress` to stop asserting the old (buggy) wipe-achievements behavior.
- Added `testClearAllProgressKeepsUnlockedAchievements`: unlocks two achievements, calls `clearAllProgress()`, asserts progress is cleared and both achievements survive.

Full xcodebuild not run (heavy); change is offline and localized. Verified by self-review and diff.

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)