### PR TITLE
Fix: editing a song preserves its view count and practice time

### DIFF
--- a/iosApp/UkuleleCompanion/Views/SongEditorView.swift
+++ b/iosApp/UkuleleCompanion/Views/SongEditorView.swift
@@ -339,7 +339,10 @@ struct SongEditorView: View {
             strumPatternName: strumPatternName,
             labels: labels,
             createdAt: existingSong?.createdAt ?? now,
-            updatedAt: now
+            updatedAt: now,
+            viewCount: existingSong?.viewCount ?? 0,
+            lastViewedAt: existingSong?.lastViewedAt ?? 0,
+            totalViewTimeMs: existingSong?.totalViewTimeMs ?? 0
         )
         viewModel.save(song: song)
     }


### PR DESCRIPTION
`SongEditorView.saveSong()` rebuilt `StoredSong` from scratch and passed none of `viewCount`, `lastViewedAt` or `totalViewTimeMs`, so they fell through to the `= 0` defaults in the memberwise initialiser. Every edit of an existing song therefore reset its play history (view count, last-viewed date and accumulated practice time) to zero, permanently overwriting the stored record — and a subsequent backup carried the zeroed values into an Android restore.

This mirrors how `id`, `subtitle` and `createdAt` are already carried over from `existingSong`, and matches Android's `saveSheet` behaviour (which uses `existing.copy(...)`).

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)