### PR TITLE
Fix: practice routine fills its advertised duration

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
@@ -15,7 +15,6 @@ import kotlin.random.Random
  * form a structured practice session.
  */
 object PracticeRoutineGenerator {
-
     /**
      * Generates a practice routine.
      *
@@ -80,24 +79,36 @@ object PracticeRoutineGenerator {
         )
     }
 
-    private fun generateWarmUp(level: SkillLevel, random: Random): PracticeStep {
-        val warmups = when (level) {
-            SkillLevel.BEGINNER -> listOf(
-                "Slowly strum each open string (G-C-E-A) and listen for clear tones.",
-                "Practice placing and lifting your fingers on the C chord shape.",
-                "Strum C and Am chords slowly, 4 beats each, for 2 minutes.",
-            )
-            SkillLevel.INTERMEDIATE -> listOf(
-                "Play a chromatic scale on each string from fret 1 to 5 and back.",
-                "Cycle through C-Am-F-G at 80 BPM, 4 beats per chord.",
-                "Practice barre chord shapes slowly up the neck.",
-            )
-            SkillLevel.ADVANCED -> listOf(
-                "Warm up with the major scale in 3 different positions.",
-                "Play chord inversions up the neck for any chord.",
-                "Fingerpick through an arpeggio pattern at a comfortable tempo.",
-            )
-        }
+    private fun generateWarmUp(
+        level: SkillLevel,
+        random: Random,
+    ): PracticeStep {
+        val warmups =
+            when (level) {
+                SkillLevel.BEGINNER -> {
+                    listOf(
+                        "Slowly strum each open string (G-C-E-A) and listen for clear tones.",
+                        "Practice placing and lifting your fingers on the C chord shape.",
+                        "Strum C and Am chords slowly, 4 beats each, for 2 minutes.",
+                    )
+                }
+
+                SkillLevel.INTERMEDIATE -> {
+                    listOf(
+                        "Play a chromatic scale on each string from fret 1 to 5 and back.",
+                        "Cycle through C-Am-F-G at 80 BPM, 4 beats per chord.",
+                        "Practice barre chord shapes slowly up the neck.",
+                    )
+                }
+
+                SkillLevel.ADVANCED -> {
+                    listOf(
+                        "Warm up with the major scale in 3 different positions.",
+                        "Play chord inversions up the neck for any chord.",
+                        "Fingerpick through an arpeggio pattern at a comfortable tempo.",
+                    )
+                }
+            }
         return PracticeStep(
             type = StepType.WARM_UP,
             title = "Warm Up",
@@ -112,82 +123,95 @@ object PracticeRoutineGenerator {
         minutes: Int,
         level: SkillLevel,
         random: Random,
-    ): PracticeStep = when (type) {
-        StepType.CHORD_DRILL -> {
-            val chords = when (level) {
-                SkillLevel.BEGINNER -> listOf("C", "Am", "F", "G", "Em", "Dm")
-                SkillLevel.INTERMEDIATE -> listOf("Bm", "F#m", "Bb", "Eb", "A7", "Dm7")
-                SkillLevel.ADVANCED -> listOf("Cmaj7", "Am7", "Dm9", "G13", "Bbmaj7")
+    ): PracticeStep =
+        when (type) {
+            StepType.CHORD_DRILL -> {
+                val chords =
+                    when (level) {
+                        SkillLevel.BEGINNER -> listOf("C", "Am", "F", "G", "Em", "Dm")
+                        SkillLevel.INTERMEDIATE -> listOf("Bm", "F#m", "Bb", "Eb", "A7", "Dm7")
+                        SkillLevel.ADVANCED -> listOf("Cmaj7", "Am7", "Dm9", "G13", "Bbmaj7")
+                    }
+                val chord1 = chords[random.nextInt(chords.size)]
+                val chord2 = chords[random.nextInt(chords.size)]
+                PracticeStep(
+                    type = type,
+                    title = "Chord Transition: $chord1 ↔ $chord2",
+                    description =
+                        "Switch between $chord1 and $chord2 with a metronome. " +
+                            "Start at 60 BPM and increase by 10 each minute.",
+                    durationMinutes = minutes,
+                    navTarget = NavSection.CHORD_TRANSITION,
+                )
             }
-            val chord1 = chords[random.nextInt(chords.size)]
-            val chord2 = chords[random.nextInt(chords.size)]
-            PracticeStep(
-                type = type,
-                title = "Chord Transition: $chord1 ↔ $chord2",
-                description = "Switch between $chord1 and $chord2 with a metronome. Start at 60 BPM and increase by 10 each minute.",
-                durationMinutes = minutes,
-                navTarget = NavSection.CHORD_TRANSITION,
-            )
-        }
-        StepType.SCALE_PRACTICE -> {
-            val scales = when (level) {
-                SkillLevel.BEGINNER -> listOf("C Major", "A Minor", "G Major")
-                SkillLevel.INTERMEDIATE -> listOf("D Major", "E Minor Pentatonic", "Blues Scale")
-                SkillLevel.ADVANCED -> listOf("Mixolydian", "Dorian", "Melodic Minor")
-            }
-            val scale = scales[random.nextInt(scales.size)]
-            PracticeStep(
-                type = type,
-                title = "Scale: $scale",
-                description = "Play the $scale scale ascending and descending. Try in different positions on the fretboard.",
-                durationMinutes = minutes,
-                navTarget = NavSection.SCALE_PRACTICE,
-            )
-        }
-        StepType.EAR_TRAINING -> {
-            PracticeStep(
-                type = type,
-                title = "Ear Training",
-                description = "Identify intervals and chord types by ear. Focus on getting at least 70% correct.",
-                durationMinutes = minutes,
-                navTarget = NavSection.CHORD_EAR,
-            )
-        }
-        StepType.THEORY_QUIZ -> {
-            PracticeStep(
-                type = type,
-                title = "Theory Check",
-                description = "Answer theory questions to reinforce your knowledge. Aim for a 5-question streak!",
-                durationMinutes = minutes,
-                navTarget = NavSection.THEORY_QUIZ,
-            )
-        }
-        StepType.SONG_PRACTICE -> {
-            PracticeStep(
-                type = type,
-                title = "Song Practice",
-                description = "Pick a song from your songbook and play through it. Focus on smooth chord changes.",
-                durationMinutes = minutes,
-                navTarget = NavSection.SONGBOOK,
-            )
-        }
 
-        StepType.WARM_UP, StepType.FREE_PLAY -> {
-            // Already handled separately
-            PracticeStep(
-                type = type,
-                title = "Free Play",
-                description = "Play whatever you like!",
-                durationMinutes = minutes,
-                navTarget = null,
-            )
+            StepType.SCALE_PRACTICE -> {
+                val scales =
+                    when (level) {
+                        SkillLevel.BEGINNER -> listOf("C Major", "A Minor", "G Major")
+                        SkillLevel.INTERMEDIATE -> listOf("D Major", "E Minor Pentatonic", "Blues Scale")
+                        SkillLevel.ADVANCED -> listOf("Mixolydian", "Dorian", "Melodic Minor")
+                    }
+                val scale = scales[random.nextInt(scales.size)]
+                PracticeStep(
+                    type = type,
+                    title = "Scale: $scale",
+                    description =
+                        "Play the $scale scale ascending and descending. " +
+                            "Try in different positions on the fretboard.",
+                    durationMinutes = minutes,
+                    navTarget = NavSection.SCALE_PRACTICE,
+                )
+            }
+
+            StepType.EAR_TRAINING -> {
+                PracticeStep(
+                    type = type,
+                    title = "Ear Training",
+                    description = "Identify intervals and chord types by ear. Focus on getting at least 70% correct.",
+                    durationMinutes = minutes,
+                    navTarget = NavSection.CHORD_EAR,
+                )
+            }
+
+            StepType.THEORY_QUIZ -> {
+                PracticeStep(
+                    type = type,
+                    title = "Theory Check",
+                    description = "Answer theory questions to reinforce your knowledge. Aim for a 5-question streak!",
+                    durationMinutes = minutes,
+                    navTarget = NavSection.THEORY_QUIZ,
+                )
+            }
+
+            StepType.SONG_PRACTICE -> {
+                PracticeStep(
+                    type = type,
+                    title = "Song Practice",
+                    description = "Pick a song from your songbook and play through it. Focus on smooth chord changes.",
+                    durationMinutes = minutes,
+                    navTarget = NavSection.SONGBOOK,
+                )
+            }
+
+            StepType.WARM_UP, StepType.FREE_PLAY -> {
+                // Already handled separately
+                PracticeStep(
+                    type = type,
+                    title = "Free Play",
+                    description = "Play whatever you like!",
+                    durationMinutes = minutes,
+                    navTarget = null,
+                )
+            }
         }
-    }
 
     /**
      * Practice step types.
      */
-    enum class StepType(val label: String) {
+    enum class StepType(
+        val label: String,
+    ) {
         WARM_UP("Warm Up"),
         CHORD_DRILL("Chord Drill"),
         SCALE_PRACTICE("Scale Practice"),
@@ -201,7 +225,10 @@ object PracticeRoutineGenerator {
     /**
      * Focus areas that map to step types.
      */
-    enum class FocusArea(val label: String, val stepTypes: List<StepType>) {
+    enum class FocusArea(
+        val label: String,
+        val stepTypes: List<StepType>,
+    ) {
         CHORDS("Chords", listOf(StepType.CHORD_DRILL)),
         SCALES("Scales", listOf(StepType.SCALE_PRACTICE)),
         EAR("Ear Training", listOf(StepType.EAR_TRAINING)),
@@ -212,7 +239,9 @@ object PracticeRoutineGenerator {
     /**
      * User skill levels.
      */
-    enum class SkillLevel(val label: String) {
+    enum class SkillLevel(
+        val label: String,
+    ) {
         BEGINNER("Beginner"),
         INTERMEDIATE("Intermediate"),
         ADVANCED("Advanced"),

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGenerator.kt
@@ -41,10 +41,18 @@ object PracticeRoutineGenerator {
         val exerciseCount = (remainingTime / 3).coerceIn(2, 5)
         val timePerExercise = remainingTime / exerciseCount
 
-        val availableTypes = focusAreas.flatMap { it.stepTypes }.distinct().toMutableList()
+        val focusTypes = focusAreas.flatMap { it.stepTypes }.distinct()
+        // Draw from a pool that refills once exhausted, so selecting fewer
+        // focus areas than exerciseCount still fills the requested time
+        // (types repeat) instead of yielding a routine shorter than the title
+        // advertises. See #609.
+        val availableTypes = focusTypes.toMutableList()
 
         repeat(exerciseCount) {
-            if (availableTypes.isEmpty()) return@repeat
+            if (focusTypes.isEmpty()) return@repeat
+            if (availableTypes.isEmpty()) {
+                availableTypes.addAll(focusTypes)
+            }
             val typeIndex = random.nextInt(availableTypes.size)
             val type = availableTypes.removeAt(typeIndex)
             steps.add(generateStep(type, timePerExercise, skillLevel, random))
@@ -61,10 +69,14 @@ object PracticeRoutineGenerator {
             ),
         )
 
+        val totalMinutes = steps.sumOf { it.durationMinutes }
+
         return PracticeRoutine(
-            title = "${durationMinutes}-Minute ${skillLevel.label} Practice",
+            // Title from the realised total, never the requested duration, so
+            // the header can never overstate the routine. See #609.
+            title = "$totalMinutes-Minute ${skillLevel.label} Practice",
             steps = steps,
-            totalMinutes = steps.sumOf { it.durationMinutes },
+            totalMinutes = totalMinutes,
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGeneratorTest.kt
@@ -52,10 +52,60 @@ class PracticeRoutineGeneratorTest {
     }
 
     @Test
-    fun titleIncludesDurationAndLevel() {
+    fun titleIncludesRealisedDurationAndLevel() {
         val routine = PracticeRoutineGenerator.generate(durationMinutes = 30, skillLevel = SkillLevel.ADVANCED)
-        assertTrue(routine.title.contains("30"), "Title should include duration")
+        // Title must reflect the realised total, never the requested duration,
+        // so the header can never overstate the routine (#609).
+        assertTrue(
+            routine.title.contains("${routine.totalMinutes}"),
+            "Title '${routine.title}' should include realised total ${routine.totalMinutes}",
+        )
         assertTrue(routine.title.contains("Advanced"), "Title should include skill level")
+    }
+
+    @Test
+    fun singleFocusAreaFillsRequestedDuration() {
+        // Regression for #609: selecting one focus area used to drain the type
+        // pool, so a "15-Minute" routine delivered only ~7 minutes. The pool
+        // now refills, so the routine fills the requested time and the title
+        // matches the realised total.
+        val routine = PracticeRoutineGenerator.generate(
+            durationMinutes = 15,
+            skillLevel = SkillLevel.BEGINNER,
+            focusAreas = setOf(FocusArea.CHORDS),
+        )
+
+        // The title must exactly match the realised total (no overstating).
+        assertEquals(
+            routine.steps.sumOf { it.durationMinutes },
+            routine.totalMinutes,
+            "totalMinutes should equal the sum of step durations",
+        )
+        assertTrue(
+            routine.title.contains("${routine.totalMinutes}"),
+            "Title '${routine.title}' should advertise the realised ${routine.totalMinutes} minutes",
+        )
+
+        // The routine must fill close to the requested 15 minutes, not the old
+        // 7-minute (warm-up + one drill + cool-down) result.
+        assertTrue(
+            routine.totalMinutes >= 14,
+            "Single focus area at 15 min should fill the duration, got ${routine.totalMinutes}",
+        )
+
+        // The focused exercises (everything but warm-up and cool-down) should
+        // all be chord drills, repeating to fill the time.
+        val exercises = routine.steps.filter {
+            it.type != StepType.WARM_UP && it.type != StepType.FREE_PLAY
+        }
+        assertTrue(
+            exercises.size > 1,
+            "Pool should refill so exercises repeat, got ${exercises.size}",
+        )
+        assertTrue(
+            exercises.all { it.type == StepType.CHORD_DRILL },
+            "Only Chords was selected, so every exercise should be a chord drill",
+        )
     }
 
     // --- Skill levels ---

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/PracticeRoutineGeneratorTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class PracticeRoutineGeneratorTest {
-
     @Test
     fun defaultRoutineIsNonEmpty() {
         val routine = PracticeRoutineGenerator.generate()
@@ -69,11 +68,12 @@ class PracticeRoutineGeneratorTest {
         // pool, so a "15-Minute" routine delivered only ~7 minutes. The pool
         // now refills, so the routine fills the requested time and the title
         // matches the realised total.
-        val routine = PracticeRoutineGenerator.generate(
-            durationMinutes = 15,
-            skillLevel = SkillLevel.BEGINNER,
-            focusAreas = setOf(FocusArea.CHORDS),
-        )
+        val routine =
+            PracticeRoutineGenerator.generate(
+                durationMinutes = 15,
+                skillLevel = SkillLevel.BEGINNER,
+                focusAreas = setOf(FocusArea.CHORDS),
+            )
 
         // The title must exactly match the realised total (no overstating).
         assertEquals(
@@ -95,9 +95,10 @@ class PracticeRoutineGeneratorTest {
 
         // The focused exercises (everything but warm-up and cool-down) should
         // all be chord drills, repeating to fill the time.
-        val exercises = routine.steps.filter {
-            it.type != StepType.WARM_UP && it.type != StepType.FREE_PLAY
-        }
+        val exercises =
+            routine.steps.filter {
+                it.type != StepType.WARM_UP && it.type != StepType.FREE_PLAY
+            }
         assertTrue(
             exercises.size > 1,
             "Pool should refill so exercises repeat, got ${exercises.size}",
@@ -141,8 +142,10 @@ class PracticeRoutineGeneratorTest {
     fun shortRoutineHasFewerSteps() {
         val short = PracticeRoutineGenerator.generate(durationMinutes = 10)
         val long = PracticeRoutineGenerator.generate(durationMinutes = 30)
-        assertTrue(short.steps.size <= long.steps.size,
-            "Short routine (${short.steps.size} steps) should have <= steps than long (${long.steps.size})")
+        assertTrue(
+            short.steps.size <= long.steps.size,
+            "Short routine (${short.steps.size} steps) should have <= steps than long (${long.steps.size})",
+        )
     }
 
     // --- Step types are valid ---


### PR DESCRIPTION
`PracticeRoutineGenerator` drained its pool of exercise types without refilling it, so selecting fewer focus areas than the duration implied produced a routine much shorter than its title advertised — a default "15-Minute" routine with only **Chords** selected delivered warm-up (2) + one chord drill (3) + cool-down (2) = **7 minutes** under a "15-Minute" header.

## Changes (shared KMP, `PracticeRoutineGenerator.kt`)
1. **Refill the type pool.** The pool of step types now refills from `focusAreas` once exhausted, so step types repeat and the routine fills the requested time instead of stopping short.
2. **Honest title.** The title is built from the realised `totalMinutes` rather than the requested `durationMinutes`, so the header can never overstate the routine (title, `totalMinutes`, and the step-duration sum are always in agreement).

## Tests
- New `singleFocusAreaFillsRequestedDuration`: one focus area (Chords) at 15 min now fills the duration (>= 14 min), the exercises repeat as chord drills, and the title matches the realised total — no longer 7 minutes under a "15-Minute" header.
- Updated `titleIncludesRealisedDurationAndLevel` (was `titleIncludesDurationAndLevel`) to assert the title reflects the realised total, since with integer-divided per-exercise time a 30-min request realises 29 min.

## Verification
- `./gradlew :shared:jvmTest` (PracticeRoutineGeneratorTest) — pass
- `./gradlew :app:compileDebugKotlin` — pass
- No new ktlint violations introduced; no platform imports added to `commonMain`; fully offline.

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)