### PR TITLE
Fix: iOS Fretboard Note Map plays each fret at its real octave

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/KMPBridging.swift
+++ b/iosApp/UkuleleCompanion/Helpers/KMPBridging.swift
@@ -91,6 +91,11 @@ extension UkuleleTuning {
     var stringNameArray: [String] {
         (0..<Int(stringNames.count)).map { (stringNames[$0] as? String) ?? "" }
     }
+
+    /// Octave number of each open string as a Swift `[Int32]` array.
+    var octaveInts: [Int32] {
+        (0..<Int(octaves.count)).map { (octaves[$0] as? NSNumber)?.int32Value ?? 0 }
+    }
 }
 
 // MARK: - ChordVoicing convenience

--- a/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
+++ b/iosApp/UkuleleCompanion/Views/FretboardNoteMapView.swift
@@ -62,6 +62,7 @@ struct FretboardNoteMapView: View {
 
                     let pitchClasses = tuning.pitchClassInts
                     let stringNames = tuning.stringNameArray
+                    let octaves = tuning.octaveInts
 
                     ForEach(Array((0..<4).reversed()), id: \.self) { stringIndex in
                         HStack(spacing: 0) {
@@ -76,6 +77,9 @@ struct FretboardNoteMapView: View {
                                     openStringPitchClass: openPC,
                                     fret: Int32(fret)
                                 )
+                                // Octave for this cell, matching Android's
+                                // baseOctave + (openPc + fret) / 12 (see #588).
+                                let octave = octaves[stringIndex] + (openPC + Int32(fret)) / 12
                                 let isHighlighted = highlightPitchClass < 0 ||
                                     note.pitchClass == highlightPitchClass
                                 let isOpenString = fret == 0
@@ -85,13 +89,13 @@ struct FretboardNoteMapView: View {
                                     .frame(width: cellSize, height: cellSize)
                                     .background(
                                         isHighlighted
-                                            ? (isOpenString ? Color.accentColor.opacity(0.3) : Color.accentColor.opacity(0.15))
+                                            ? Color.accentColor.opacity(isOpenString ? 0.3 : 0.15)
                                             : Color(.systemGray6)
                                     )
                                     .foregroundStyle(isHighlighted ? .primary : .quaternary)
                                     .border(Color(.systemGray4), width: 0.5)
                                     .onTapGesture {
-                                        tonePlayer.playNote(pitchClass: note.pitchClass)
+                                        tonePlayer.playNote(pitchClass: note.pitchClass, octave: octave)
                                     }
                                     .accessibilityLabel("\(note.name), string \(stringIndex + 1), fret \(fret)")
                                     .accessibilityValue(isHighlighted ? "highlighted" : "dimmed")


### PR DESCRIPTION
Tapping a cell in the iOS Fretboard Note Map called `tonePlayer.playNote(pitchClass:)`, whose overload hardcodes octave 4. As a result fret 0 and fret 12 of the same string sounded identical, and High-G vs Low-G — the toggle this very screen offers — was inaudible, since those tunings differ only in the G string's octave.

## Change
- `FretboardNoteMapView.swift`: compute the cell's octave the way Android's `FretboardNoteMapView.kt` does — `baseOctave + (openPc + fret) / 12`, using the string's base octave from `effectiveTuning` — and call the existing octave-aware overload `tonePlayer.playNote(pitchClass:octave:)`.
- `KMPBridging.swift`: add an `octaveInts` helper on `UkuleleTuning`, mirroring the existing `pitchClassInts`, to read each open string's base octave as `[Int32]`.

Reformatted one pre-existing 127-char background line to satisfy the style check.

## Verification
Self-reviewed the octave arithmetic against Android's `FretboardNoteMapView.kt` (identical `baseOctave + (openPc + fret) / 12`); confirmed the `playNote(pitchClass:octave:)` overload exists and takes `Int32`. Full xcodebuild not run (heavy) — pending. Fully offline.

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)