### PR TITLE
Fix: iOS Progression Practice strums the full chord

### DIFF
--- a/iosApp/UkuleleCompanion/Views/ProgressionPracticeView.swift
+++ b/iosApp/UkuleleCompanion/Views/ProgressionPracticeView.swift
@@ -19,12 +19,6 @@ struct ProgressionPracticeView: View {
     private let tuning: [shared.UkuleleString]
     private let cachedVoicings: [[ChordVoicing]]
 
-    private static let sampleNames = [
-        "uke_c", "uke_csharp", "uke_d", "uke_dsharp",
-        "uke_e", "uke_f", "uke_fsharp", "uke_g",
-        "uke_gsharp", "uke_a", "uke_asharp", "uke_b",
-    ]
-
     init(progression: Progression, keyRoot: Int32) {
         self.progression = progression
         self.keyRoot = keyRoot
@@ -302,12 +296,11 @@ struct ProgressionPracticeView: View {
 
     private func playVoicing(_ voicing: ChordVoicing) {
         let frets = voicing.fretInts
-        for (i, fret) in frets.enumerated() {
-            guard fret >= 0 else { continue }
-            let pc = (tuning[i].openPitchClass + Int32(fret)) % 12
-            tonePlayer.play(Self.sampleNames[Int(pc)])
-            return
+        let pitchClasses = frets.enumerated().compactMap { i, fret -> Int32? in
+            guard fret >= 0 else { return nil }
+            return (tuning[i].openPitchClass + Int32(fret)) % 12
         }
+        tonePlayer.playChord(pitchClasses: pitchClasses, strumDelayMs: 40)
     }
 
     // MARK: - Tap Tempo


### PR DESCRIPTION
`ProgressionPracticeView.playVoicing` had a `return` inside the loop meant to strum all four strings, so only the first non-muted string sounded. For C major (0 0 0 3) that was always the open G string — every chord in a practice session played the same single note, giving no harmonic feedback.

This is the identical defect fixed for `VoiceLeadingView` in #340 / PR #345; that fix updated only `VoiceLeadingView` and missed this second site.

## Change
- Collect the pitch classes for every non-muted string via `compactMap` and hand them to `TonePlayer.playChord(pitchClasses:strumDelayMs:)`, which already applies the strum delay + volume. Uses `strumDelayMs: 40` to match the `VoiceLeadingView.playVoicing` fix.
- Removed the now-unused `sampleNames` table (also dropped in the reference fix).

## Verification
- Self-review + type check: `playChord(pitchClasses: [Int32], strumDelayMs:)` matches the `Int32?` `compactMap` output; both views use the same `TonePlayer`.
- Grepped `Views/` for other `for … { … .play(); return }` playback loops — no additional sites found (this was the last of the two).
- Full `xcodebuild` not run (heavy); build verification pending CI. Fully offline change.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)