### PR TITLE
Fix: ChordPro export transposes the key with the content

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
@@ -512,7 +512,10 @@ internal fun SheetViewer(
             val shareSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
             val effectiveSheet =
                 if (transposeSemitones != 0) {
-                    sheet.copy(content = displayContent)
+                    sheet.copy(
+                        content = displayContent,
+                        key = ChordSheetTranspose.transposeKey(sheet.key, transposeSemitones),
+                    )
                 } else {
                     sheet
                 }

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ChordProExporterTest {
-
     private fun sheet(
         title: String = "Test Song",
         subtitle: String = "",
@@ -206,13 +205,16 @@ class ChordProExporterTest {
 
     @Test
     fun exportCompleteSong() {
-        val result = ChordProExporter.export(sheet(
-            title = "Amazing Grace",
-            artist = "Traditional",
-            key = "G",
-            capo = 2,
-            content = "[Verse]\n[G]Amazing grace",
-        ))
+        val result =
+            ChordProExporter.export(
+                sheet(
+                    title = "Amazing Grace",
+                    artist = "Traditional",
+                    key = "G",
+                    capo = 2,
+                    content = "[Verse]\n[G]Amazing grace",
+                ),
+            )
         assertTrue(result.contains("{title: Amazing Grace}"))
         assertTrue(result.contains("{artist: Traditional}"))
         assertTrue(result.contains("{key: G}"))
@@ -316,14 +318,15 @@ class ChordProExporterTest {
 
     @Test
     fun roundTripPreservesMetadata() {
-        val original = sheet(
-            title = "Round Trip",
-            subtitle = "A Subtitle",
-            artist = "Test Artist",
-            key = "Am",
-            capo = 4,
-            content = "[Am]Hello [G]world",
-        )
+        val original =
+            sheet(
+                title = "Round Trip",
+                subtitle = "A Subtitle",
+                artist = "Test Artist",
+                key = "Am",
+                capo = 4,
+                content = "[Am]Hello [G]world",
+            )
         val exported = ChordProExporter.export(original)
         val reimported = ChordProParser.parse(exported)
         assertEquals("Round Trip", reimported.title)
@@ -336,10 +339,11 @@ class ChordProExporterTest {
 
     @Test
     fun roundTripPreservesSections() {
-        val original = sheet(
-            title = "Sections Test",
-            content = "[Verse]\nLine 1\n[Chorus]\nLine 2\n[Bridge]\nLine 3",
-        )
+        val original =
+            sheet(
+                title = "Sections Test",
+                content = "[Verse]\nLine 1\n[Chorus]\nLine 2\n[Bridge]\nLine 3",
+            )
         val exported = ChordProExporter.export(original)
         val reimported = ChordProParser.parse(exported)
         assertTrue(reimported.content.contains("[Verse]"))
@@ -352,10 +356,11 @@ class ChordProExporterTest {
 
     @Test
     fun roundTripPreservesCustomSectionNames() {
-        val original = sheet(
-            title = "Custom Sections",
-            content = "[Verse 2]\nSecond verse lyrics",
-        )
+        val original =
+            sheet(
+                title = "Custom Sections",
+                content = "[Verse 2]\nSecond verse lyrics",
+            )
         val exported = ChordProExporter.export(original)
         val reimported = ChordProParser.parse(exported)
         assertTrue(reimported.content.contains("[Verse 2]"), "Content: ${reimported.content}")

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/data/ChordProExporterTest.kt
@@ -1,5 +1,6 @@
 package com.baijum.ukufretboard.data
 
+import com.baijum.ukufretboard.domain.ChordSheetTranspose
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -74,6 +75,23 @@ class ChordProExporterTest {
     fun exportOmitsEmptyKey() {
         val result = ChordProExporter.export(sheet(key = ""))
         assertFalse(result.contains("{key"))
+    }
+
+    // Regression for #591: exporting a transposed preview must move the key with
+    // the content. Mirrors the effectiveSheet construction in SheetViewer.kt so a
+    // +2 preview of a song in C emits {key: D}, not the stale {key: C}.
+    @Test
+    fun exportTransposedPreviewMovesKeyWithContent() {
+        val semitones = 2
+        val original = sheet(key = "C", content = "[C]Amazing grace")
+        val effectiveSheet =
+            original.copy(
+                content = ChordSheetTranspose.transpose(original.content, semitones),
+                key = ChordSheetTranspose.transposeKey(original.key, semitones),
+            )
+        val result = ChordProExporter.export(effectiveSheet)
+        assertTrue(result.contains("{key: D}"), "Key should be transposed to D: $result")
+        assertFalse(result.contains("{key: C}"), "Stale original key must not survive: $result")
     }
 
     // --- export: capo ---


### PR DESCRIPTION
## Summary

When a song is previewed transposed, the Android share sheet built `effectiveSheet` by transposing the content but copying the original `{key:}` through untouched (`SheetViewer.kt:513-518`). `ChordProExporter` then wrote the stale key next to the transposed chords, so the emitted `.cho` advertised a key the chords no longer were in. Re-importing that file stored the stale key, which wins over the detector — permanently mislabeling the song for the user and anyone the file was shared with. iOS already handles this correctly.

## Fix

Transpose the key alongside the content in `effectiveSheet`, mirroring `SongbookViewModel.applyTranspose` and the iOS `SongbookViewModel` path:

```kotlin
sheet.copy(
    content = displayContent,
    key = ChordSheetTranspose.transposeKey(sheet.key, transposeSemitones),
)
```

## Test

Added `exportTransposedPreviewMovesKeyWithContent` to `ChordProExporterTest`, which mirrors the `effectiveSheet` construction: a +2 preview of a song in C must export `{key: D}` and must not emit the stale `{key: C}`. Confirmed the assertion fails against the old key-less `copy`.

## Verification

- `./gradlew :app:compileDebugKotlin` — passes
- `./gradlew :shared:jvmTest --tests ChordProExporterTest` — passes
- ktlint: new lines clean (remaining reports are pre-existing baseline entries)
- Fully offline; no network, analytics, or accessibility changes.

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)