### PR TITLE
Fix: Share/Copy/PDF export keeps section headers

### DIFF
--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatter.kt
@@ -9,7 +9,6 @@ import com.baijum.ukufretboard.data.Progression
  * Formatting and sharing utilities for chord sheets and progressions.
  */
 object ChordSheetFormatter {
-
     /**
      * Formats a chord sheet with chords placed above the lyrics.
      *
@@ -55,6 +54,7 @@ object ChordSheetFormatter {
                             }
                             lyricLine.append(segment.text)
                         }
+
                         is ChordParser.TextSegment.Chord -> {
                             // Pad chord line to match current position
                             while (chordLine.length < lyricLine.length) {
@@ -106,8 +106,8 @@ object ChordSheetFormatter {
         return null
     }
 
-    fun extractSections(content: String): List<SectionMarker> {
-        return content.lines().mapIndexedNotNull { index, line ->
+    fun extractSections(content: String): List<SectionMarker> =
+        content.lines().mapIndexedNotNull { index, line ->
             val trimmed = line.trim()
             val match = sectionPattern.matchEntire(trimmed)
             if (match != null) {
@@ -116,7 +116,6 @@ object ChordSheetFormatter {
                 null
             }
         }
-    }
 
     /**
      * Formats a chord sheet as plain text with inline chord brackets.
@@ -152,12 +151,12 @@ object ChordSheetFormatter {
         keyRoot: Int,
     ): String {
         val keyName = Notes.enharmonicForKey(keyRoot, keyRoot)
-        val chords = progression.degrees.joinToString(" \u2013 ") { degree ->
-            val chordRoot = (keyRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
-            Notes.enharmonicForKey(chordRoot, keyRoot) + degree.quality
-        }
+        val chords =
+            progression.degrees.joinToString(" \u2013 ") { degree ->
+                val chordRoot = (keyRoot + degree.interval) % Notes.PITCH_CLASS_COUNT
+                Notes.enharmonicForKey(chordRoot, keyRoot) + degree.quality
+            }
         val numerals = progression.degrees.joinToString(" \u2013 ") { it.numeral }
         return "${progression.name} in $keyName:\n$numerals\n$chords"
     }
-
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatter.kt
@@ -37,8 +37,10 @@ object ChordSheetFormatter {
         sheet.content.lines().forEach { line ->
             val segments = ChordParser.parseLine(line)
             if (segments.isEmpty() || segments.all { it is ChordParser.TextSegment.PlainText }) {
-                // No chords — just output the line
-                sb.appendLine(line.replace(Regex("\\[[^]]*]"), ""))
+                // No chords — just output the line verbatim. This branch is
+                // chord-free by definition, so section labels like [Verse] /
+                // [Chorus] must survive (see #590).
+                sb.appendLine(line)
             } else {
                 // Build chord line and lyric line
                 val chordLine = StringBuilder()

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatterTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatterTest.kt
@@ -15,7 +15,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ChordSheetFormatterTest {
-
     private fun sheet(
         title: String = "Test Song",
         subtitle: String = "",
@@ -35,49 +34,55 @@ class ChordSheetFormatterTest {
 
     @Test
     fun chordsAboveLyricsIncludesTitle() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "My Song", content = "Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "My Song", content = "Hello"),
+            )
         assertTrue(result.startsWith("My Song"), "Should start with title: $result")
     }
 
     @Test
     fun chordsAboveLyricsIncludesArtist() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "My Song", artist = "The Band", content = "Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "My Song", artist = "The Band", content = "Hello"),
+            )
         assertTrue(result.contains("by The Band"), "Should include artist: $result")
     }
 
     @Test
     fun chordsAboveLyricsOmitsEmptyArtist() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "My Song", content = "Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "My Song", content = "Hello"),
+            )
         assertFalse(result.contains("by "), "Should not include 'by' when artist is empty")
     }
 
     @Test
     fun chordsAboveLyricsIncludesSubtitle() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "My Song", subtitle = "Words by Newton", content = "Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "My Song", subtitle = "Words by Newton", content = "Hello"),
+            )
         assertTrue(result.contains("Words by Newton"), "Should include subtitle: $result")
     }
 
     @Test
     fun chordsAboveLyricsOmitsEmptySubtitle() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "My Song", content = "Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "My Song", content = "Hello"),
+            )
         assertFalse(result.contains("Words by"), "Should not include subtitle when empty")
     }
 
     @Test
     fun chordsAboveLyricsPlacesChordsAbove() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(content = "[C]Hello [G]world")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(content = "[C]Hello [G]world"),
+            )
         val lines = result.lines()
         // Find the chord line and lyric line
         val chordLineIdx = lines.indexOfFirst { it.trimStart().startsWith("C") && it.contains("G") }
@@ -89,9 +94,10 @@ class ChordSheetFormatterTest {
 
     @Test
     fun chordsAboveLyricsStripsChordBrackets() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(content = "[Am]Lyrics here")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(content = "[Am]Lyrics here"),
+            )
         assertFalse(result.contains("[Am]"), "Brackets should be stripped")
         assertTrue(result.contains("Lyrics here"), "Lyrics should remain")
         assertTrue(result.contains("Am"), "Chord name should appear (above)")
@@ -99,25 +105,28 @@ class ChordSheetFormatterTest {
 
     @Test
     fun plainLineWithoutChordsPassesThrough() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(content = "Just plain text")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(content = "Just plain text"),
+            )
         assertTrue(result.contains("Just plain text"), "Plain text should pass through")
     }
 
     @Test
     fun emptyContentProducesHeaderOnly() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(title = "Empty", content = "")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(title = "Empty", content = ""),
+            )
         assertTrue(result.contains("Empty"), "Should contain title")
     }
 
     @Test
     fun multipleLinesChordsAboveLyrics() {
-        val result = ChordSheetFormatter.formatChordsAboveLyrics(
-            sheet(content = "[C]Line one\n[Am]Line two")
-        )
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(content = "[C]Line one\n[Am]Line two"),
+            )
         assertTrue(result.contains("Line one"), "First line lyrics present")
         assertTrue(result.contains("Line two"), "Second line lyrics present")
         assertTrue(result.contains("C"), "C chord present")
@@ -142,41 +151,46 @@ class ChordSheetFormatterTest {
 
     @Test
     fun plainTextIncludesTitle() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(title = "My Song", content = "[C]Hello")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(title = "My Song", content = "[C]Hello"),
+            )
         assertTrue(result.startsWith("My Song"), "Should start with title")
     }
 
     @Test
     fun plainTextIncludesArtist() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(title = "Song", artist = "Artist", content = "text")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(title = "Song", artist = "Artist", content = "text"),
+            )
         assertTrue(result.contains("by Artist"))
     }
 
     @Test
     fun plainTextOmitsEmptyArtist() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(title = "Song", content = "text")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(title = "Song", content = "text"),
+            )
         assertFalse(result.contains("by "))
     }
 
     @Test
     fun plainTextIncludesSubtitle() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(title = "Song", subtitle = "A Subtitle", content = "text")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(title = "Song", subtitle = "A Subtitle", content = "text"),
+            )
         assertTrue(result.contains("A Subtitle"), "Should include subtitle: $result")
     }
 
     @Test
     fun plainTextOmitsEmptySubtitle() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(title = "Song", content = "text")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(title = "Song", content = "text"),
+            )
         val lines = result.lines()
         assertEquals("Song", lines[0], "First line should be title")
         assertTrue(lines[1].isEmpty(), "Second line should be blank when no subtitle/artist")
@@ -184,18 +198,20 @@ class ChordSheetFormatterTest {
 
     @Test
     fun plainTextPreservesChordBrackets() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(content = "[Am]Hello [G]world")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(content = "[Am]Hello [G]world"),
+            )
         assertTrue(result.contains("[Am]"), "Chord brackets should be preserved")
         assertTrue(result.contains("[G]"), "Chord brackets should be preserved")
     }
 
     @Test
     fun plainTextPreservesLineBreaks() {
-        val result = ChordSheetFormatter.formatPlainText(
-            sheet(content = "Line 1\nLine 2\nLine 3")
-        )
+        val result =
+            ChordSheetFormatter.formatPlainText(
+                sheet(content = "Line 1\nLine 2\nLine 3"),
+            )
         assertTrue(result.contains("Line 1"))
         assertTrue(result.contains("Line 2"))
         assertTrue(result.contains("Line 3"))
@@ -205,13 +221,15 @@ class ChordSheetFormatterTest {
 
     @Test
     fun progressionIncludesNameAndKey() {
-        val prog = Progression(
-            "Pop", "desc",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(7, "", "V"),
-            ),
-        )
+        val prog =
+            Progression(
+                "Pop",
+                "desc",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(7, "", "V"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         assertTrue(result.contains("Pop"), "Should contain progression name")
         assertTrue(result.contains("C"), "Should contain key name C")
@@ -219,15 +237,17 @@ class ChordSheetFormatterTest {
 
     @Test
     fun progressionInCMajorShowsCorrectChords() {
-        val prog = Progression(
-            "I-IV-V-I", "test",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(5, "", "IV"),
-                ChordDegree(7, "", "V"),
-                ChordDegree(0, "", "I"),
-            ),
-        )
+        val prog =
+            Progression(
+                "I-IV-V-I",
+                "test",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(5, "", "IV"),
+                    ChordDegree(7, "", "V"),
+                    ChordDegree(0, "", "I"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         // Check chord names
         assertTrue(result.contains("C"), "Should contain C")
@@ -237,15 +257,17 @@ class ChordSheetFormatterTest {
 
     @Test
     fun progressionShowsRomanNumerals() {
-        val prog = Progression(
-            "test", "desc",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(9, "m", "vi"),
-                ChordDegree(5, "", "IV"),
-                ChordDegree(7, "", "V"),
-            ),
-        )
+        val prog =
+            Progression(
+                "test",
+                "desc",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(9, "m", "vi"),
+                    ChordDegree(5, "", "IV"),
+                    ChordDegree(7, "", "V"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         assertTrue(result.contains("I"), "Should contain I")
         assertTrue(result.contains("vi"), "Should contain vi")
@@ -255,14 +277,16 @@ class ChordSheetFormatterTest {
 
     @Test
     fun progressionInGMajor() {
-        val prog = Progression(
-            "test", "desc",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(5, "", "IV"),
-                ChordDegree(7, "", "V"),
-            ),
-        )
+        val prog =
+            Progression(
+                "test",
+                "desc",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(5, "", "IV"),
+                    ChordDegree(7, "", "V"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 7) // G major
         assertTrue(result.contains("G"), "Should contain G as key/root")
         assertTrue(result.contains("D"), "V of G is D")
@@ -270,36 +294,42 @@ class ChordSheetFormatterTest {
 
     @Test
     fun progressionWithMinorChords() {
-        val prog = Progression(
-            "test", "desc",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(9, "m", "vi"),
-            ),
-        )
+        val prog =
+            Progression(
+                "test",
+                "desc",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(9, "m", "vi"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         assertTrue(result.contains("Am"), "vi of C should be Am")
     }
 
     @Test
     fun progressionUsesEnDashSeparator() {
-        val prog = Progression(
-            "test", "desc",
-            listOf(
-                ChordDegree(0, "", "I"),
-                ChordDegree(5, "", "IV"),
-            ),
-        )
+        val prog =
+            Progression(
+                "test",
+                "desc",
+                listOf(
+                    ChordDegree(0, "", "I"),
+                    ChordDegree(5, "", "IV"),
+                ),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         assertTrue(result.contains("\u2013"), "Should use en dash separator")
     }
 
     @Test
     fun singleChordProgression() {
-        val prog = Progression(
-            "One Chord", "desc",
-            listOf(ChordDegree(0, "", "I")),
-        )
+        val prog =
+            Progression(
+                "One Chord",
+                "desc",
+                listOf(ChordDegree(0, "", "I")),
+            )
         val result = ChordSheetFormatter.formatProgression(prog, 0)
         assertTrue(result.contains("C"), "Should contain chord C")
         assertFalse(result.contains("\u2013"), "No separator for single chord")

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatterTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/ChordSheetFormatterTest.kt
@@ -124,6 +124,20 @@ class ChordSheetFormatterTest {
         assertTrue(result.contains("Am"), "Am chord present")
     }
 
+    @Test
+    fun chordsAboveLyricsKeepsSectionHeaders() {
+        // Regression for #590: section labels are chord-free lines, so the
+        // "no chords" branch must emit them verbatim rather than stripping the
+        // bracket token. Both label shapes reach this branch:
+        // [Chorus] (root C + "horus", invalid chord) and [Verse] (V not A-G).
+        val result =
+            ChordSheetFormatter.formatChordsAboveLyrics(
+                sheet(content = "[Verse]\nLine A\n[Chorus]\nLine B"),
+            )
+        assertTrue(result.contains("[Verse]"), "Verse header should survive: $result")
+        assertTrue(result.contains("[Chorus]"), "Chorus header should survive: $result")
+    }
+
     // --- formatPlainText() ---
 
     @Test


### PR DESCRIPTION
`formatChordsAboveLyrics` (shared, behind Share as text / Copy to clipboard / Export as PDF on both platforms) reached its "no chords" branch for any chord-free line and stripped every bracket token from it via `line.replace(Regex("\\[[^]]*]"), "")`. That branch is chord-free by definition, so the regex could never remove a chord — the only thing it ever deleted was a section label (`[Verse]`, `[Chorus]`, `[Bridge]`, `[Intro]`, …), silently erasing song structure from every export while the app still shows those headings on screen and in section navigation.

## Change
- Emit the line verbatim in that branch (`sb.appendLine(line)`).
- Add a regression test (`chordsAboveLyricsKeepsSectionHeaders`) asserting `[Verse]` and `[Chorus]` survive `formatChordsAboveLyrics`. Confirmed it fails when the old strip line is reintroduced (`AssertionError`), so it discriminates.

## Verification
- `./gradlew :shared:jvmTest --tests ChordSheetFormatterTest` — passing
- `./gradlew :app:compileDebugKotlin` — passing
- No platform imports added to commonMain; fully offline; no new ktlint violations beyond baseline.

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)