### PR TITLE
Fix: neural strong-disagreement override is reachable again

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/PitchMonitorViewModel.kt
@@ -10,6 +10,7 @@ import com.baijum.ukufretboard.domain.ChordDetector
 import com.baijum.ukufretboard.domain.ChordFrameInput
 import com.baijum.ukufretboard.domain.FrameGate
 import com.baijum.ukufretboard.domain.FrameGateResult
+import com.baijum.ukufretboard.domain.NeuralArbitrator
 import com.baijum.ukufretboard.domain.NeuralPitchResult
 import com.baijum.ukufretboard.domain.NeuralPitchSupervisor
 import com.baijum.ukufretboard.domain.PitchDetector
@@ -480,14 +481,16 @@ class PitchMonitorViewModel : ViewModel() {
 
         if (isOctaveRelation(yinResult.frequencyHz, neuralResult.frequencyHz) &&
             neuralResult.confidence >= 0.85 &&
-            yinResult.confidence >= 0.12
+            yinResult.confidence >= PitchDetector.DEFAULT_THRESHOLD *
+            NeuralArbitrator.YIN_CONFIDENCE_OCTAVE_FRACTION
         ) {
             return yinResult.copy(frequencyHz = neuralResult.frequencyHz)
         }
 
         return if (semitoneGap >= ARBITRATION_STRONG_SEMITONES &&
             neuralResult.confidence >= 0.93 &&
-            yinResult.confidence >= 0.16
+            yinResult.confidence >= PitchDetector.DEFAULT_THRESHOLD *
+            NeuralArbitrator.YIN_CONFIDENCE_STRONG_FRACTION
         ) {
             yinResult.copy(frequencyHz = neuralResult.frequencyHz)
         } else {

--- a/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/PitchMonitorViewModel.swift
@@ -407,12 +407,19 @@ final class PitchMonitorViewModel: ObservableObject {
         if semitoneGap <= Self.arbitrationIgnoreSemitones { return yinFreq }
         if neuralConsistencyFrames < Self.neuralConsistencyRequired { return yinFreq }
 
+        // YIN confidence is a CMND dip value (lower is better) that the
+        // detector only ever emits strictly below its threshold, so these
+        // gates are expressed as fractions of that threshold to stay in the
+        // reachable [0, threshold) range — see #603.
+        let yinThreshold = PitchDetector.shared.DEFAULT_THRESHOLD
         if Self.isOctaveRelation(yinFreq, neuralResult.frequencyHz)
-            && neuralResult.confidence >= 0.85 && yinConf >= 0.12 {
+            && neuralResult.confidence >= 0.85
+            && yinConf >= yinThreshold * NeuralArbitrator.companion.YIN_CONFIDENCE_OCTAVE_FRACTION {
             return neuralResult.frequencyHz
         }
         if semitoneGap >= Self.arbitrationStrongSemitones
-            && neuralResult.confidence >= 0.93 && yinConf >= 0.16 {
+            && neuralResult.confidence >= 0.93
+            && yinConf >= yinThreshold * NeuralArbitrator.companion.YIN_CONFIDENCE_STRONG_FRACTION {
             return neuralResult.frequencyHz
         }
         return yinFreq

--- a/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/TunerViewModel.swift
@@ -264,7 +264,8 @@ final class TunerViewModel: ObservableObject {
 
             let arbitration = neuralArbitrator.arbitrate(
                 yinResult: result,
-                neuralResult: neuralResult
+                neuralResult: neuralResult,
+                yinThreshold: PitchDetector.shared.DEFAULT_THRESHOLD
             )
             let finalHz = arbitration.frequencyHz
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
@@ -64,6 +64,23 @@ class NeuralArbitrator {
         /** Required consecutive similar neural readings before override. */
         const val CONSISTENCY_FRAMES = 2
 
+        /**
+         * YIN confidence gates for octave correction and strong-disagreement
+         * override, expressed as fractions of the detector's CMND threshold.
+         *
+         * YIN confidence is a CMND dip value where **lower is better**, and the
+         * detector only ever emits values strictly below its threshold (see
+         * [PitchDetector.detect]). Expressing these gates relative to that same
+         * threshold keeps them inside the reachable `[0, threshold)` range, so
+         * they can never silently drift out of it (see #603). Strong
+         * disagreement demands a poorer (higher) YIN confidence than octave
+         * correction, hence the larger fraction.
+         */
+        const val YIN_CONFIDENCE_OCTAVE_FRACTION = 0.8
+
+        /** @see YIN_CONFIDENCE_OCTAVE_FRACTION */
+        const val YIN_CONFIDENCE_STRONG_FRACTION = 0.95
+
         fun semitoneDistance(aHz: Double, bHz: Double): Double {
             if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
             return abs(12.0 * log2(aHz / bHz))
@@ -160,10 +177,16 @@ class NeuralArbitrator {
      * 5. Strong disagreement (≥ [ARBITRATION_STRONG_SEMITONES]) with neural
      *    confidence ≥ 0.93 → override with neural Hz.
      * 6. Otherwise → use YIN.
+     *
+     * @param yinThreshold the CMND threshold the YIN detector was run with
+     *   (default [PitchDetector.DEFAULT_THRESHOLD]). The YIN-confidence gates
+     *   are fractions of this value so they stay inside the reachable
+     *   `[0, yinThreshold)` range — see [YIN_CONFIDENCE_OCTAVE_FRACTION].
      */
     fun arbitrate(
         yinResult: PitchResult,
         neuralResult: NeuralPitchResult?,
+        yinThreshold: Double = PitchDetector.DEFAULT_THRESHOLD,
     ): ArbitrationResult {
         if (neuralResult == null) {
             return ArbitrationResult(
@@ -195,7 +218,7 @@ class NeuralArbitrator {
 
         if (isOctaveRelation(yinResult.frequencyHz, neuralResult.frequencyHz) &&
             neuralResult.confidence >= 0.85 &&
-            yinResult.confidence >= 0.12
+            yinResult.confidence >= yinThreshold * YIN_CONFIDENCE_OCTAVE_FRACTION
         ) {
             return ArbitrationResult(
                 frequencyHz = neuralResult.frequencyHz,
@@ -207,7 +230,7 @@ class NeuralArbitrator {
 
         return if (semitoneGap >= ARBITRATION_STRONG_SEMITONES &&
             neuralResult.confidence >= 0.93 &&
-            yinResult.confidence >= 0.16
+            yinResult.confidence >= yinThreshold * YIN_CONFIDENCE_STRONG_FRACTION
         ) {
             ArbitrationResult(
                 frequencyHz = neuralResult.frequencyHz,

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrator.kt
@@ -44,7 +44,6 @@ enum class PitchSource { YIN, NEURAL }
  * ```
  */
 class NeuralArbitrator {
-
     companion object {
         /** Run neural inference every N audio frames. */
         const val SUPERVISOR_INTERVAL = 5
@@ -81,12 +80,18 @@ class NeuralArbitrator {
         /** @see YIN_CONFIDENCE_OCTAVE_FRACTION */
         const val YIN_CONFIDENCE_STRONG_FRACTION = 0.95
 
-        fun semitoneDistance(aHz: Double, bHz: Double): Double {
+        fun semitoneDistance(
+            aHz: Double,
+            bHz: Double,
+        ): Double {
             if (aHz <= 0.0 || bHz <= 0.0) return Double.MAX_VALUE
             return abs(12.0 * log2(aHz / bHz))
         }
 
-        fun isOctaveRelation(aHz: Double, bHz: Double): Boolean {
+        fun isOctaveRelation(
+            aHz: Double,
+            bHz: Double,
+        ): Boolean {
             if (aHz <= 0.0 || bHz <= 0.0) return false
             val semitones = semitoneDistance(aHz, bHz)
             return abs(semitones - 12.0) <= 1.0 || abs(semitones - 24.0) <= 1.0
@@ -160,9 +165,7 @@ class NeuralArbitrator {
      * Returns the most recent neural result if it is still within the
      * [RESULT_TTL_FRAMES] window, or `null` if stale / unavailable.
      */
-    fun currentResult(): NeuralPitchResult? {
-        return if (resultAgeFrames <= RESULT_TTL_FRAMES) lastResult else null
-    }
+    fun currentResult(): NeuralPitchResult? = if (resultAgeFrames <= RESULT_TTL_FRAMES) lastResult else null
 
     // --- Arbitration ---------------------------------------------------------
 
@@ -270,13 +273,14 @@ class NeuralArbitrator {
         }
 
         val previous = lastFrequencyForConsistency
-        consistencyFrames = if (previous != null &&
-            semitoneDistance(previous, neuralFrequencyHz) <= 0.5
-        ) {
-            consistencyFrames + 1
-        } else {
-            1
-        }
+        consistencyFrames =
+            if (previous != null &&
+                semitoneDistance(previous, neuralFrequencyHz) <= 0.5
+            ) {
+                consistencyFrames + 1
+            } else {
+                1
+            }
         lastFrequencyForConsistency = neuralFrequencyHz
     }
 }

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
@@ -36,7 +36,6 @@ data class PitchResult(
  * This is a pure-Kotlin implementation with no external dependencies.
  */
 object PitchDetector {
-
     /**
      * Default CMND threshold.
      *
@@ -112,7 +111,10 @@ object PitchDetector {
         }
     }
 
-    private fun ensureDiffBuffers(sampleSize: Int, maxLag: Int) {
+    private fun ensureDiffBuffers(
+        sampleSize: Int,
+        maxLag: Int,
+    ) {
         val prefixSize = sampleSize + 1
         val diffSize = maxLag + 1
         if (sampleSize != cachedSampleSize) {
@@ -299,8 +301,9 @@ object PitchDetector {
     // --- Fast YIN helpers ---------------------------------------------------
 
     /**
-     * Computes the squared difference function using FFT-based
-     * cross-correlation (O(N log N) instead of O(N * maxLag)).
+     * Computes the squared difference function into [outDiff] using FFT-based
+     * cross-correlation (O(N log N) instead of O(N * maxLag)). Must be called
+     * while [bufferLock] is held.
      *
      * Uses the decomposition:
      *   d(tau) = E0 + E(tau) - 2 * r(tau)
@@ -312,11 +315,7 @@ object PitchDetector {
      * @param samples Audio samples of length N.
      * @param halfLen Window length W = N/2.
      * @param maxLag  Maximum lag to compute.
-     * @return A [FloatArray] of size maxLag+1 containing d(0)..d(maxLag).
-     */
-    /**
-     * Computes the squared difference function into [outDiff] using
-     * FFT-based cross-correlation. Must be called while [bufferLock] is held.
+     * @param outDiff Output buffer of size maxLag+1, filled with d(0)..d(maxLag).
      */
     private fun computeDifferenceFunctionFFTLocked(
         samples: FloatArray,
@@ -342,8 +341,10 @@ object PitchDetector {
         FFTProcessor.fft(fftSigReal, fftSigImag)
 
         for (i in 0 until fftSize) {
-            val ar = fftRefReal[i]; val ai = fftRefImag[i]
-            val br = fftSigReal[i]; val bi = fftSigImag[i]
+            val ar = fftRefReal[i]
+            val ai = fftRefImag[i]
+            val br = fftSigReal[i]
+            val bi = fftSigImag[i]
             fftRefReal[i] = ar * br + ai * bi
             fftRefImag[i] = ar * bi - ai * br
         }
@@ -352,9 +353,10 @@ object PitchDetector {
 
         for (tau in 1..maxLag) {
             val energyTau = prefixSq[tau + halfLen] - prefixSq[tau]
-            outDiff[tau] = (energy0 + energyTau - 2.0 * fftRefReal[tau].toDouble())
-                .coerceAtLeast(0.0)
-                .toFloat()
+            outDiff[tau] =
+                (energy0 + energyTau - 2.0 * fftRefReal[tau].toDouble())
+                    .coerceAtLeast(0.0)
+                    .toFloat()
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
+++ b/shared/src/commonMain/kotlin/com/baijum/ukufretboard/domain/PitchDetector.kt
@@ -55,15 +55,6 @@ object PitchDetector {
     private const val SILENCE_THRESHOLD = 0.01f
 
     /**
-     * Maximum CMNDF dip value considered reliable.
-     *
-     * During clean sustain, `cmnd[bestTau]` is typically 0.01–0.10.
-     * During attack transients it jumps to 0.3–0.8. Frames where the
-     * best dip exceeds this value are rejected as aperiodic.
-     */
-    private const val CONFIDENCE_REJECT_THRESHOLD = 0.30
-
-    /**
      * Neighbourhood radius (in samples) for the Best Local Estimate
      * refinement (YIN paper, Step 5). The raw difference function is
      * searched within ±[BEST_LOCAL_RADIUS] of the CMND-selected lag
@@ -207,10 +198,11 @@ object PitchDetector {
 
             if (bestTau < 0) return@withLock null
 
-            // --- Step 4: Confidence gate ------------------------------------
-            if (cmnd[bestTau] > CONFIDENCE_REJECT_THRESHOLD) return@withLock null
-
-            // --- Step 5: Best Local Estimate (YIN paper, Step 5) ------------
+            // --- Step 4: Best Local Estimate (YIN paper, Step 5) ------------
+            // Note: there is no separate confidence-reject gate here. By
+            // construction `findFirstDipBelow` only returns a tau whose CMND
+            // value is strictly below `threshold` (≤ DEFAULT_THRESHOLD = 0.15),
+            // so any `cmnd[bestTau] > 0.30` test could never fire (see #603).
             var localBestTau = bestTau
             var localBestVal = diff[bestTau]
             val searchStart = (bestTau - BEST_LOCAL_RADIUS).coerceAtLeast(minLag)

--- a/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrationReachabilityTest.kt
+++ b/shared/src/commonTest/kotlin/com/baijum/ukufretboard/domain/NeuralArbitrationReachabilityTest.kt
@@ -1,0 +1,139 @@
+package com.baijum.ukufretboard.domain
+
+import kotlin.math.PI
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Reachability tests for the neural arbitrator's YIN-confidence gates.
+ *
+ * Regression coverage for #603: the "strong disagreement" override once
+ * required `yinResult.confidence >= 0.16`, but [PitchDetector] can never emit a
+ * confidence that high — [PitchResult.confidence] is the CMND dip value, and by
+ * construction it is always strictly below the detector's threshold
+ * ([PitchDetector.DEFAULT_THRESHOLD] = 0.15). The gate was therefore dead code.
+ *
+ * Unlike [NeuralArbitratorTest], these tests never hand-build a [PitchResult].
+ * They feed **real synthesised audio** through [PitchDetector.detect] and use
+ * the confidence it actually produces, so an out-of-range constant makes the
+ * suite fail instead of silently passing.
+ */
+class NeuralArbitrationReachabilityTest {
+    private companion object {
+        const val SAMPLE_RATE = 44100
+        const val FRAME_SIZE = 4096
+        const val TARGET_HZ = 196.0 // G3 — a low string, where octave latching bites.
+        const val AMPLITUDE = 0.5f
+    }
+
+    /**
+     * A sine plus deterministic broadband noise. Increasing [noiseAmplitude]
+     * degrades periodicity, which raises the CMND dip value (YIN confidence)
+     * toward — but never past — the detector threshold.
+     */
+    private fun noisySine(
+        frequencyHz: Double,
+        noiseAmplitude: Float,
+        seed: Int,
+    ): FloatArray {
+        val random = Random(seed)
+        val omega = 2.0 * PI * frequencyHz / SAMPLE_RATE
+        return FloatArray(FRAME_SIZE) { i ->
+            val tone = AMPLITUDE * sin(omega * i).toFloat()
+            val noise = (random.nextFloat() * 2f - 1f) * noiseAmplitude
+            tone + noise
+        }
+    }
+
+    /**
+     * Detects [TARGET_HZ] across a fine, deterministic sweep of noise levels
+     * and returns every real [PitchResult] the detector emitted. The sweep
+     * spans clean sine (confidence ≈ 0) up to noise levels that push the CMND
+     * dip close to the threshold. Shared by every test so the "reachable"
+     * assertion and the override case always agree on the same signals.
+     */
+    private fun detections(): List<PitchResult> {
+        val results = mutableListOf<PitchResult>()
+        var noise = 0.0f
+        while (noise <= 0.6f) {
+            val samples = noisySine(TARGET_HZ, noise, seed = noise.toRawBits())
+            PitchDetector.detect(samples, SAMPLE_RATE)?.let { results += it }
+            noise += 0.005f
+        }
+        return results
+    }
+
+    private val strongGate: Double
+        get() = PitchDetector.DEFAULT_THRESHOLD * NeuralArbitrator.YIN_CONFIDENCE_STRONG_FRACTION
+
+    @Test
+    fun realDetectorConfidenceStaysBelowThreshold() {
+        val results = detections()
+        assertTrue(results.isNotEmpty(), "expected at least one real detection across the sweep")
+        // The core structural invariant: confidence is a sub-threshold CMND dip.
+        // Any arbitration gate at or above the threshold is therefore dead code.
+        results.forEach { r ->
+            assertTrue(
+                r.confidence >= 0.0 && r.confidence < PitchDetector.DEFAULT_THRESHOLD,
+                "real YIN confidence must lie in [0, ${PitchDetector.DEFAULT_THRESHOLD}) but was ${r.confidence}",
+            )
+        }
+    }
+
+    @Test
+    fun strongDisagreementGateIsReachableByRealAudio() {
+        // A gate expressed as a fraction of the threshold necessarily sits
+        // inside the reachable [0, threshold) band. Guard against a future edit
+        // that pushes it back out (the #603 regression).
+        assertTrue(
+            strongGate < PitchDetector.DEFAULT_THRESHOLD,
+            "strong-disagreement gate $strongGate must be below the threshold to ever fire",
+        )
+
+        val maxConfidence = detections().maxOfOrNull { it.confidence }
+        assertNotNull(maxConfidence, "expected at least one real detection")
+        assertTrue(
+            maxConfidence >= strongGate,
+            "real audio should be able to reach the strong-disagreement gate " +
+                "($strongGate) but the highest real confidence was $maxConfidence",
+        )
+    }
+
+    @Test
+    fun realAudioDrivesStrongDisagreementOverride() {
+        // The highest-confidence real detection clears the strong-disagreement
+        // gate. With the buggy 0.16 constant no real signal could, and this
+        // search would come up empty — exactly the signal #603 asks for.
+        val yin = detections().filter { it.confidence >= strongGate }.maxByOrNull { it.confidence }
+        assertNotNull(yin, "no real detection reached the strong-disagreement gate $strongGate")
+
+        // Neural reports a fundamental ~5 semitones below the YIN pitch — a
+        // strong, non-octave disagreement — with high confidence.
+        val neuralHz = yin.frequencyHz / 2.0.pow(5.0 / 12.0)
+        val neural = NeuralPitchResult(frequencyHz = neuralHz, confidence = 0.95)
+
+        val arb = NeuralArbitrator()
+        // Prime the consistency window so the override is eligible.
+        repeat(NeuralArbitrator.CONSISTENCY_FRAMES + 1) {
+            advanceToInferenceFrame(arb)
+            arb.onInferenceResult(neural)
+        }
+
+        val decision = arb.arbitrate(yin, neural)
+        assertTrue(
+            decision.source == PitchSource.NEURAL && decision.reason == "strong_disagreement",
+            "expected neural strong-disagreement override, got ${decision.source}/${decision.reason}",
+        )
+        assertTrue(decision.frequencyHz == neuralHz, "override should adopt the neural frequency")
+    }
+
+    private fun advanceToInferenceFrame(arb: NeuralArbitrator) {
+        while (!arb.shouldRunInference()) {
+            // advance frame counter to the next inference tick
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The neural arbitrator's **strong-disagreement** override branch was dead code. It required `yinResult.confidence >= 0.16`, but `PitchResult.confidence` is the YIN CMND dip value (**lower is better**) and the detector only ever emits values strictly below its threshold (`DEFAULT_THRESHOLD = 0.15`). So `confidence ∈ [0, 0.15)` and `>= 0.16` was unsatisfiable — on both platforms, in both the Tuner and the Pitch Monitor. Octave correction uses `>= 0.12`, which stays reachable, masking the failure.

Impact: when YIN latches onto a non-octave partial (e.g. a low-G/C string) while the SwiftF0 supervisor confidently reports the true fundamental, the arbitrator was supposed to override YIN — instead it always kept YIN, so the tuner named the wrong note.

## What changed

- **`NeuralArbitrator.kt`** — `arbitrate` now takes the detector's `yinThreshold` (default `PitchDetector.DEFAULT_THRESHOLD`). Both YIN gates are expressed as fractions of it via new constants: `YIN_CONFIDENCE_OCTAVE_FRACTION = 0.8` (→ 0.12, unchanged) and `YIN_CONFIDENCE_STRONG_FRACTION = 0.95` (→ 0.1425, now reachable). This keeps them inside `[0, threshold)` so they can't drift out of range again.
- **`PitchDetector.kt`** — removed the dead `cmnd[bestTau] > CONFIDENCE_REJECT_THRESHOLD` reject check (and its now-unused `0.30` constant); `findFirstDipBelow` only ever returns a tau strictly below the threshold, so a `> 0.30` test could never fire.
- **Pitch Monitor duplicates** — the inline `arbitrate` copies in `PitchMonitorViewModel.kt` and `PitchMonitorViewModel.swift` get the same threshold-relative gates; the iOS `TunerViewModel.swift` call site passes the threshold through.
- **New test** — `NeuralArbitrationReachabilityTest.kt` feeds **real synthesised audio** (a deterministic noisy-sine sweep) through `PitchDetector.detect` and drives the arbitrator with the confidence it actually produces, asserting (a) real confidence always stays in `[0, threshold)` and (b) real audio can reach the strong-disagreement gate and trigger the override. An unreachable gate constant now fails the suite instead of passing silently.

No per-frame allocation added — only constants, thresholds, and a primitive multiply in the audio path. Fully offline.

## Verification

- `./gradlew :shared:jvmTest` — pass (full shared suite)
- `./gradlew :app:compileDebugKotlin` — pass
- `scripts/ktlint.sh` ratchet — pass (no new violations)

iOS build not run in this environment; Swift changes follow the existing `PitchDetector.shared.DEFAULT_THRESHOLD` / `X.companion.CONST` interop patterns already used in the codebase.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)