### PR TITLE
Fix: iOS playback volume survives backup export and restore

### DIFF
--- a/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
+++ b/iosApp/UkuleleCompanion/Helpers/BackupRestoreManager.swift
@@ -612,7 +612,9 @@ private enum PracticeTimerCoder {
     }
 }
 
-private enum SettingsCoder {
+// Not `private`: the settings round trip (export → build → extract → import) is
+// exercised by RepositoryBackupTests via `@testable import` (#599).
+enum SettingsCoder {
     private static let themeToKMP: [String: String] = [
         "Light": "LIGHT", "Dark": "DARK",
         "System": "SYSTEM", "High Contrast": "HIGH_CONTRAST",

--- a/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
+++ b/iosApp/UkuleleCompanion/Repositories/SettingsRepository.swift
@@ -66,7 +66,10 @@ final class SettingsRepository {
     func exportSettings() -> [String: Any] {
         [
             "sound_enabled": defaults.object(forKey: "sound_enabled") as? Bool ?? true,
-            "volume": defaults.object(forKey: "volume") as? Float ?? 1.0,
+            // Store as Double: the backup dictionary crosses a [String: Any] boundary, and
+            // `Any(Float) as? Double` is always nil (Swift `as?` does no numeric conversion
+            // unless the value arrived as an NSNumber). BackupRestoreManager reads this as Double.
+            "volume": Double(defaults.object(forKey: "volume") as? Float ?? 1.0),
             "note_duration_ms": defaults.object(forKey: "note_duration_ms") as? Int ?? 600,
             "strum_delay_ms": defaults.object(forKey: "strum_delay_ms") as? Int ?? 50,
             "play_on_tap": defaults.bool(forKey: "play_on_tap"),
@@ -96,7 +99,8 @@ final class SettingsRepository {
 
     func importSettings(_ dict: [String: Any]) {
         if let v = dict["sound_enabled"] as? Bool { defaults.set(v, forKey: "sound_enabled") }
-        if let v = dict["volume"] as? Float { defaults.set(v, forKey: "volume") }
+        // Read as Double to match the export type; `Any(Double) as? Float` is always nil.
+        if let v = dict["volume"] as? Double { defaults.set(Float(v), forKey: "volume") }
         if let v = dict["note_duration_ms"] as? Int { defaults.set(v, forKey: "note_duration_ms") }
         if let v = dict["strum_delay_ms"] as? Int { defaults.set(v, forKey: "strum_delay_ms") }
         if let v = dict["play_on_tap"] as? Bool { defaults.set(v, forKey: "play_on_tap") }

--- a/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
+++ b/iosApp/UkuleleCompanionTests/RepositoryBackupTests.swift
@@ -293,4 +293,38 @@ final class RepositoryBackupTests: XCTestCase {
 
         XCTAssertEqual(repository.getAll().map(\.title), ["Amazing Grace"])
     }
+
+    // MARK: - Settings round trip
+
+    /// A non-default playback volume must survive the full settings backup round
+    /// trip. The value crosses two `[String: Any]` boundaries — export → build,
+    /// then extract → import — and `as?` does no numeric conversion between two
+    /// Swift-native numeric types boxed in `Any`, so a Float/Double mismatch on
+    /// either hop silently drops the value and the app reverts to its default
+    /// (#599). Both ends must agree on `Double`.
+    func testVolumeSurvivesSettingsBackupRoundTrip() {
+        // SettingsRepository stores settings in its own suite, not `.standard`.
+        let suite = UserDefaults(suiteName: "app_settings") ?? .standard
+        let saved = suite.object(forKey: "volume")
+        defer {
+            if let saved { suite.set(saved, forKey: "volume") } else { suite.removeObject(forKey: "volume") }
+        }
+
+        // A volume the user chose — distinct from every default in the pipeline
+        // (export 1.0, build 0.7, restore 1.0) so a dropped value cannot masquerade.
+        suite.set(Float(0.2), forKey: "volume")
+
+        let repository = SettingsRepository()
+        let exported = repository.exportSettings()
+        let roundTripped = SettingsCoder.extract(SettingsCoder.build(exported))
+
+        // Clear the stored value so only the import can restore it.
+        suite.removeObject(forKey: "volume")
+        repository.importSettings(roundTripped)
+
+        XCTAssertEqual(
+            repository.load().volume, 0.2, accuracy: 0.0001,
+            "playback volume must survive export → build → extract → import"
+        )
+    }
 }


### PR DESCRIPTION
## Problem

iOS playback volume was silently dropped in **both** directions of the backup round trip (#599). The value crosses a `[String: Any]` boundary between `SettingsRepository` and `SettingsCoder`, and Swift's `as?` performs no numeric conversion between two Swift-native numeric types boxed in `Any` (it only bridges when the value arrived as an `NSNumber`).

- **Export**: `SettingsRepository.exportSettings` put a `Float`, but `SettingsCoder.build` read `as? Double` → `nil` → every backup recorded the `0.7` default.
- **Import**: `SettingsCoder.extract` emitted a `Double`, but `SettingsRepository.importSettings` read `as? Float` → `nil` → nothing was written, so restore left volume at the `1.0` default.

## Fix

Settle on `Double` at every dictionary boundary:
- `exportSettings` writes `Double(volume)`.
- `importSettings` reads `as? Double`, stores `Float`.
- `SettingsCoder` already used `Double` on both ends — no change to its volume logic.

## Test

Adds `testVolumeSurvivesSettingsBackupRoundTrip` in `RepositoryBackupTests`, exercising `exportSettings → SettingsCoder.build → SettingsCoder.extract → importSettings` and asserting a non-default `0.2` volume survives. `SettingsCoder` is widened from `private` to internal so the test reaches it via `@testable import`. The test discriminates: with either cast un-fixed it lands on a pipeline default (1.0/0.7), not 0.2.

The melody-duration coder in `BackupRestoreManager.swift` was left untouched.

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings backup and restore so playback volume values are preserved accurately during export and import.
* **Tests**
  * Added coverage for complete settings backup round trips, including volume preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->