### PR TITLE
Fix: auto-scroll honours fractional speeds (0.5x, 1.5x)

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/AutoScrollAccumulator.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/AutoScrollAccumulator.kt
@@ -1,0 +1,33 @@
+package com.baijum.ukufretboard.ui.songbook
+
+/**
+ * Accumulates a fractional auto-scroll speed (pixels per tick) and hands back
+ * whole-pixel steps, carrying the sub-pixel remainder to later ticks.
+ *
+ * `scrollState.animateScrollTo` only accepts an integer pixel offset, so naively
+ * calling `speed.toInt().coerceAtLeast(1)` truncated every fractional speed up to
+ * at least one pixel per tick — making 0.5x indistinguishable from 1x and every
+ * half-step in Performance mode inert (see issue #583). Accumulating the remainder
+ * makes 0.5x scroll one pixel every other tick and 1.5x three pixels every two
+ * ticks, on average.
+ *
+ * A fresh instance must be created whenever the speed changes or auto-scroll
+ * restarts so the carried remainder does not leak across sessions. Both call sites
+ * create it inside a `LaunchedEffect` keyed on the speed, which does exactly that.
+ */
+class AutoScrollAccumulator {
+    private var remainder = 0f
+
+    /**
+     * Advance by [speed] pixels and return the whole pixels to scroll this tick
+     * (0 when the accumulated fraction has not yet reached a full pixel). Negative
+     * or zero speeds contribute nothing.
+     */
+    fun nextDelta(speed: Float): Int {
+        if (speed <= 0f) return 0
+        remainder += speed
+        val delta = remainder.toInt()
+        remainder -= delta
+        return delta
+    }
+}

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/PerformanceModeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/PerformanceModeView.kt
@@ -44,6 +44,7 @@ import com.baijum.ukufretboard.data.ChordDisplayStyle
 import com.baijum.ukufretboard.domain.ChordSheetFormatter
 import com.baijum.ukufretboard.ui.LocalReduceMotion
 import com.baijum.ukufretboard.ui.rememberTouchExplorationEnabled
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun PerformanceModeView(
@@ -72,22 +73,35 @@ internal fun PerformanceModeView(
 
     LaunchedEffect(autoScrolling, scrollSpeed) {
         if (autoScrolling) {
+            // Accumulate the fractional remainder so fractional speeds (e.g. 0.5x,
+            // 1.5x) scroll less than one pixel per tick on average instead of being
+            // truncated up to a whole pixel. A fresh accumulator resets the remainder
+            // on every scrollSpeed change or restart because this effect is keyed on
+            // autoScrolling + scrollSpeed.
+            val accumulator = AutoScrollAccumulator()
             while (autoScrolling) {
-                programmaticScroll.value = true
-                try {
-                    scrollState.animateScrollTo(
-                        scrollState.value + scrollSpeed.toInt().coerceAtLeast(1),
-                        animationSpec =
-                            androidx.compose.animation.core.tween(
-                                durationMillis = 16,
-                                easing = androidx.compose.animation.core.LinearEasing,
-                            ),
-                    )
-                } finally {
-                    programmaticScroll.value = false
-                }
-                if (scrollState.value >= scrollState.maxValue) {
-                    autoScrolling = false
+                val delta = accumulator.nextDelta(scrollSpeed)
+                if (delta > 0) {
+                    programmaticScroll.value = true
+                    try {
+                        scrollState.animateScrollTo(
+                            scrollState.value + delta,
+                            animationSpec =
+                                androidx.compose.animation.core.tween(
+                                    durationMillis = 16,
+                                    easing = androidx.compose.animation.core.LinearEasing,
+                                ),
+                        )
+                    } finally {
+                        programmaticScroll.value = false
+                    }
+                    if (scrollState.value >= scrollState.maxValue) {
+                        autoScrolling = false
+                    }
+                } else {
+                    // No pixel to move this tick; keep the ~16ms cadence so a
+                    // sub-1px/tick speed doesn't busy-loop.
+                    delay(16L)
                 }
             }
         }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/PerformanceModeView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/PerformanceModeView.kt
@@ -46,6 +46,9 @@ import com.baijum.ukufretboard.ui.LocalReduceMotion
 import com.baijum.ukufretboard.ui.rememberTouchExplorationEnabled
 import kotlinx.coroutines.delay
 
+/** ~60fps auto-scroll tick cadence, in milliseconds. */
+private const val AUTO_SCROLL_TICK_MS = 16L
+
 @Composable
 internal fun PerformanceModeView(
     displayContent: String,
@@ -101,7 +104,7 @@ internal fun PerformanceModeView(
                 } else {
                     // No pixel to move this tick; keep the ~16ms cadence so a
                     // sub-1px/tick speed doesn't busy-loop.
-                    delay(16L)
+                    delay(AUTO_SCROLL_TICK_MS)
                 }
             }
         }

--- a/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/songbook/SheetViewer.kt
@@ -282,19 +282,28 @@ internal fun SheetViewer(
         // Auto-scroll effect
         LaunchedEffect(autoScrolling, scrollSpeed) {
             if (autoScrolling) {
+                // Accumulate the fractional remainder so fractional speeds (0.5x)
+                // scroll less than one pixel per tick on average instead of being
+                // truncated up to 1px. A fresh accumulator resets the remainder on
+                // every scrollSpeed change or restart because this effect is keyed
+                // on autoScrolling + scrollSpeed.
+                val accumulator = AutoScrollAccumulator()
                 while (autoScrolling) {
-                    programmaticScroll.value = true
-                    try {
-                        scrollState.animateScrollTo(
-                            scrollState.value + scrollSpeed.toInt().coerceAtLeast(1),
-                            animationSpec =
-                                androidx.compose.animation.core.tween(
-                                    durationMillis = 16,
-                                    easing = androidx.compose.animation.core.LinearEasing,
-                                ),
-                        )
-                    } finally {
-                        programmaticScroll.value = false
+                    val delta = accumulator.nextDelta(scrollSpeed)
+                    if (delta > 0) {
+                        programmaticScroll.value = true
+                        try {
+                            scrollState.animateScrollTo(
+                                scrollState.value + delta,
+                                animationSpec =
+                                    androidx.compose.animation.core.tween(
+                                        durationMillis = 16,
+                                        easing = androidx.compose.animation.core.LinearEasing,
+                                    ),
+                            )
+                        } finally {
+                            programmaticScroll.value = false
+                        }
                     }
                     delay(16L)
                 }

--- a/app/src/test/java/com/baijum/ukufretboard/ui/songbook/AutoScrollAccumulatorTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/ui/songbook/AutoScrollAccumulatorTest.kt
@@ -1,0 +1,57 @@
+package com.baijum.ukufretboard.ui.songbook
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression tests for issue #583: fractional auto-scroll speeds were truncated
+ * with `toInt().coerceAtLeast(1)`, making 0.5x identical to 1x and every
+ * Performance-mode half-step inert. The accumulator must carry the sub-pixel
+ * remainder instead.
+ */
+class AutoScrollAccumulatorTest {
+    @Test
+    fun `0_5x yields one pixel every other tick`() {
+        val acc = AutoScrollAccumulator()
+        val deltas = (1..6).map { acc.nextDelta(0.5f) }
+        // 0.5, 1.0, 1.5, 2.0, 2.5, 3.0 -> 0,1,0,1,0,1
+        assertEquals(listOf(0, 1, 0, 1, 0, 1), deltas)
+        assertEquals("three pixels over six ticks", 3, deltas.sum())
+    }
+
+    @Test
+    fun `1_5x yields three pixels per two ticks`() {
+        val acc = AutoScrollAccumulator()
+        val deltas = (1..4).map { acc.nextDelta(1.5f) }
+        // 1.5, 3.0, 4.5, 6.0 -> 1,2,1,2
+        assertEquals(listOf(1, 2, 1, 2), deltas)
+        assertEquals("six pixels over four ticks", 6, deltas.sum())
+    }
+
+    @Test
+    fun `1x yields one pixel every tick`() {
+        val acc = AutoScrollAccumulator()
+        repeat(5) { assertEquals(1, acc.nextDelta(1f)) }
+    }
+
+    @Test
+    fun `whole speeds move exactly that many pixels each tick`() {
+        val acc = AutoScrollAccumulator()
+        assertEquals(2, acc.nextDelta(2f))
+        assertEquals(3, acc.nextDelta(3f))
+    }
+
+    @Test
+    fun `zero and negative speeds never scroll`() {
+        val acc = AutoScrollAccumulator()
+        assertEquals(0, acc.nextDelta(0f))
+        assertEquals(0, acc.nextDelta(-1f))
+    }
+
+    @Test
+    fun `0_5x accumulated across many ticks averages half a pixel`() {
+        val acc = AutoScrollAccumulator()
+        val total = (1..100).sumOf { acc.nextDelta(0.5f) }
+        assertEquals(50, total)
+    }
+}


### PR DESCRIPTION
Auto-scroll converted the fractional speed multiplier to `Int` per tick (`scrollSpeed.toInt().coerceAtLeast(1)`), so **0.5x truncated to 0 → lifted to 1 = identical to 1x**, and every Performance-mode half-step (1.5x, 2.5x, …) was inert. Slow scroll is the setting that matters most for the app's low-vision users, and it was exactly the value that never worked.

## Fix
- New `AutoScrollAccumulator` carries the sub-pixel remainder across ticks: 0.5x scrolls one pixel every other tick, 1.5x three pixels every two ticks.
- Applied at **both** call sites — `SheetViewer` share-viewer auto-scroll and `PerformanceModeView`.
- A fresh accumulator is created inside each `LaunchedEffect` (keyed on `autoScrolling` + `scrollSpeed`), so the remainder resets on any speed change or restart.
- `PerformanceModeView` delays 16 ms on zero-delta ticks to keep the ~16 ms cadence without busy-looping (its loop had no unconditional delay).
- Stayed within the auto-scroll `LaunchedEffect`; did not touch the share/export path.

## Tests
`AutoScrollAccumulatorTest` asserts 0.5x → one pixel every other tick, 1.5x → three pixels per two ticks, whole speeds pass through, and zero/negative speeds never scroll.

## Verification
- `./gradlew :app:compileDebugKotlin` — pass
- `./gradlew :app:testDebugUnitTest --tests AutoScrollAccumulatorTest` — pass
- `scripts/ktlint.sh` — no new violations
- Fully offline; no animation/reduce-motion behaviour changed.

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)