### PR TITLE
Fix: iOS melody recording gates room noise before detection

### DIFF
--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -357,7 +357,10 @@ final class MelodyViewModel: ObservableObject {
                 // where a pluck attack is broadband and YIN reports garbage.
                 if self.blankingFramesRemaining > 0 {
                     self.blankingFramesRemaining -= 1
-                    self.frameGate.exit()
+                    // FrameGate is a shared (KMP) non-Sendable type, so release it
+                    // on the main actor like the other paths do, rather than
+                    // calling exit() directly from this nonisolated closure.
+                    Task { @MainActor [weak self] in self?.frameGate.exit() }
                     return
                 }
 

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -100,8 +100,11 @@ final class MelodyViewModel: ObservableObject {
     private static let stabilizationThreshold = 3
 
     // Pre-detection gating constants, matched exactly to Android MelodyViewModel.
-    private static let onsetRatioThreshold: Float = 3.0
-    private static let blankingFrames = 2
+    // `nonisolated` so they can be read from the nonisolated audio-processing
+    // queue closure without forcing it onto the main actor (which would in turn
+    // reject the direct `frameGate.exit()` on the gated paths).
+    private nonisolated static let onsetRatioThreshold: Float = 3.0
+    private nonisolated static let blankingFrames = 2
 
     private let repository: MelodyRepository
     private let tonePlayer = TonePlayer()

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -99,6 +99,10 @@ final class MelodyViewModel: ObservableObject {
     private var loadedMelodyId: String? = nil
     private static let stabilizationThreshold = 3
 
+    // Pre-detection gating constants, matched exactly to Android MelodyViewModel.
+    private static let onsetRatioThreshold: Float = 3.0
+    private static let blankingFrames = 2
+
     private let repository: MelodyRepository
     private let tonePlayer = TonePlayer()
     private var playbackTask: Task<Void, Never>?
@@ -113,6 +117,13 @@ final class MelodyViewModel: ObservableObject {
     private var awaitingSilence = false
     private nonisolated(unsafe) var previousFrequency: KotlinDouble? = nil
 
+    // Amplitude gate + onset blanking state (accessed only on the serial
+    // audioProcessingQueue; the frame gate guarantees one frame in flight).
+    // noiseGateRms defaults to Android's 0.04 and is overwritten from settings.
+    private nonisolated(unsafe) var noiseGateRms: Float = 0.04
+    private nonisolated(unsafe) var previousRms: Float = 0
+    private nonisolated(unsafe) var blankingFramesRemaining = 0
+
     init(repository: MelodyRepository = MelodyRepository()) {
         self.repository = repository
         savedMelodies = repository.getAll()
@@ -120,6 +131,12 @@ final class MelodyViewModel: ObservableObject {
 
     var noteNames: [String] {
         Notes.shared.NOTE_NAMES_SHARP.asStrings
+    }
+
+    /// Sets the amplitude gate below which recording frames are discarded,
+    /// fed from the noise-gate setting the same way the tuner is.
+    func setNoiseGateRms(_ rms: Float) {
+        noiseGateRms = rms
     }
 
     func addNote(pitchClass: Int, octave: Int) {
@@ -314,11 +331,50 @@ final class MelodyViewModel: ObservableObject {
         lastDetectedOctave = nil
         awaitingSilence = false
         previousFrequency = nil
+        previousRms = 0
+        blankingFramesRemaining = 0
 
         audioEngine.onBuffer = { [weak self] samples in
             guard let self else { return }
             guard self.frameGate.tryEnter() else { return }
             self.audioProcessingQueue.async {
+                // Pre-detection gating, ported from Android MelodyViewModel so
+                // room noise/speech is not stabilised into notes. RMS is computed
+                // in place (equivalent to PitchDetector.rms) to avoid allocating a
+                // KotlinFloatArray on gated frames in the audio hot path.
+                let currentRms = sqrt(
+                    samples.reduce(Float(0)) { $0 + $1 * $1 } / Float(max(samples.count, 1))
+                )
+                if self.previousRms > 0 && currentRms / self.previousRms > Self.onsetRatioThreshold {
+                    self.blankingFramesRemaining = Self.blankingFrames
+                }
+                self.previousRms = currentRms
+
+                // Onset blanking: discard the frames right after a sudden RMS jump,
+                // where a pluck attack is broadband and YIN reports garbage.
+                if self.blankingFramesRemaining > 0 {
+                    self.blankingFramesRemaining -= 1
+                    self.frameGate.exit()
+                    return
+                }
+
+                // Amplitude gate: below the noise floor, reset any pending hint so a
+                // stale note cannot survive a pause, and discard the frame.
+                if currentRms < self.noiseGateRms {
+                    self.previousFrequency = nil
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        defer { self.frameGate.exit() }
+                        self.detectedNote = nil
+                        self.stableCount = 0
+                        self.lastDetectedPitchClass = nil
+                        self.lastDetectedOctave = nil
+                        self.stabilizationProgress = 0
+                        self.awaitingSilence = false
+                    }
+                    return
+                }
+
                 let floatArray = KotlinFloatArray(size: Int32(samples.count))
                 for i in 0..<samples.count {
                     floatArray.set(index: Int32(i), value: samples[i])
@@ -403,6 +459,8 @@ final class MelodyViewModel: ObservableObject {
         lastDetectedOctave = nil
         awaitingSilence = false
         previousFrequency = nil
+        previousRms = 0
+        blankingFramesRemaining = 0
     }
 
     func save(name: String) {

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -3,6 +3,7 @@ import shared
 
 struct MelodyNotepadView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @EnvironmentObject var settings: SettingsViewModel
     @StateObject private var viewModel = MelodyViewModel()
     @State private var showingSaveDialog = false
     @State private var saveName = ""
@@ -71,11 +72,23 @@ struct MelodyNotepadView: View {
                 renameName = ""
             }
         }
+        .onAppear {
+            viewModel.setNoiseGateRms(Self.filteringToRms(settings.noiseGateFiltering))
+        }
+        .onChange(of: settings.noiseGateFiltering) { newVal in
+            viewModel.setNoiseGateRms(Self.filteringToRms(newVal))
+        }
         .onDisappear {
             if viewModel.isRecording {
                 viewModel.stopRecording()
             }
         }
+    }
+
+    // Mirrors SoundSettings.filteringToRms / TunerView so melody recording uses
+    // the same noise-gate setting as the tuner and pitch monitor.
+    private static func filteringToRms(_ filtering: Float) -> Float {
+        0.002 + filtering * 0.051
     }
 
     private var modeToggle: some View {
@@ -467,7 +480,10 @@ struct MelodyNotepadView: View {
                         .font(.caption)
                 }
                 .buttonStyle(.bordered)
-                .accessibilityLabel(viewModel.steps.count >= MelodyViewModel.stepCount16 ? "Shrink to 8 steps" : "Expand to 16 steps")
+                .accessibilityLabel(
+                    viewModel.steps.count >= MelodyViewModel.stepCount16
+                        ? "Shrink to 8 steps" : "Expand to 16 steps"
+                )
             }
         }
         .sheet(item: Binding(


### PR DESCRIPTION
iOS Melody Notepad recording fed every captured buffer straight into pitch detection with no amplitude gate and no onset blanking, so room noise/speech was stabilised into notes and auto-written to the user's melody (only the shared detector's 0.01 RMS floor stood in the way).

This ports the Android `MelodyViewModel` pre-detection gating block into `iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift`, before detection, on the audio queue:

- **RMS in place** — computed inline from the sample buffer (equivalent to `PitchDetector.rms`), so gated frames allocate no `KotlinFloatArray` in the audio hot path.
- **Onset blanking** — a sudden RMS jump (`currentRms / previousRms > 3.0`) sets `blankingFramesRemaining = 2`; while frames remain, decrement and discard, because a pluck attack is broadband and YIN reports garbage during it.
- **Amplitude gate** — bail below `noiseGateRms` (default `0.04`), now fed from the noise-gate setting the same way the tuner and pitch monitor are (`MelodyNotepadView` wires `filteringToRms(settings.noiseGateFiltering)` on appear and on change).
- **State reset** on the gated/silent path — clears `previousFrequency` and the stabilization state (`stableCount`, `stabilizationProgress`, detected-note hint, `awaitingSilence`) so a stale hint cannot survive a pause.

Constants match Android exactly (`ONSET_RATIO_THRESHOLD` 3.0, `BLANKING_FRAMES` 2, `noiseGateRms` 0.04). The default `noiseGateFiltering` (0.75) maps to ~0.0403 RMS, consistent with the 0.04 default. The in-flight `sanitized()`/octave-clamp area was left untouched.

Verification: self-reviewed against Android's `MelodyViewModel.kt` gating block; full `xcodebuild` not run in this environment (pending CI). Change is fully offline.

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)