### PR TITLE
Fix: melody step grid is scratch state, no longer flags unsaved changes

### DIFF
--- a/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -138,6 +139,18 @@ fun MelodyNotepadView(
                 onSetStep = viewModel::setStep,
                 onClearStep = viewModel::clearStep,
                 onExpandSteps = viewModel::expandSteps,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.melody_step_sequencer_scratch_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp),
             )
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
+++ b/app/src/main/java/com/baijum/ukufretboard/viewmodel/MelodyViewModel.kt
@@ -250,10 +250,12 @@ class MelodyViewModel : ViewModel() {
                 octave = state.currentOctave,
                 duration = state.selectedDuration,
             )
+        // The step grid is scratch state and is never persisted with the melody
+        // (see saveMelody / Melody model), so grid edits must not mark the
+        // document dirty — otherwise Save promises to store a grid it discards.
         _uiState.update {
             it.copy(
                 steps = it.steps.toMutableList().apply { set(index, note) },
-                hasUnsavedChanges = true,
             )
         }
         playNote(pitchClass, state.currentOctave)
@@ -262,10 +264,10 @@ class MelodyViewModel : ViewModel() {
     fun clearStep(index: Int) {
         val state = _uiState.value
         if (index !in state.steps.indices) return
+        // Scratch-state grid edit — do not mark the document dirty (see setStep).
         _uiState.update {
             it.copy(
                 steps = it.steps.toMutableList().apply { set(index, null) },
-                hasUnsavedChanges = true,
             )
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -833,6 +833,7 @@
     <string name="melody_added_feedback">تمت إضافة %s</string>
     <string name="melody_mode_linear">خطي</string>
     <string name="melody_mode_step_sequencer">مُتتابع خطوات</string>
+    <string name="melody_step_sequencer_scratch_hint">شبكة الخطوات مساحة مؤقتة — لا تُحفظ مع اللحن.</string>
     <string name="melody_duration_whole">كاملة</string>
     <string name="melody_duration_half">نصف</string>
     <string name="melody_duration_quarter">ربع</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -828,6 +828,7 @@
     <string name="melody_added_feedback">已添加 %s</string>
     <string name="melody_mode_linear">线性</string>
     <string name="melody_mode_step_sequencer">步进音序器</string>
+    <string name="melody_step_sequencer_scratch_hint">步进网格是草稿，不会随旋律一起保存。</string>
     <string name="melody_duration_whole">全音符</string>
     <string name="melody_duration_half">二分音符</string>
     <string name="melody_duration_quarter">四分音符</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -829,6 +829,7 @@
     <string name="melody_added_feedback">%s hinzugefügt</string>
     <string name="melody_mode_linear">Linear</string>
     <string name="melody_mode_step_sequencer">Step-Sequenzer</string>
+    <string name="melody_step_sequencer_scratch_hint">Das Schrittraster ist ein Notizzettel – wird nicht mit der Melodie gespeichert.</string>
     <string name="melody_duration_whole">ganz</string>
     <string name="melody_duration_half">halb</string>
     <string name="melody_duration_quarter">viertel</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -830,6 +830,7 @@
     <string name="melody_added_feedback">%s añadido</string>
     <string name="melody_mode_linear">Lineal</string>
     <string name="melody_mode_step_sequencer">Secuenciador</string>
+    <string name="melody_step_sequencer_scratch_hint">La cuadrícula de pasos es un borrador: no se guarda con la melodía.</string>
     <string name="melody_duration_whole">redonda</string>
     <string name="melody_duration_half">blanca</string>
     <string name="melody_duration_quarter">negra</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -830,6 +830,7 @@
     <string name="melody_added_feedback">%s ajouté</string>
     <string name="melody_mode_linear">Linéaire</string>
     <string name="melody_mode_step_sequencer">Séquenceur</string>
+    <string name="melody_step_sequencer_scratch_hint">La grille de pas est un brouillon — non enregistrée avec la mélodie.</string>
     <string name="melody_duration_whole">ronde</string>
     <string name="melody_duration_half">blanche</string>
     <string name="melody_duration_quarter">noire</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -829,6 +829,7 @@
     <string name="melody_added_feedback">%s जोड़ा गया</string>
     <string name="melody_mode_linear">रैखिक</string>
     <string name="melody_mode_step_sequencer">स्टेप सीक्वेंसर</string>
+    <string name="melody_step_sequencer_scratch_hint">स्टेप ग्रिड एक अस्थायी नोट है — यह धुन के साथ सहेजा नहीं जाता।</string>
     <string name="melody_duration_whole">पूर्ण</string>
     <string name="melody_duration_half">आधी</string>
     <string name="melody_duration_quarter">चौथाई</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -828,6 +828,7 @@
     <string name="melody_added_feedback">%s ditambahkan</string>
     <string name="melody_mode_linear">Linear</string>
     <string name="melody_mode_step_sequencer">Step Sequencer</string>
+    <string name="melody_step_sequencer_scratch_hint">Kisi langkah adalah catatan sementara — tidak disimpan bersama melodi.</string>
     <string name="melody_duration_whole">penuh</string>
     <string name="melody_duration_half">setengah</string>
     <string name="melody_duration_quarter">seperempat</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -830,6 +830,7 @@
     <string name="melody_added_feedback">%s aggiunto</string>
     <string name="melody_mode_linear">Lineare</string>
     <string name="melody_mode_step_sequencer">Sequenziatore</string>
+    <string name="melody_step_sequencer_scratch_hint">La griglia dei passi è una bozza: non viene salvata con la melodia.</string>
     <string name="melody_duration_whole">semibreve</string>
     <string name="melody_duration_half">minima</string>
     <string name="melody_duration_quarter">semiminima</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -828,6 +828,7 @@
     <string name="melody_added_feedback">%s を追加</string>
     <string name="melody_mode_linear">リニア</string>
     <string name="melody_mode_step_sequencer">ステップシーケンサー</string>
+    <string name="melody_step_sequencer_scratch_hint">ステップグリッドはスクラッチ用で、メロディーと一緒には保存されません。</string>
     <string name="melody_duration_whole">全音符</string>
     <string name="melody_duration_half">2分音符</string>
     <string name="melody_duration_quarter">4分音符</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -828,6 +828,7 @@
     <string name="melody_added_feedback">%s 추가됨</string>
     <string name="melody_mode_linear">순차</string>
     <string name="melody_mode_step_sequencer">스텝 시퀀서</string>
+    <string name="melody_step_sequencer_scratch_hint">스텝 그리드는 임시 메모이며 멜로디와 함께 저장되지 않습니다.</string>
     <string name="melody_duration_whole">온음표</string>
     <string name="melody_duration_half">2분음표</string>
     <string name="melody_duration_quarter">4분음표</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -829,6 +829,7 @@
     <string name="melody_added_feedback">%s toegevoegd</string>
     <string name="melody_mode_linear">Lineair</string>
     <string name="melody_mode_step_sequencer">Stappensequencer</string>
+    <string name="melody_step_sequencer_scratch_hint">Het stappenraster is een kladblok — wordt niet met de melodie opgeslagen.</string>
     <string name="melody_duration_whole">heel</string>
     <string name="melody_duration_half">half</string>
     <string name="melody_duration_quarter">kwart</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -831,6 +831,7 @@
     <string name="melody_added_feedback">Dodano %s</string>
     <string name="melody_mode_linear">Liniowy</string>
     <string name="melody_mode_step_sequencer">Sekwencer krokowy</string>
+    <string name="melody_step_sequencer_scratch_hint">Siatka kroków to brudnopis — nie jest zapisywana z melodią.</string>
     <string name="melody_duration_whole">cała</string>
     <string name="melody_duration_half">półnuta</string>
     <string name="melody_duration_quarter">ćwierćnuta</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -830,6 +830,7 @@
     <string name="melody_added_feedback">%s adicionado</string>
     <string name="melody_mode_linear">Linear</string>
     <string name="melody_mode_step_sequencer">Sequenciador</string>
+    <string name="melody_step_sequencer_scratch_hint">A grade de passos é um rascunho — não é salva com a melodia.</string>
     <string name="melody_duration_whole">semibreve</string>
     <string name="melody_duration_half">mínima</string>
     <string name="melody_duration_quarter">semínima</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -831,6 +831,7 @@
     <string name="melody_added_feedback">Добавлено: %s</string>
     <string name="melody_mode_linear">Линейный</string>
     <string name="melody_mode_step_sequencer">Секвенсор</string>
+    <string name="melody_step_sequencer_scratch_hint">Сетка шагов — черновик и не сохраняется вместе с мелодией.</string>
     <string name="melody_duration_whole">целая</string>
     <string name="melody_duration_half">половинная</string>
     <string name="melody_duration_quarter">четвертная</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -829,6 +829,7 @@
     <string name="melody_added_feedback">%s eklendi</string>
     <string name="melody_mode_linear">Doğrusal</string>
     <string name="melody_mode_step_sequencer">Adım Sıralayıcı</string>
+    <string name="melody_step_sequencer_scratch_hint">Adım ızgarası bir müsvedde — melodiyle birlikte kaydedilmez.</string>
     <string name="melody_duration_whole">tam</string>
     <string name="melody_duration_half">yarım</string>
     <string name="melody_duration_quarter">dörtlük</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -7,6 +7,7 @@
     <string name="melody_added_feedback">已添加 %s</string>
     <string name="melody_mode_linear">线性</string>
     <string name="melody_mode_step_sequencer">步进音序器</string>
+    <string name="melody_step_sequencer_scratch_hint">步进网格是草稿，不会随旋律一起保存。</string>
     <string name="melody_duration_whole">全音符</string>
     <string name="melody_duration_half">二分音符</string>
     <string name="melody_duration_quarter">四分音符</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -939,6 +939,7 @@
     <string name="melody_added_feedback">Added %s</string>
     <string name="melody_mode_linear">Linear</string>
     <string name="melody_mode_step_sequencer">Step Sequencer</string>
+    <string name="melody_step_sequencer_scratch_hint">Step grid is a scratch pad — not saved with the melody.</string>
     <string name="melody_duration_whole">whole</string>
     <string name="melody_duration_half">half</string>
     <string name="melody_duration_quarter">quarter</string>

--- a/app/src/test/java/com/baijum/ukufretboard/viewmodel/MelodyViewModelTest.kt
+++ b/app/src/test/java/com/baijum/ukufretboard/viewmodel/MelodyViewModelTest.kt
@@ -1,0 +1,65 @@
+package com.baijum.ukufretboard.viewmodel
+
+import com.baijum.ukufretboard.data.SoundSettings
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for issue #581: the step-sequencer grid is scratch state
+ * that is never persisted with the melody, so grid edits must NOT mark the
+ * document as having unsaved changes. Real note edits still must.
+ */
+class MelodyViewModelTest {
+    private lateinit var vm: MelodyViewModel
+
+    @Before
+    fun setUp() {
+        vm = MelodyViewModel()
+        // Disable sound so playNote() does not launch a coroutine on the
+        // (unavailable) Main dispatcher during the unit test.
+        vm.setSoundSettings(SoundSettings(enabled = false))
+    }
+
+    @Test
+    fun setStepDoesNotMarkDocumentDirty() {
+        assertFalse(vm.uiState.value.hasUnsavedChanges)
+
+        vm.setStep(index = 0, pitchClass = 0)
+
+        val state = vm.uiState.value
+        assertNotNull("Step should be written to the scratch grid", state.steps[0])
+        assertFalse(
+            "Editing the scratch-pad grid must not flag unsaved changes",
+            state.hasUnsavedChanges,
+        )
+    }
+
+    @Test
+    fun clearStepDoesNotMarkDocumentDirty() {
+        vm.setStep(index = 0, pitchClass = 0)
+
+        vm.clearStep(index = 0)
+
+        val state = vm.uiState.value
+        assertNull("Step should be cleared", state.steps[0])
+        assertFalse(
+            "Clearing a scratch-pad step must not flag unsaved changes",
+            state.hasUnsavedChanges,
+        )
+    }
+
+    @Test
+    fun addNoteStillMarksDocumentDirty() {
+        assertFalse(vm.uiState.value.hasUnsavedChanges)
+
+        vm.addNote(pitchClass = 0, octave = 4)
+
+        val state = vm.uiState.value
+        assertTrue("A real note edit must still flag unsaved changes", state.hasUnsavedChanges)
+        assertTrue(state.notes.isNotEmpty())
+    }
+}

--- a/iosApp/UkuleleCompanion/Localizable.xcstrings
+++ b/iosApp/UkuleleCompanion/Localizable.xcstrings
@@ -54782,6 +54782,106 @@
         }
       }
     },
+    "melody_step_sequencer_scratch_hint": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step grid is a scratch pad — not saved with the melody."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La grille de pas est un brouillon — non enregistrée avec la mélodie."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Schrittraster ist ein Notizzettel – wird nicht mit der Melodie gespeichert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cuadrícula de pasos es un borrador: no se guarda con la melodía."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La griglia dei passi è una bozza: non viene salvata con la melodia."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A grade de passos é um rascunho — não é salva com a melodia."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Het stappenraster is een kladblok — wordt niet met de melodie opgeslagen."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сетка шагов — черновик и не сохраняется вместе с мелодией."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adım ızgarası bir müsvedde — melodiyle birlikte kaydedilmez."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Siatka kroków to brudnopis — nie jest zapisywana z melodią."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステップグリッドはスクラッチ用で、メロディーと一緒には保存されません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스텝 그리드는 임시 메모이며 멜로디와 함께 저장되지 않습니다."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "स्टेप ग्रिड एक अस्थायी नोट है — यह धुन के साथ सहेजा नहीं जाता।"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kisi langkah adalah catatan sementara — tidak disimpan bersama melodi."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شبكة الخطوات مساحة مؤقتة — لا تُحفظ مع اللحن."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "步进网格是草稿，不会随旋律一起保存。"
+          }
+        }
+      }
+    },
     "melody_step_sequencer_title": {
       "localizations": {
         "en": {

--- a/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
+++ b/iosApp/UkuleleCompanion/ViewModels/MelodyViewModel.swift
@@ -207,15 +207,17 @@ final class MelodyViewModel: ObservableObject {
             duration: selectedDuration,
             isRest: false
         )
+        // The step grid is scratch state and is never persisted with the melody
+        // (see saveMelody / MelodyData), so grid edits must not mark the document
+        // dirty — otherwise Save promises to store a grid it discards.
         steps[index] = note
-        hasUnsavedChanges = true
         tonePlayer.playNote(pitchClass: Int32(pitchClass))
     }
 
     func clearStep(index: Int) {
         guard index >= 0 && index < steps.count else { return }
+        // Scratch-state grid edit — do not mark the document dirty (see setStep).
         steps[index] = nil
-        hasUnsavedChanges = true
     }
 
     func expandSteps() {
@@ -254,10 +256,10 @@ final class MelodyViewModel: ObservableObject {
     }
 
     func clearAllSteps() {
+        // Scratch-state grid edit — do not mark the document dirty (see setStep).
         for i in 0..<steps.count {
             steps[i] = nil
         }
-        hasUnsavedChanges = true
     }
 
     private func showFeedback(_ text: String) {

--- a/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
+++ b/iosApp/UkuleleCompanion/Views/MelodyNotepadView.swift
@@ -485,6 +485,11 @@ struct MelodyNotepadView: View {
                         ? "Shrink to 8 steps" : "Expand to 16 steps"
                 )
             }
+
+            Text("melody_step_sequencer_scratch_hint")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .sheet(item: Binding(
             get: { stepPitchPickerIndex.map { StepPickerItem(index: $0) } },

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -2151,10 +2151,10 @@
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyNotepadView.kt">
         <error line="3" column="1" source="standard:import-ordering" />
-        <error line="55" column="24" source="standard:multiline-expression-wrapping" />
-        <error line="68" column="20" source="standard:multiline-expression-wrapping" />
-        <error line="118" column="28" source="standard:multiline-expression-wrapping" />
-        <error line="127" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="56" column="24" source="standard:multiline-expression-wrapping" />
+        <error line="69" column="20" source="standard:multiline-expression-wrapping" />
+        <error line="119" column="28" source="standard:multiline-expression-wrapping" />
+        <error line="128" column="28" source="standard:multiline-expression-wrapping" />
     </file>
     <file name="app/src/main/java/com/baijum/ukufretboard/ui/melody/MelodyStepSequencer.kt">
         <error line="60" column="24" source="standard:multiline-expression-wrapping" />


### PR DESCRIPTION
## Problem (#581)

The Melody Notepad's step-sequencer grid is scratch state — the persisted `Melody` model has no step field and `saveMelody` writes only `notes`. But editing the grid set `hasUnsavedChanges = true`, so the title showed a `*` and prompted a Save that silently discarded the grid and could write an empty melody. The app reported success while losing the grid.

## Fix — treat the grid as scratch state (the chosen direction, not persistence)

**Android** (`MelodyViewModel.kt`): removed `hasUnsavedChanges = true` from the step-grid mutators **only** — `setStep` and `clearStep` (`expandSteps` never set it). All note mutators (`addNote`, `addRest`, `deleteSelectedNote`, `setBpm`, mic recording) still flag unsaved changes.

**iOS** (`MelodyViewModel.swift`): same — removed the flag from `setStep`, `clearStep`, and `clearAllSteps` (the grid-clear helper). Note mutators (`addNote`, `addRest`, `deleteNote`, `deleteNoteAt`) keep it.

**UI note (both platforms)** — added a concise scratch-pad hint below the grid in step-sequencer mode:
> Step grid is a scratch pad — not saved with the melody.

The new string was added to the English source, all 15 other Android locale `strings.xml` files, and regenerated into `Localizable.xcstrings` (16 locales) via `scripts/convert_strings.py`. It's plain text, readable by TalkBack/VoiceOver.

## Tests

Added `MelodyViewModelTest` asserting a step-grid edit (`setStep`/`clearStep`) does **not** set `hasUnsavedChanges`, while a note edit (`addNote`) still does.

## Verification

- Android: `:app:compileDebugKotlin`, the new unit test, `:app:detekt`, ktlint (baseline-aware, exit 0), and `lintDebug` (no MissingTranslation) all pass. ktlint baseline had only the affected file's line numbers spliced (import add shifted 4 pre-existing entries by +1).
- iOS: `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` — **BUILD SUCCEEDED** (compiles the Swift edits).
- Accessibility review: no regressions on either platform.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a localized hint explaining that the melody step-sequencer grid is temporary and isn’t saved with melodies.
  * Displayed the hint below the step-sequencer controls on Android and iOS.

* **Bug Fixes**
  * Editing or clearing the temporary step grid no longer marks a melody as having unsaved changes.
  * Regular melody note edits continue to trigger unsaved-change indicators.

* **Localization**
  * Added translations for the hint across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->