### PR TITLE
Fix: iOS Favourites playback and Scale Practice grid follow the selected tuning

### DIFF
--- a/iosApp/UkuleleCompanion/Views/FavoritesView.swift
+++ b/iosApp/UkuleleCompanion/Views/FavoritesView.swift
@@ -3,6 +3,7 @@ import shared
 
 struct FavoritesView: View {
     @EnvironmentObject private var viewModel: FavoritesViewModel
+    @EnvironmentObject private var settings: SettingsViewModel
     @State private var selectedFolderId: String?
     @State private var showCreateFolder = false
     @State private var renamingFolder: FavoriteFolderData?
@@ -199,7 +200,7 @@ struct FavoritesView: View {
     private func playFavorite(_ fav: FavoriteVoicingData) {
         let pitchClasses = fav.frets.enumerated().compactMap { i, fret -> Int32? in
             guard fret >= 0 else { return nil }
-            let openPc = UkuleleTuning.highG.pitchClassInts[i]
+            let openPc = settings.resolvedTuning.pitchClassInts[i]
             return (openPc + Int32(fret)) % 12
         }
         tonePlayer.playChord(pitchClasses: pitchClasses, strumDelayMs: 40)

--- a/iosApp/UkuleleCompanion/Views/ScalePracticeView.swift
+++ b/iosApp/UkuleleCompanion/Views/ScalePracticeView.swift
@@ -159,7 +159,7 @@ struct ScalePracticeView: View {
         let currentPC = viewModel.currentNoteIndex >= 0 && viewModel.currentNoteIndex < viewModel.scaleNotes.count
             ? viewModel.scaleNotes[viewModel.currentNoteIndex] : -1
         let fretRange = viewModel.fretPosition.range(lastFret: settings.lastFret)
-        let tuning: [Int] = [7, 0, 4, 9] // G C E A (High-G)
+        let tuning: [Int] = settings.resolvedTuning.pitchClassInts.map(Int.init)
 
         VStack(spacing: 0) {
             ForEach(Array((0..<4).reversed()), id: \.self) { stringIdx in


### PR DESCRIPTION
Two iOS views hardcoded High-G open pitch classes, so under Low-G / Baritone tunings they computed the wrong pitches. Both now read the selected tuning from `SettingsViewModel.resolvedTuning.pitchClassInts` — pure pitch-class arithmetic, no tuning literal, correct for High-G, Low-G and Baritone.

- **#639 — Favourites playback:** `FavoritesView.playFavorite` sourced open pitch classes from `UkuleleTuning.highG.pitchClassInts`; now uses `settings.resolvedTuning.pitchClassInts`. Added `@EnvironmentObject var settings: SettingsViewModel` (already injected at the ContentView root).
- **#640 — Scale Practice grid:** `ScalePracticeView.scaleFretboardView` hardcoded `let tuning: [Int] = [7, 0, 4, 9]`; now derives it from `settings.resolvedTuning.pitchClassInts.map(Int.init)` (the view already held `settings`). The `(tuning[stringIdx] + fret) % 12` note calc follows the real tuning.

Verified with `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`: **BUILD SUCCEEDED**. Fully offline; no other files touched.

Closes #639
Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)