### PR TITLE
Fix: shared chord-diagram image honours Left-Handed and tuning

### DIFF
--- a/iosApp/UkuleleCompanion/Views/ShareChordSheet.swift
+++ b/iosApp/UkuleleCompanion/Views/ShareChordSheet.swift
@@ -18,8 +18,24 @@ struct ShareChordInfo: Identifiable {
 /// Sheet that previews a shareable chord diagram and offers a "Share as Image" button.
 struct ShareChordSheet: View {
     let info: ShareChordInfo
+    // ImageRenderer content cannot read the diagram environment values, so the
+    // handedness and tuning must be handed to ShareableChordDiagramView
+    // explicitly. Read them from the shared SettingsViewModel (#638).
+    @EnvironmentObject private var settings: SettingsViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var renderedImage: UIImage?
+
+    /// Open-string names for the current tuning, resolved the same way the
+    /// on-screen diagram's `\.diagramStringNames` environment value is (#576).
+    private var stringNames: [String] {
+        settings.resolvedTuning.stringNameArray
+    }
+
+    /// Open-string pitch classes for the current tuning, needed so the exported
+    /// note names are correct for Baritone (D-G-B-E) as well as G-C-E-A tunings.
+    private var openPitchClasses: [Int] {
+        settings.resolvedTuning.pitchClassInts.map { Int($0) }
+    }
 
     var body: some View {
         NavigationStack {
@@ -27,7 +43,10 @@ struct ShareChordSheet: View {
                 ShareableChordDiagramView(
                     voicing: info.voicing,
                     chordName: info.chordName,
-                    inversionLabel: info.inversionLabel
+                    inversionLabel: info.inversionLabel,
+                    leftHanded: settings.leftHanded,
+                    stringNames: stringNames,
+                    openPitchClasses: openPitchClasses
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .shadow(color: .black.opacity(0.1), radius: 4, y: 2)
@@ -72,7 +91,10 @@ struct ShareChordSheet: View {
         let diagram = ShareableChordDiagramView(
             voicing: info.voicing,
             chordName: info.chordName,
-            inversionLabel: info.inversionLabel
+            inversionLabel: info.inversionLabel,
+            leftHanded: settings.leftHanded,
+            stringNames: stringNames,
+            openPitchClasses: openPitchClasses
         )
         let renderer = ImageRenderer(content: diagram)
         renderer.scale = 3.0  // High-res for sharing

--- a/iosApp/UkuleleCompanion/Views/ShareableChordDiagramView.swift
+++ b/iosApp/UkuleleCompanion/Views/ShareableChordDiagramView.swift
@@ -8,6 +8,16 @@ struct ShareableChordDiagramView: View {
     let chordName: String
     var inversionLabel: String?
 
+    // ImageRenderer draws this view outside the SwiftUI hierarchy, so it cannot
+    // read `\.leftHanded` / `\.diagramStringNames` from the environment the way
+    // the on-screen ChordDiagramView does (#637). The two settings are therefore
+    // passed in explicitly from SettingsViewModel at the call site (#638) so the
+    // exported PNG mirrors for left-handed players and labels strings/notes for
+    // the selected tuning (High-G, Low-G, Baritone, ...).
+    var leftHanded: Bool = false
+    var stringNames: [String] = ["G", "C", "E", "A"]
+    var openPitchClasses: [Int] = [7, 0, 4, 9] // G C E A
+
     private let stringCount = 4
     private let minFretRows = 5
     private let stringSpacing: CGFloat = 36
@@ -17,10 +27,23 @@ struct ShareableChordDiagramView: View {
     private let nutThickness: CGFloat = 5
     private let dotColor = Color(red: 0.18, green: 0.49, blue: 0.20) // #2E7D32
 
-    private let standardOpenPitchClasses: [Int] = [7, 0, 4, 9] // G C E A
-
+    /// Voicing frets in draw order — reversed for a left-handed player so the
+    /// exported diagram mirrors the on-screen one (matches ChordDiagramView).
     private var frets: [Int] {
-        voicing.fretInts
+        let raw = voicing.fretInts
+        return leftHanded ? raw.reversed() : raw
+    }
+
+    /// Open-string pitch classes in the same draw order as `frets`, so the note
+    /// names below the grid stay aligned with each mirrored string.
+    private var orderedPitchClasses: [Int] {
+        leftHanded ? Array(openPitchClasses.reversed()) : openPitchClasses
+    }
+
+    /// Open-string names in the same draw order as `frets`, used for the
+    /// accessibility description so it reflects the mirrored order (#638).
+    private var orderedStringNames: [String] {
+        leftHanded ? Array(stringNames.reversed()) : stringNames
     }
 
     private var startFret: Int {
@@ -51,8 +74,14 @@ struct ShareableChordDiagramView: View {
     private var diagramWidth: CGFloat { CGFloat(stringCount - 1) * stringSpacing }
 
     private var accessibilityDescription: String {
-        let fretList = frets.map { $0 < 0 ? "muted" : "\($0)" }.joined(separator: ", ")
-        var desc = "\(chordName) chord diagram, frets: \(fretList)"
+        // Name each string in the (possibly mirrored) draw order so a blind
+        // left-handed user hears the same layout the sighted image shows (#638).
+        let perString = zip(orderedStringNames, frets).map { name, fret -> String in
+            if fret < 0 { return "\(name) string muted" }
+            if fret == 0 { return "\(name) string open" }
+            return "\(name) string fret \(fret)"
+        }.joined(separator: ", ")
+        var desc = "\(chordName) chord diagram, \(perString)"
         if let label = inversionLabel { desc += ", \(label)" }
         return desc
     }
@@ -199,7 +228,7 @@ struct ShareableChordDiagramView: View {
             for s in 0..<stringCount {
                 let fret = currentFrets[s]
                 let x = stringXPositions[s]
-                let openPitch = standardOpenPitchClasses[s]
+                let openPitch = orderedPitchClasses[s]
 
                 let noteName: String
                 if fret < 0 {


### PR DESCRIPTION
Follow-up to #637. `ShareableChordDiagramView` is drawn by `ImageRenderer` (`ShareChordSheet.swift:77`), which renders **outside** the SwiftUI view hierarchy and so never inherited the `\.leftHanded` / `\.diagramStringNames` environment values #637 wired up for the on-screen `ChordDiagramView`. The exported/shared PNG therefore always drew G-C-E-A left-to-right and never mirrored for left-handed players.

## Fix
Pass the settings in explicitly (the environment can't reach `ImageRenderer` content):

- `ShareableChordDiagramView` gains `leftHanded: Bool`, `stringNames: [String]`, and `openPitchClasses: [Int]` init parameters.
- `frets`, the open string names, and the open pitch classes are all reversed in lockstep when `leftHanded`, and drawn at sequential x-positions — the exact mirroring `ChordDiagramView` performs. Finger numbers follow the reversed `frets`.
- The exported image's `accessibilityDescription` is rebuilt from the mirrored, tuning-named strings (e.g. "A string open, E string fret 3, ...") so blind left-handed users hear the same layout the image shows.
- `ShareChordSheet` reads `settings.leftHanded` and `settings.resolvedTuning` (string names + pitch classes) from the shared `SettingsViewModel` and passes them into both construction sites.

Open pitch classes are passed alongside the names so exported note labels are correct for Baritone (D-G-B-E) as well as the G-C-E-A tunings (High-G / Low-G).

## Verification
- `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build` → **BUILD SUCCEEDED**.
- Mirroring logic checked line-by-line against `ChordDiagramView` (reversed `frets` + reversed labels, drawn at sequential positions).
- Fully offline; scope limited to the two files named in the issue.

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)