### PR TITLE
Docs: Play edge-to-edge warnings are AndroidX callers, no action needed

### DIFF
--- a/.cursor/rules/edge_to_edge.mdc
+++ b/.cursor/rules/edge_to_edge.mdc
@@ -1,33 +1,72 @@
 ---
-description: Edge-to-edge Play Store warnings and deferred action items — relevant when upgrading Material Components, handling Play Store warnings, or working on edge-to-edge / window insets
+description: Edge-to-edge Play Store warnings and why they are expected — relevant when handling Play Console warnings, upgrading androidx.activity or Material Components, or working on edge-to-edge / window insets
 globs: app/src/main/java/**/MainActivity.kt, app/src/main/java/**/ui/theme/Theme.kt, gradle/libs.versions.toml
 alwaysApply: false
 ---
 
-# Edge-to-Edge Play Store Warnings (Deferred)
+# Edge-to-Edge Play Store Warnings (Expected — No Action)
 
-Two Google Play Console recommendations were analyzed in March 2026. No action is required from app code — the root cause is in the Material Components library.
+Google Play Console shows two "recommended actions" on every production
+release. They were first analyzed in March 2026 and re-analyzed in September
+2026 against the shipped 9.13.0 release (versionCode 110). **Both are expected
+and require no app change.** Do not spend a session re-investigating them
+unless something in the "Re-check when" section below has changed.
 
 ## Warning 1: "Edge-to-edge may not display for all users"
 
-- **Status:** Already handled.
-- The app calls `enableEdgeToEdge()` in `MainActivity.onCreate()` before `setContent`.
-- Both `FretboardScreen` and `OnboardingScreen` use Material 3 `Scaffold` with `innerPadding`, which automatically accounts for system bar insets.
-- `OnboardingScreen` bottom bar applies `navigationBarsPadding()`.
-- **Follow-up:** A visual audit on an Android 15+ device/emulator could confirm nothing is clipped behind system bars (bottom sheets, dialogs, drawer, FABs).
+- **Status:** Already handled by app code.
+- `MainActivity.onCreate()` calls `enableEdgeToEdge()` before `setContent`.
+- `FretboardScreen` and `OnboardingScreen` use Material 3 `Scaffold` with
+  `innerPadding`, which accounts for system bar insets; the onboarding bottom
+  bar applies `navigationBarsPadding()`.
+- `targetSdk` is 36, and no theme or manifest uses
+  `windowOptOutEdgeToEdgeEnforcement`, `statusBarColor`, `navigationBarColor`
+  or `windowLayoutInDisplayCutoutMode`.
+- This banner is the generic companion to Warning 2 and fires together with it.
 
 ## Warning 2: "Your app uses deprecated APIs or parameters for edge-to-edge"
 
-- **Deprecated APIs flagged:** `setStatusBarColor`, `setNavigationBarColor`, `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`
-- **Root cause:** Internal code in `com.google.android.material:material:1.13.0`:
-  - `EdgeToEdgeUtils.applyEdgeToEdge()` calls `window.setStatusBarColor()` / `window.setNavigationBarColor()`
-  - `BottomSheetDialog.onCreate()` uses the above utilities
-  - `MaterialDatePicker.onStart()` sets `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`
-- **Not in app code** — the obfuscated class names (`b.q.b`, `b.t.b`, `b.v.b`, `b.r.t`) in the Play Console map to these Material library internals after R8.
-- **Upstream fix:** Commit `c2051db` in Material Components, available in `1.14.0-alpha` but not yet in a stable release.
-- **Tracked at:** https://github.com/material-components/material-components-android/issues/4507
+- **Deprecated APIs flagged:** `setStatusBarColor`, `setNavigationBarColor`,
+  `setDecorFitsSystemWindows`, `layoutInDisplayCutoutMode`, and the
+  status/navigation bar contrast-enforced setters.
+- **Root cause (verified September 2026):** every caller is inside AndroidX,
+  none is app code. Verified by disassembling the release APK
+  (`dexdump` from build-tools) and mapping the obfuscated class names through
+  `app/build/outputs/mapping/release/mapping.txt`:
+
+  | Deprecated API | Caller in the shipped APK |
+  |----------------|---------------------------|
+  | `Window.setStatusBarColor` / `setNavigationBarColor` | `androidx.activity.EdgeToEdgeApi26`, `EdgeToEdgeApi29`, `EdgeToEdgeApi35` |
+  | `Window.setDecorFitsSystemWindows` | R8-outlined API stub for `androidx.core.view.WindowCompat` |
+  | `WindowManager.LayoutParams.layoutInDisplayCutoutMode` | R8-outlined API stub for AndroidX Core |
+  | `setStatusBarContrastEnforced` / `setNavigationBarContrastEnforced` | R8-outlined API stub for AndroidX Compose UI |
+
+  Those `EdgeToEdgeApi*` classes **are** `enableEdgeToEdge()` (activity-compose
+  1.13.0). Even the API 35 path unconditionally sets both bars to
+  `Color.TRANSPARENT` through the deprecated setters. Play Console's check is a
+  static bytecode scan, so it flags library callers exactly like app code.
+  Because the calls come from Google's own recommended API, the warning is a
+  false positive for this app. The only way to silence it would be to stop
+  calling `enableEdgeToEdge()`, which would be a regression.
+- **Material Components is not the cause.** The March 2026 analysis blamed
+  `com.google.android.material:material:1.13.0` internals and said to revisit
+  once 1.14.0 shipped. 9.13.0 already ships Material 1.14.0, whose AAR contains
+  no references to the deprecated setters, and the warning persists. Keep the
+  `material` dependency: `res/values/themes.xml` inherits from
+  `Theme.Material3.DayNight.NoActionBar`, which it provides.
+- No official Google page states that the warning can be ignored when the
+  callers are AndroidX; the conclusion above rests on the bytecode evidence.
 
 ## Action
 
-- **Decision (March 2026):** No action for now.
-- **Revisit when:** Material Components `1.14.0` stable is released. Update the `material` version in `gradle/libs.versions.toml` (currently `1.13.0`) and verify the Play Console warnings are resolved.
+- **Decision (September 2026):** No code change. The console's
+  "Is this useful?" thumbs-down is the only feedback channel Google offers.
+- **Still worth doing once:** a visual pass on an Android 15+ emulator to
+  confirm nothing is clipped behind system bars (bottom sheets, dialogs,
+  drawer, FABs).
+- **Re-check when:** `androidx.activity` / `activity-compose` is bumped past
+  1.13.0 (its `EdgeToEdge.kt` may stop calling the deprecated setters), or the
+  console lists a caller that does **not** map to an AndroidX class. To
+  re-verify, unzip `classes*.dex` from `app-release.apk`, run
+  `dexdump -d` and grep for `Landroid/view/Window;.setStatusBarColor`, then
+  look up the obfuscated class in `mapping.txt`.

--- a/.cursor/rules/edge_to_edge.mdc
+++ b/.cursor/rules/edge_to_edge.mdc
@@ -1,6 +1,6 @@
 ---
 description: Edge-to-edge Play Store warnings and why they are expected — relevant when handling Play Console warnings, upgrading androidx.activity or Material Components, or working on edge-to-edge / window insets
-globs: app/src/main/java/**/MainActivity.kt, app/src/main/java/**/ui/theme/Theme.kt, gradle/libs.versions.toml
+globs: app/src/main/java/**/MainActivity.kt, app/src/main/java/**/ui/theme/Theme.kt, app/src/main/java/**/ui/navigation/FretboardScreen.kt, app/src/main/java/**/ui/OnboardingScreen.kt, gradle/libs.versions.toml
 alwaysApply: false
 ---
 
@@ -46,8 +46,11 @@ unless something in the "Re-check when" section below has changed.
   `Color.TRANSPARENT` through the deprecated setters. Play Console's check is a
   static bytecode scan, so it flags library callers exactly like app code.
   Because the calls come from Google's own recommended API, the warning is a
-  false positive for this app. The only way to silence it would be to stop
-  calling `enableEdgeToEdge()`, which would be a regression.
+  false positive for this app. With the shipped activity-compose 1.13.0, the
+  only app-side way to silence it would be to stop calling
+  `enableEdgeToEdge()`, which would be a regression; a future
+  `androidx.activity` release that drops the deprecated setters may clear it
+  on its own (see "Re-check when" below).
 - **Material Components is not the cause.** The March 2026 analysis blamed
   `com.google.android.material:material:1.13.0` internals and said to revisit
   once 1.14.0 shipped. 9.13.0 already ships Material 1.14.0, whose AAR contains
@@ -68,5 +71,13 @@ unless something in the "Re-check when" section below has changed.
   1.13.0 (its `EdgeToEdge.kt` may stop calling the deprecated setters), or the
   console lists a caller that does **not** map to an AndroidX class. To
   re-verify, unzip `classes*.dex` from `app-release.apk`, run
-  `dexdump -d` and grep for `Landroid/view/Window;.setStatusBarColor`, then
-  look up the obfuscated class in `mapping.txt`.
+  `dexdump -d` on each, and grep for every flagged signature:
+  `Landroid/view/Window;.setStatusBarColor`,
+  `Landroid/view/Window;.setNavigationBarColor`,
+  `Landroid/view/Window;.setDecorFitsSystemWindows`,
+  `Landroid/view/Window;.setStatusBarContrastEnforced`,
+  `Landroid/view/Window;.setNavigationBarContrastEnforced`, and
+  `Landroid/view/WindowManager$LayoutParams;.layoutInDisplayCutoutMode`.
+  Note the enclosing `Class descriptor` of each hit and look every one of
+  them up in `mapping.txt` (`grep -E "^[^ ].* -> <name>:$"`). All must map
+  to `androidx.*` classes or R8 `$$ExternalSyntheticApiModelOutline` stubs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ The canonical rule bodies live in these `.cursor/rules/*.mdc` files (auto-attach
 | `compose-ui.mdc` | `ui/**/*.kt` | Material 3, recomposition, Compose-only UI |
 | `compose-coroutines.mdc` | `ui/**/*.kt` | Compose scroll/coroutine patterns, programmatic vs user scroll |
 | `testing-conventions.mdc` | `test/**/*.kt`, `androidTest/**/*.kt` | Kotest property tests, JUnit 4, what to test when |
-| `edge_to_edge.mdc` | `MainActivity.kt`, `Theme.kt`, `libs.versions.toml` | Play Store edge-to-edge warnings (deferred) |
+| `edge_to_edge.mdc` | `MainActivity.kt`, `Theme.kt`, `libs.versions.toml` | Play Store edge-to-edge warnings (expected: callers are AndroidX, no action) |
 
 ## Skills Reference
 


### PR DESCRIPTION
## Summary

Play Console shows two recommended actions on 9.13.0: "Edge-to-edge may not display for all users" and "Your app uses deprecated APIs or parameters for edge-to-edge". The existing `edge_to_edge.mdc` rule blamed Material Components 1.13.0 internals and said to revisit once 1.14.0 shipped. 9.13.0 already ships Material 1.14.0, whose AAR contains no references to the deprecated setters, and the warnings persist.

Disassembling the shipped 9.13.0 release APK (`dexdump`) and mapping the obfuscated callers through the R8 `mapping.txt` shows every deprecated call comes from AndroidX, none from app code:

| Deprecated API | Caller in the shipped APK |
|---|---|
| `setStatusBarColor` / `setNavigationBarColor` | `androidx.activity.EdgeToEdgeApi26`, `Api29`, `Api35` (`enableEdgeToEdge()` itself) |
| `setDecorFitsSystemWindows` | R8-outlined stub for `androidx.core.view.WindowCompat` |
| `layoutInDisplayCutoutMode` | R8-outlined stub for AndroidX Core |
| contrast-enforced setters | R8-outlined stub for AndroidX Compose UI |

Play Console's check is a static bytecode scan, so it flags library callers like app code. The warning is expected for any app using `enableEdgeToEdge()`; the only way to silence it would be to drop that call, which would be a regression.

## Changes

- Rewrite `.cursor/rules/edge_to_edge.mdc` with the September 2026 evidence, a re-verification recipe, and the conditions for re-checking (activity-compose bump past 1.13.0, or a flagged caller that is not AndroidX). Keeps the one-time Android 15+ visual audit as the only open follow-up.
- Update the rule's summary line in `AGENTS.md` (`CLAUDE.md` is a symlink to it).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the status of Google Play edge-to-edge warnings for the current release.
  * Documented that the warnings are associated with AndroidX behavior and do not require an application code change.
  * Added guidance for visual review and future re-checks if platform, library, or warning details change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->